### PR TITLE
Add time triggered `Server` polling

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -59,11 +59,11 @@ func main() {
 	var registryResyncInterval time.Duration
 	var webhookPort int
 	var enforceFirstBoot bool
-	var resyncInterval time.Duration
+	var serverResyncInterval time.Duration
 
 	flag.DurationVar(&registryResyncInterval, "registry-resync-interval", 10*time.Second,
 		"Defines the interval at which the registry is polled for new server information.")
-	flag.DurationVar(&resyncInterval, "resync-interval", 30*time.Second,
+	flag.DurationVar(&serverResyncInterval, "server-resync-interval", 30*time.Second,
 		"Defines the interval at which the server is polled.")
 	flag.StringVar(&registryURL, "registry-url", "", "The URL of the registry.")
 	flag.StringVar(&registryProtocol, "registry-protocol", "http", "The protocol to use for the registry.")
@@ -205,7 +205,7 @@ func main() {
 		ProbeOSImage:           probeOSImage,
 		RegistryURL:            registryURL,
 		RegistryResyncInterval: registryResyncInterval,
-		ResyncInterval:         resyncInterval,
+		ResyncInterval:         serverResyncInterval,
 		EnforceFirstBoot:       enforceFirstBoot,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Server")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -56,11 +56,15 @@ func main() {
 	var registryPort int
 	var registryProtocol string
 	var registryURL string
-	var requeueInterval time.Duration
+	var registryResyncInterval time.Duration
 	var webhookPort int
 	var enforceFirstBoot bool
+	var resyncInterval time.Duration
 
-	flag.DurationVar(&requeueInterval, "requeue-interval", 10*time.Second, "Reconciler requeue interval.")
+	flag.DurationVar(&registryResyncInterval, "registry-resync-interval", 10*time.Second,
+		"Defines the interval at which the registry is polled for new server information.")
+	flag.DurationVar(&resyncInterval, "resync-interval", 30*time.Second,
+		"Defines the interval at which the server is polled.")
 	flag.StringVar(&registryURL, "registry-url", "", "The URL of the registry.")
 	flag.StringVar(&registryProtocol, "registry-protocol", "http", "The protocol to use for the registry.")
 	flag.IntVar(&registryPort, "registry-port", 10000, "The port to use for the registry.")
@@ -193,15 +197,16 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.ServerReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		Insecure:         insecure,
-		ManagerNamespace: managerNamespace,
-		ProbeImage:       probeImage,
-		ProbeOSImage:     probeOSImage,
-		RegistryURL:      registryURL,
-		RequeueInterval:  requeueInterval,
-		EnforceFirstBoot: enforceFirstBoot,
+		Client:                 mgr.GetClient(),
+		Scheme:                 mgr.GetScheme(),
+		Insecure:               insecure,
+		ManagerNamespace:       managerNamespace,
+		ProbeImage:             probeImage,
+		ProbeOSImage:           probeOSImage,
+		RegistryURL:            registryURL,
+		RegistryResyncInterval: registryResyncInterval,
+		ResyncInterval:         resyncInterval,
+		EnforceFirstBoot:       enforceFirstBoot,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Server")
 		os.Exit(1)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -162,15 +162,16 @@ func SetupTest() *corev1.Namespace {
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
 		Expect((&ServerReconciler{
-			Client:           k8sManager.GetClient(),
-			Scheme:           k8sManager.GetScheme(),
-			Insecure:         true,
-			ManagerNamespace: ns.Name,
-			ProbeImage:       "foo:latest",
-			ProbeOSImage:     "fooOS:latest",
-			RegistryURL:      registryURL,
-			RequeueInterval:  50 * time.Millisecond,
-			EnforceFirstBoot: true,
+			Client:                 k8sManager.GetClient(),
+			Scheme:                 k8sManager.GetScheme(),
+			Insecure:               true,
+			ManagerNamespace:       ns.Name,
+			ProbeImage:             "foo:latest",
+			ProbeOSImage:           "fooOS:latest",
+			RegistryURL:            registryURL,
+			RegistryResyncInterval: 50 * time.Millisecond,
+			ResyncInterval:         100 * time.Millisecond,
+			EnforceFirstBoot:       true,
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
 		Expect((&ServerClaimReconciler{


### PR DESCRIPTION
# Proposed Changes

Currently we are missing e.g. PowerState changes on a `Server` if they are manually performed. In order to check periodically for the correct `Server` status we introduce a new flag `--server-resync-interval` (default: 30 sec) which will trigger a `Server` reconciliation according to this value.

Maybe in the future we can have an event source e.g. via BMC event subscriptions to remove the polling of resources. For now that is the easiest way to get potential state drifts resolved.

Additionally the `--requeue-interval` flag has been renamed to `--registry-resync-interval` as it better represents the actual usage of this flag.