### PR TITLE
Add `config/dev` kustomize

### DIFF
--- a/config/dev/delete_manager_auth_proxy_patch.yaml
+++ b/config/dev/delete_manager_auth_proxy_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        $patch: delete
+      - name: manager
+        args: []

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- ../default
+
+patches:
+- path: delete_manager_auth_proxy_patch.yaml


### PR DESCRIPTION
# Proposed Changes
`config/dev` can be used for local dev setup and for now it will disable the `kube-rbac-proxy` sidecar