### PR TITLE
Add support for inline BMC access in `Server` reconciler

### DIFF
--- a/api/v1alpha1/bmc_types.go
+++ b/api/v1alpha1/bmc_types.go
@@ -8,6 +8,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	BMCType              = "bmc"
+	ProtocolRedfish      = "Redfish"
+	ProtocolRedfishLocal = "RedfishLocal"
+)
+
 // BMCSpec defines the desired state of BMC
 type BMCSpec struct {
 	// EndpointRef is a reference to the Kubernetes object that contains the endpoint information for the BMC.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -9,7 +9,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/config/crd/bases/metal.ironcore.dev_bmcs.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcs.yaml
@@ -72,8 +72,8 @@ spec:
             properties:
               bmcSecretRef:
                 description: |-
-                  LocalObjectReference contains enough information to let you locate the
-                  referenced object inside the same namespace.
+                  BMCSecretRef is a reference to the Kubernetes Secret object that contains the credentials
+                  required to access the BMC. This secret includes sensitive information such as usernames and passwords.
                 properties:
                   name:
                     default: ""
@@ -89,10 +89,19 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               consoleProtocol:
+                description: |-
+                  ConsoleProtocol specifies the protocol to be used for console access to the BMC.
+                  This field is optional and can be omitted if console access is not required.
                 properties:
                   name:
+                    description: |-
+                      Name specifies the name of the console protocol.
+                      This could be a protocol such as "SSH", "Telnet", etc.
                     type: string
                   port:
+                    description: |-
+                      Port specifies the port number used for console access.
+                      This port is used by the specified console protocol to establish connections.
                     format: int32
                     type: integer
                 required:
@@ -101,8 +110,8 @@ spec:
                 type: object
               endpointRef:
                 description: |-
-                  LocalObjectReference contains enough information to let you locate the
-                  referenced object inside the same namespace.
+                  EndpointRef is a reference to the Kubernetes object that contains the endpoint information for the BMC.
+                  This reference is typically used to locate the BMC endpoint within the cluster.
                 properties:
                   name:
                     default: ""
@@ -118,10 +127,19 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               protocol:
+                description: |-
+                  Protocol specifies the protocol to be used for communicating with the BMC.
+                  It could be a standard protocol such as IPMI or Redfish.
                 properties:
                   name:
+                    description: |-
+                      Name specifies the name of the protocol.
+                      This could be a protocol such as "IPMI", "Redfish", etc.
                     type: string
                   port:
+                    description: |-
+                      Port specifies the port number used for communication.
+                      This port is used by the specified protocol to establish connections.
                     format: int32
                     type: integer
                 required:
@@ -134,9 +152,11 @@ spec:
             - protocol
             type: object
           status:
-            description: BMCStatus defines the observed state of BMC
+            description: BMCStatus defines the observed state of BMC.
             properties:
               conditions:
+                description: Conditions represents the latest available observations
+                  of the BMC's current state.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for
@@ -206,23 +226,38 @@ spec:
                   type: object
                 type: array
               firmwareVersion:
+                description: FirmwareVersion is the version of the firmware currently
+                  running on the BMC.
                 type: string
               ip:
+                description: |-
+                  IP is the IP address of the BMC.
+                  The type is specified as string and is schemaless.
                 type: string
               macAddress:
+                description: |-
+                  MACAddress is the MAC address of the BMC.
+                  The format is validated using a regular expression pattern.
                 pattern: ^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$
                 type: string
               manufacturer:
+                description: Manufacturer is the name of the BMC manufacturer.
                 type: string
               model:
+                description: Model is the model number or name of the BMC.
                 type: string
               powerState:
+                description: PowerState represents the current power state of the
+                  BMC.
                 type: string
               serialNumber:
+                description: SerialNumber is the serial number of the BMC.
                 type: string
               sku:
+                description: SKU is the stock keeping unit identifier for the BMC.
                 type: string
               state:
+                description: State represents the current state of the BMC.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/metal.ironcore.dev_serverbootconfigurations.yaml
+++ b/config/crd/bases/metal.ironcore.dev_serverbootconfigurations.yaml
@@ -55,12 +55,12 @@ spec:
             type: object
           spec:
             description: ServerBootConfigurationSpec defines the desired state of
-              ServerBootConfiguration
+              ServerBootConfiguration.
             properties:
               ignitionSecretRef:
                 description: |-
-                  LocalObjectReference contains enough information to let you locate the
-                  referenced object inside the same namespace.
+                  IgnitionSecretRef is a reference to the Kubernetes Secret object that contains
+                  the ignition configuration for the server. This field is optional and can be omitted if not specified.
                 properties:
                   name:
                     default: ""
@@ -76,11 +76,13 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               image:
+                description: |-
+                  Image specifies the boot image to be used for the server.
+                  This field is optional and can be omitted if not specified.
                 type: string
               serverRef:
-                description: |-
-                  LocalObjectReference contains enough information to let you locate the
-                  referenced object inside the same namespace.
+                description: ServerRef is a reference to the server for which this
+                  boot configuration is intended.
                 properties:
                   name:
                     default: ""
@@ -100,9 +102,10 @@ spec:
             type: object
           status:
             description: ServerBootConfigurationStatus defines the observed state
-              of ServerBootConfiguration
+              of ServerBootConfiguration.
             properties:
               state:
+                description: State represents the current state of the boot configuration.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/metal.ironcore.dev_serverclaims.yaml
+++ b/config/crd/bases/metal.ironcore.dev_serverclaims.yaml
@@ -53,12 +53,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServerClaimSpec defines the desired state of ServerClaim
+            description: ServerClaimSpec defines the desired state of ServerClaim.
             properties:
               ignitionSecretRef:
                 description: |-
-                  LocalObjectReference contains enough information to let you locate the
-                  referenced object inside the same namespace.
+                  IgnitionSecretRef is a reference to the Kubernetes Secret object that contains
+                  the ignition configuration for the server. This field is optional and can be omitted if not specified.
                 properties:
                   name:
                     default: ""
@@ -74,13 +74,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               image:
+                description: Image specifies the boot image to be used for the server.
                 type: string
               power:
+                description: Power specifies the desired power state of the server.
                 type: string
               serverRef:
                 description: |-
-                  LocalObjectReference contains enough information to let you locate the
-                  referenced object inside the same namespace.
+                  ServerRef is a reference to a specific server to be claimed.
+                  This field is optional and can be omitted if the server is to be selected using ServerSelector.
                 properties:
                   name:
                     default: ""
@@ -97,9 +99,8 @@ spec:
                 x-kubernetes-map-type: atomic
               serverSelector:
                 description: |-
-                  A label selector is a label query over a set of resources. The result of matchLabels and
-                  matchExpressions are ANDed. An empty label selector matches all objects. A null
-                  label selector matches no objects.
+                  ServerSelector specifies a label selector to identify the server to be claimed.
+                  This field is optional and can be omitted if a specific server is referenced using ServerRef.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -149,9 +150,10 @@ spec:
             - power
             type: object
           status:
-            description: ServerClaimStatus defines the observed state of ServerClaim
+            description: ServerClaimStatus defines the observed state of ServerClaim.
             properties:
               phase:
+                description: Phase represents the current phase of the server claim.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -65,14 +65,17 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServerSpec defines the desired state of Server
+            description: ServerSpec defines the desired state of a Server.
             properties:
               bmc:
+                description: |-
+                  BMC contains the access details for the BMC.
+                  This field is optional and can be omitted if no BMC access is specified.
                 properties:
                   bmcSecretRef:
                     description: |-
-                      LocalObjectReference contains enough information to let you locate the
-                      referenced object inside the same namespace.
+                      BMCSecretRef is a reference to the Kubernetes Secret object that contains the credentials
+                      required to access the BMC. This secret includes sensitive information such as usernames and passwords.
                     properties:
                       name:
                         default: ""
@@ -88,12 +91,21 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   endpoint:
+                    description: Endpoint is the address of the BMC endpoint.
                     type: string
                   protocol:
+                    description: Protocol specifies the protocol to be used for communicating
+                      with the BMC.
                     properties:
                       name:
+                        description: |-
+                          Name specifies the name of the protocol.
+                          This could be a protocol such as "IPMI", "Redfish", etc.
                         type: string
                       port:
+                        description: |-
+                          Port specifies the port number used for communication.
+                          This port is used by the specified protocol to establish connections.
                         format: int32
                         type: integer
                     required:
@@ -107,8 +119,8 @@ spec:
                 type: object
               bmcRef:
                 description: |-
-                  LocalObjectReference contains enough information to let you locate the
-                  referenced object inside the same namespace.
+                  BMCRef is a reference to the BMC object associated with this server.
+                  This field is optional and can be omitted if no BMC is associated with this server.
                 properties:
                   name:
                     default: ""
@@ -125,23 +137,9 @@ spec:
                 x-kubernetes-map-type: atomic
               bootConfigurationRef:
                 description: |-
-                  ObjectReference contains enough information to let you inspect or modify the referred object.
-                  ---
-                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
-                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
-                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
-                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
-                      Those cannot be well described when embedded.
-                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
-                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
-                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
-                      and the version of the actual struct is irrelevant.
-                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
-                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
-
-
-                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
-                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  BootConfigurationRef is a reference to a BootConfiguration object that specifies
+                  the boot configuration for this server. This field is optional and can be omitted
+                  if no boot configuration is specified.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -185,29 +183,16 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               indicatorLED:
-                description: IndicatorLED represents LED indicator states
+                description: IndicatorLED specifies the desired state of the server's
+                  indicator LED.
                 type: string
               power:
+                description: Power specifies the desired power state of the server.
                 type: string
               serverClaimRef:
                 description: |-
-                  ObjectReference contains enough information to let you inspect or modify the referred object.
-                  ---
-                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
-                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
-                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
-                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
-                      Those cannot be well described when embedded.
-                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
-                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
-                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
-                      and the version of the actual struct is irrelevant.
-                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
-                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
-
-
-                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
-                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  ServerClaimRef is a reference to a ServerClaim object that claims this server.
+                  This field is optional and can be omitted if no claim is associated with this server.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -251,14 +236,17 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               uuid:
+                description: UUID is the unique identifier for the server.
                 type: string
             required:
             - uuid
             type: object
           status:
-            description: ServerStatus defines the observed state of Server
+            description: ServerStatus defines the observed state of Server.
             properties:
               conditions:
+                description: Conditions represents the latest available observations
+                  of the server's current state.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for
@@ -328,18 +316,28 @@ spec:
                   type: object
                 type: array
               indicatorLED:
-                description: IndicatorLED represents LED indicator states
+                description: IndicatorLED specifies the current state of the server's
+                  indicator LED.
                 type: string
               manufacturer:
+                description: Manufacturer is the name of the server manufacturer.
                 type: string
               networkInterfaces:
+                description: NetworkInterfaces is a list of network interfaces associated
+                  with the server.
                 items:
+                  description: NetworkInterface defines the details of a network interface.
                   properties:
                     ip:
+                      description: |-
+                        IP is the IP address assigned to the network interface.
+                        The type is specified as string and is schemaless.
                       type: string
                     macAddress:
+                      description: MACAddress is the MAC address of the network interface.
                       type: string
                     name:
+                      description: Name is the name of the network interface.
                       type: string
                   required:
                   - ip
@@ -348,12 +346,17 @@ spec:
                   type: object
                 type: array
               powerState:
+                description: PowerState represents the current power state of the
+                  server.
                 type: string
               serialNumber:
+                description: SerialNumber is the serial number of the server.
                 type: string
               sku:
+                description: SKU is the stock keeping unit identifier for the server.
                 type: string
               state:
+                description: State represents the current state of the server.
                 type: string
             type: object
         type: object

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -55,7 +55,7 @@ func (r *BMCReconciler) reconcileExists(ctx context.Context, log logr.Logger, bm
 }
 
 func (r *BMCReconciler) delete(ctx context.Context, log logr.Logger, bmcObj *metalv1alpha1.BMC) (ctrl.Result, error) {
-	log.V(1).Info("Deleting BMC ")
+	log.V(1).Info("Deleting BMC")
 	if _, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, bmcObj, BMCFinalizer); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/bmcutils.go
+++ b/internal/controller/bmcutils.go
@@ -8,8 +8,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/ironcore-dev/metal-operator/bmc"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,10 +18,7 @@ func GetBMCClientForServer(ctx context.Context, c client.Client, server *metalv1
 		b := &metalv1alpha1.BMC{}
 		bmcName := server.Spec.BMCRef.Name
 		if err := c.Get(ctx, client.ObjectKey{Name: bmcName}, b); err != nil {
-			if errors.IsNotFound(err) {
-				return nil, fmt.Errorf("BMC %q not found", bmcName)
-			}
-			return nil, err
+			return nil, fmt.Errorf("failed to get BMC: %w", err)
 		}
 
 		return GetBMCClientFromBMC(ctx, c, b, insecure)
@@ -45,7 +40,7 @@ func GetBMCClientForServer(ctx context.Context, c client.Client, server *metalv1
 		)
 	}
 
-	return nil, fmt.Errorf("server %s has nor a BMCRef nor an BMC configured", server.Name)
+	return nil, fmt.Errorf("server %s has neither a BMCRef nor a BMC configured", server.Name)
 }
 
 func GetBMCClientFromBMC(ctx context.Context, c client.Client, bmcObj *metalv1alpha1.BMC, insecure bool) (bmc.BMC, error) {

--- a/internal/controller/bmcutils.go
+++ b/internal/controller/bmcutils.go
@@ -15,15 +15,37 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetBMCClientFromBMCName(ctx context.Context, c client.Client, bmcName string, insecure bool) (bmc.BMC, error) {
-	bmc := &metalv1alpha1.BMC{}
-	if err := c.Get(ctx, client.ObjectKey{Name: bmcName}, bmc); err != nil {
-		if errors.IsNotFound(err) {
-			return nil, fmt.Errorf("BMC %q not found", bmcName)
+func GetBMCClientForServer(ctx context.Context, c client.Client, server *metalv1alpha1.Server, insecure bool) (bmc.BMC, error) {
+	if server.Spec.BMCRef != nil {
+		b := &metalv1alpha1.BMC{}
+		bmcName := server.Spec.BMCRef.Name
+		if err := c.Get(ctx, client.ObjectKey{Name: bmcName}, b); err != nil {
+			if errors.IsNotFound(err) {
+				return nil, fmt.Errorf("BMC %q not found", bmcName)
+			}
+			return nil, err
 		}
-		return nil, err
+
+		return GetBMCClientFromBMC(ctx, c, b, insecure)
 	}
-	return GetBMCClientFromBMC(ctx, c, bmc, insecure)
+
+	if server.Spec.BMC != nil {
+		bmcSecret := &metalv1alpha1.BMCSecret{}
+		if err := c.Get(ctx, client.ObjectKey{Name: server.Spec.BMC.BMCSecretRef.Name}, bmcSecret); err != nil {
+			return nil, fmt.Errorf("failed to get BMC secret: %w", err)
+		}
+
+		return CreateBMCClient(
+			ctx,
+			insecure,
+			server.Spec.BMC.Protocol.Name,
+			metalv1alpha1.MustParseIP(server.Spec.BMC.Endpoint),
+			server.Spec.BMC.Protocol.Port,
+			bmcSecret,
+		)
+	}
+
+	return nil, fmt.Errorf("server %s has nor a BMCRef nor an BMC configured", server.Name)
 }
 
 func GetBMCClientFromBMC(ctx context.Context, c client.Client, bmcObj *metalv1alpha1.BMC, insecure bool) (bmc.BMC, error) {
@@ -37,15 +59,19 @@ func GetBMCClientFromBMC(ctx context.Context, c client.Client, bmcObj *metalv1al
 		return nil, fmt.Errorf("failed to get BMC secret: %w", err)
 	}
 
+	return CreateBMCClient(ctx, insecure, bmcObj.Spec.Protocol.Name, endpoint.Spec.IP, bmcObj.Spec.Protocol.Port, bmcSecret)
+}
+
+func CreateBMCClient(ctx context.Context, insecure bool, bmcProtocol metalv1alpha1.ProtocolName, endpoint metalv1alpha1.IP, port int32, bmcSecret *metalv1alpha1.BMCSecret) (bmc.BMC, error) {
 	protocol := "https"
 	if insecure {
 		protocol = "http"
 	}
 
 	var bmcClient bmc.BMC
-	switch bmcObj.Spec.Protocol.Name {
-	case ProtocolRedfish:
-		bmcAddress := fmt.Sprintf("%s://%s:%d", protocol, endpoint.Spec.IP, bmcObj.Spec.Protocol.Port)
+	switch bmcProtocol {
+	case metalv1alpha1.ProtocolRedfish:
+		bmcAddress := fmt.Sprintf("%s://%s:%d", protocol, endpoint, port)
 		username, password, err := GetBMCCredentialsFromSecret(bmcSecret)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get credentials from BMC secret: %w", err)
@@ -54,8 +80,8 @@ func GetBMCClientFromBMC(ctx context.Context, c client.Client, bmcObj *metalv1al
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Redfish client: %w", err)
 		}
-	case ProtocolRedfishLocal:
-		bmcAddress := fmt.Sprintf("%s://%s:%d", protocol, endpoint.Spec.IP, bmcObj.Spec.Protocol.Port)
+	case metalv1alpha1.ProtocolRedfishLocal:
+		bmcAddress := fmt.Sprintf("%s://%s:%d", protocol, endpoint, port)
 		username, password, err := GetBMCCredentialsFromSecret(bmcSecret)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get credentials from BMC secret: %w", err)
@@ -65,7 +91,7 @@ func GetBMCClientFromBMC(ctx context.Context, c client.Client, bmcObj *metalv1al
 			return nil, fmt.Errorf("failed to create Redfish client: %w", err)
 		}
 	default:
-		return nil, fmt.Errorf("unsupported BMC protocol %s", bmcObj.Spec.Protocol.Name)
+		return nil, fmt.Errorf("unsupported BMC protocol %s", bmcProtocol)
 	}
 	return bmcClient, nil
 }

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -23,10 +23,7 @@ import (
 )
 
 const (
-	BMCType              = "bmc"
-	ProtocolRedfish      = "Redfish"
-	ProtocolRedfishLocal = "RedfishLocal"
-	EndpointFinalizer    = "metal.ironcore.dev/endpoint"
+	EndpointFinalizer = "metal.ironcore.dev/endpoint"
 )
 
 // EndpointReconciler reconciles a Endpoints object
@@ -79,13 +76,13 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, log logr.Logger, end
 
 	sanitizedMACAddress := strings.Replace(endpoint.Spec.MACAddress, ":", "", -1)
 	for _, m := range r.MACPrefixes.MacPrefixes {
-		if strings.HasPrefix(sanitizedMACAddress, m.MacPrefix) && m.Type == BMCType {
+		if strings.HasPrefix(sanitizedMACAddress, m.MacPrefix) && m.Type == metalv1alpha1.BMCType {
 			log.V(1).Info("Found a BMC adapter for endpoint", "Type", m.Type, "Protocol", m.Protocol)
 			if len(m.DefaultCredentials) == 0 {
 				return ctrl.Result{}, fmt.Errorf("no default credentials present for BMC %s", endpoint.Spec.MACAddress)
 			}
 			switch m.Protocol {
-			case ProtocolRedfish:
+			case metalv1alpha1.ProtocolRedfish:
 				log.V(1).Info("Creating client for BMC")
 				bmcAddress := fmt.Sprintf("%s://%s:%d", r.getProtocol(), endpoint.Spec.IP, m.Port)
 				bmcClient, err := bmc.NewRedfishBMCClient(ctx, bmcAddress, m.DefaultCredentials[0].Username, m.DefaultCredentials[0].Password, true)
@@ -106,7 +103,7 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, log logr.Logger, end
 					return ctrl.Result{}, fmt.Errorf("failed to apply BMC object: %w", err)
 				}
 				log.V(1).Info("Applied BMC object for endpoint")
-			case ProtocolRedfishLocal:
+			case metalv1alpha1.ProtocolRedfishLocal:
 				log.V(1).Info("Creating client for a local test BMC")
 				bmcAddress := fmt.Sprintf("%s://%s:%d", r.getProtocol(), endpoint.Spec.IP, m.Port)
 				bmcClient, err := bmc.NewRedfishLocalBMCClient(ctx, bmcAddress, m.DefaultCredentials[0].Username, m.DefaultCredentials[0].Password, true)

--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Endpoints Controller", func() {
 			HaveField("Spec.EndpointRef.Name", Equal(endpoint.Name)),
 			HaveField("Spec.BMCSecretRef.Name", Equal(bmc.Name)),
 			HaveField("Spec.Protocol", metalv1alpha1.Protocol{
-				Name: ProtocolRedfishLocal,
+				Name: metalv1alpha1.ProtocolRedfishLocal,
 				Port: 8000,
 			}),
 			HaveField("Spec.ConsoleProtocol", &metalv1alpha1.ConsoleProtocol{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -34,7 +34,7 @@ import (
 const (
 	pollingInterval      = 100 * time.Millisecond
 	eventuallyTimeout    = 3 * time.Second
-	consistentlyDuration = 1 * time.Second
+	consistentlyDuration = 3 * time.Second
 )
 
 var (


### PR DESCRIPTION
# Proposed Changes

Instead of relying on an `Endpoint` and `BMC` resouce to be present to interact with a `Server` you can now register a `Server` directly by providing the BMC access information via `.spec.bmc` in the `Server` spec.

Regenerated stale manifests.

Fixes #66 