### PR TITLE
add discovery state and rework initial power handling

### DIFF
--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -91,6 +91,9 @@ const (
 	// ServerStateInitial indicates that the server is in its initial state.
 	ServerStateInitial ServerState = "Initial"
 
+	// ServerStateDiscovery indicates that the server is in its discovery state.
+	ServerStateDiscovery ServerState = "Discovery"
+
 	// ServerStateAvailable indicates that the server is available for use.
 	ServerStateAvailable ServerState = "Available"
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -9,7 +9,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 


### PR DESCRIPTION
# Proposed Changes

- add `Discovery` state where we expect server to PXE boot and post to registry
- On the `Initial` state we power off the server regardless, hence no need to cover server that is [powered on](https://github.com/ironcore-dev/metal-operator/blob/main/internal/controller/server_controller.go#L438)

Fixes https://github.com/ironcore-dev/metal-operator/issues/97