### PR TITLE
Add `Tilt` for local development

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,9 @@ issues:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - dupl
     - errcheck
-    - exportloopref
     - goconst
     - gocyclo
     - gofmt

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+#// SPDX-License-Identifier: Apache-2.0
+
+update_settings(k8s_upsert_timeout_secs=60)  # on first tilt up, often can take longer than 30 seconds
+
+settings = {
+    "allowed_contexts": [
+        "kind-metal"
+    ],
+    "kubectl": "./bin/kubectl",
+    "boot_image": "ghcr.io/ironcore-dev/boot-operator:latest",
+    "cert_manager_version": "v1.15.3",
+    "new_args": {
+        "boot": [
+        "--health-probe-bind-address=:8081",
+        "--metrics-bind-address=127.0.0.1:8085",
+        "--leader-elect",
+        "--default-ipxe-server-url=http://boot-service:30007",
+        "--default-kernel-url=http://boot-service:30007/image?imageName=ghcr.io/ironcore-dev/os-images/gardenlinux&version=1443.10&layerName=vmlinuz",
+        "--default-initrd-url=http://boot-service:30007/image?imageName=ghcr.io/ironcore-dev/os-images/gardenlinux&version=1443.10&layerName=initramfs",
+        "--default-squashfs-url=http://boot-service:30007/image?imageName=ghcr.io/ironcore-dev/os-images/gardenlinux&version=1443.10&layerName=squashfs",
+        "--ipxe-service-url=http://boot-service:30007",
+        "--ipxe-service-port=30007",
+        "--controllers=ipxebootconfig,serverbootconfigpxe,serverbootconfighttp,httpbootconfig",
+        ],
+    }
+}
+
+kubectl = settings.get("kubectl")
+
+if "allowed_contexts" in settings:
+    allow_k8s_contexts(settings.get("allowed_contexts"))
+
+def deploy_cert_manager():
+    version = settings.get("cert_manager_version")
+    print("Installing cert-manager")
+    local("{} apply -f https://github.com/cert-manager/cert-manager/releases/download/{}/cert-manager.yaml".format(kubectl, version), quiet=True, echo_off=True)
+
+    print("Waiting for cert-manager to start")
+    local("{} wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager".format(kubectl), quiet=True, echo_off=True)
+    local("{} wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager-cainjector".format(kubectl), quiet=True, echo_off=True)
+    local("{} wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager-webhook".format(kubectl), quiet=True, echo_off=True)
+
+# deploy boot-operator
+def deploy_boot():
+    version = settings.get("boot_version")
+    image = settings.get("boot_image")
+    new_args = settings.get("new_args").get("boot")
+    boot_uri = "https://github.com/ironcore-dev/boot-operator//config/dev"
+    cmd = "{} apply -k {}".format(kubectl, boot_uri)
+    local(cmd, quiet=True)
+
+    replace_args_with_new_args("boot-operator-system", "boot-operator-controller-manager", new_args)
+    patch_image("boot-operator-system", "boot-operator-controller-manager", image)
+
+def patch_image(namespace, name, image):
+    patch = [{
+        "op": "replace",
+        "path": "/spec/template/spec/containers/0/image",
+        "value": image,
+    }]
+    local("{} patch deployment {} -n {} --type json -p='{}'".format(kubectl, name, namespace, str(encode_json(patch)).replace("\n", "")))
+
+def replace_args_with_new_args(namespace, name, extra_args):
+    patch = [{
+        "op": "replace",
+        "path": "/spec/template/spec/containers/0/args",
+        "value": extra_args,
+    }]
+    local("{} patch deployment {} -n {} --type json -p='{}'".format(kubectl, name, namespace, str(encode_json(patch)).replace("\n", "")))
+
+def waitforsystem():
+    print("Waiting for metal-operator to start")
+    local("{} wait --for=condition=ready --timeout=300s -n metal-operator-system pod --all".format(kubectl), quiet=False, echo_off=True)
+
+##############################
+# Actual work happens here
+##############################
+
+deploy_cert_manager()
+
+docker_build('controller', '.', target = 'manager')
+
+deploy_boot()
+
+yaml = kustomize('./config/dev')
+
+k8s_yaml(yaml)

--- a/api/v1alpha1/bmc_types.go
+++ b/api/v1alpha1/bmc_types.go
@@ -12,6 +12,7 @@ const (
 	BMCType              = "bmc"
 	ProtocolRedfish      = "Redfish"
 	ProtocolRedfishLocal = "RedfishLocal"
+	ProtocolRedfishKube  = "RedfishKube"
 )
 
 // BMCSpec defines the desired state of BMC

--- a/bmc/redfish_kube.go
+++ b/bmc/redfish_kube.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package bmc
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stmcginnis/gofish/redfish"
+	v1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	metalJobLabel = "kube.ironcore.dev/job"
+	registryURL   = "http://metal-registry.metal-operator-system.svc.cluster.local:30000/register"
+)
+
+var _ BMC = (*RedfishKubeBMC)(nil)
+
+type KubeClient struct {
+	client    client.Client
+	namespace string
+}
+
+// RedfishKubeBMC is an implementation of the BMC interface for Redfish.
+type RedfishKubeBMC struct {
+	*RedfishBMC
+	*KubeClient
+}
+
+// NewRedfishKubeBMCClient creates a new RedfishKubeBMC with the given connection details.
+func NewRedfishKubeBMCClient(
+	ctx context.Context,
+	endpoint, username, password string,
+	basicAuth bool,
+	c client.Client,
+	ns string,
+) (BMC, error) {
+	bmc, err := NewRedfishBMCClient(ctx, endpoint, username, password, basicAuth)
+	if err != nil {
+		return nil, err
+	}
+	redfishKubeBMC := &RedfishKubeBMC{
+		RedfishBMC: bmc,
+		KubeClient: &KubeClient{
+			client:    c,
+			namespace: ns,
+		},
+	}
+
+	return redfishKubeBMC, nil
+}
+
+// SetPXEBootOnce sets the boot device for the next system boot using Redfish.
+func (r *RedfishKubeBMC) SetPXEBootOnce(systemUUID string) error {
+	system, err := r.getSystemByUUID(systemUUID)
+	if err != nil {
+		return fmt.Errorf("failed to get systems: %w", err)
+	}
+	var setBoot redfish.Boot
+	// TODO: cover setting BootSourceOverrideMode with BIOS settings profile
+	if system.Boot.BootSourceOverrideMode != redfish.UEFIBootSourceOverrideMode {
+		setBoot = pxeBootWithSettingUEFIBootMode
+	} else {
+		setBoot = pxeBootWithoutSettingUEFIBootMode
+	}
+	if err := system.SetBoot(setBoot); err != nil {
+		return fmt.Errorf("failed to set the boot order: %w", err)
+	}
+	netData := `{"networkInterfaces":[{"name":"dummy0","ipAddress":"127.0.0.2","macAddress":"aa:bb:cc:dd:ee:ff"}]`
+	curlCmd := fmt.Sprintf(
+		`apk add curl && curl -H 'Content-Type: application/json' \
+-d '{"SystemUUID":"%s","data":%s}}' \
+-X POST %s`,
+		systemUUID, netData, registryURL)
+	cmd := []string{
+		"/bin/sh",
+		"-c",
+		curlCmd,
+	}
+	if err := r.createJob(context.TODO(), r.KubeClient.client, cmd, r.KubeClient.namespace, systemUUID); err != nil {
+		return fmt.Errorf("failed to create job for system %s: %w", systemUUID, err)
+	}
+	return nil
+}
+
+func (r RedfishKubeBMC) createJob(
+	ctx context.Context,
+	c client.Client,
+	cmd []string,
+	namespace,
+	systemUUID string,
+) error {
+	// Check if a job with the same label already exists
+	jobList := &v1.JobList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{metalJobLabel: systemUUID},
+	}
+	if err := c.List(ctx, jobList, listOpts...); err != nil {
+		return fmt.Errorf("failed to list jobs: %w", err)
+	}
+	if len(jobList.Items) > 0 {
+		return nil // Job already exists, do not create a new one
+	}
+
+	job := &v1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("register-%s-", systemUUID),
+			Namespace:    namespace,
+			Labels: map[string]string{
+				metalJobLabel: systemUUID,
+			},
+		},
+		Spec: v1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						metalJobLabel: systemUUID,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "registry-job",
+							Image:   "alpine:latest",
+							Command: cmd,
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+			TTLSecondsAfterFinished: ptr.To(int32(30)),
+		},
+	}
+	if err := c.Create(ctx, job); err != nil {
+		return err
+	}
+	return nil
+}

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -1,5 +1,14 @@
 resources:
 - ../default
+- ../redfish-mockup
+- registry_service.yaml
 
 patches:
 - path: delete_manager_auth_proxy_patch.yaml
+- path: manager_patch.yaml
+
+secretGenerator:
+- name: macdb
+  namespace: metal-operator-system
+  files:
+  - macdb.yaml

--- a/config/dev/macdb.yaml
+++ b/config/dev/macdb.yaml
@@ -1,0 +1,12 @@
+macPrefixes:
+- macPrefix: 23
+  manufacturer: Foo
+  protocol: RedfishKube
+  port: 8000
+  type: bmc
+  defaultCredentials:
+    - username: foo
+      password: bar
+  console:
+    type: ssh
+    port: 22

--- a/config/dev/manager_patch.yaml
+++ b/config/dev/manager_patch.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+          - --health-probe-bind-address=:8081
+          - --metrics-bind-address=127.0.0.1:8080
+          - --leader-elect
+          - --mac-prefixes-file=/etc/macdb/macdb.yaml
+          - --probe-image=ghcr.io/ironcore-dev/metalprobe:latest
+          - --probe-os-image=ghcr.io/ironcore-dev/os-images/gardenlinux:1443.10
+          - --registry-url=http://127.0.0.1:30000
+          - --registry-port=30000
+          - --enforce-first-boot
+        ports:
+        - containerPort: 30000
+        volumeMounts:
+        - mountPath: /etc/macdb/
+          name: macdb
+      - name: redfish
+        image: dmtf/redfish-mockup-server:latest
+        ports:
+        - containerPort: 8000
+      securityContext:
+        runAsNonRoot: false
+      volumes:
+      - name: macdb
+        secret:
+          defaultMode: 420
+          secretName: macdb

--- a/config/dev/registry_service.yaml
+++ b/config/dev/registry_service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: metal-registry
+  namespace: metal-operator-system
+spec:
+  ports:
+    - name: registry-server
+      port: 30000
+      targetPort: 30000
+  selector:
+    control-plane: controller-manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - metal.ironcore.dev
   resources:
   - bmcs

--- a/config/redfish-mockup/kustomization.yaml
+++ b/config/redfish-mockup/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- redfish_mockup_endpoint.yaml
+- redfish_mockup_service.yaml

--- a/config/redfish-mockup/redfish_mockup_endpoint.yaml
+++ b/config/redfish-mockup/redfish_mockup_endpoint.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Endpoint
+metadata:
+  labels:
+    app.kubernetes.io/name: endpoint
+    app.kubernetes.io/instance: endpoint-sample
+    app.kubernetes.io/part-of: metal-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: metal-operator
+  name: endpoint-sample
+spec:
+  ip: "127.0.0.1"
+  macAddress: "23:11:8A:33:CF:EA"

--- a/config/redfish-mockup/redfish_mockup_service.yaml
+++ b/config/redfish-mockup/redfish_mockup_service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redfish
+  namespace: metal-operator-system
+spec:
+  ports:
+  - port: 8000
+    targetPort: 8000
+  selector:
+    control-plane: controller-manager

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -4,7 +4,7 @@
 
 - go version v1.22.0+
 - docker version 17.03+.
-- kubectl version v1.11.3+.
+- kubectl version v1.28.0+.
 
 ## Overview
 
@@ -37,4 +37,37 @@ The Redfish mock server can be started and stopped with the following command
 ```shell
 make startbmc
 make stopbmc
+```
+
+### Run the local Tilt development environment
+
+#### Prerequisites
+
+- [Tilt v0.33.17+](https://docs.tilt.dev/install.html)
+- [Kind v0.23.0+](https://kind.sigs.k8s.io/docs/user/quick-start/)
+
+The local development environment can be started via
+
+```shell
+make tilt-up
+```
+
+This `Makefile` directive will:
+- create a local Kind cluster with local registry
+- install cert-manager
+- install [boot-operator](https://github.com/ironcore-dev/boot-operator) to reconcile the `ServerBootConfiguration` CRD
+- start the `metal-operator` controller and Redfish mock server as a sidecar container
+- an Endpoint resource is created to point to the Redfish mock server
+- this will result in `Server` resources being created and reconciled by the `metal-operator`
+
+```shell
+‹kind-metal› kubectl get server
+NAME                            UUID                                   MANUFACTURER   POWERSTATE   STATE       AGE
+compute-0-bmc-endpoint-sample   38947555-7742-3448-3784-823347823834   Contoso        On           Available   3m21s
+```
+
+The local development environment can be deleted via
+
+```shell
+make kind-delete
 ```

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -68,6 +68,7 @@ type ServerReconciler struct {
 //+kubebuilder:rbac:groups=metal.ironcore.dev,resources=servers/finalizers,verbs=update
 //+kubebuilder:rbac:groups=metal.ironcore.dev,resources=serverconfigurations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="batch",resources=jobs,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+#// SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+KUBECTL=$REPO_ROOT/bin/kubectl
+
+# desired kind cluster name; default is "metal"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-metal}"
+
+if [[ "$(kind get clusters)" =~ .*"${KIND_CLUSTER_NAME}".* ]]; then
+  echo "cluster already exists, moving on"
+  exit 0
+fi
+
+reg_name='kind-registry'
+reg_port="${KIND_REGISTRY_PORT:-5000}"
+
+# create registry container unless it already exists
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:5000"]
+EOF
+
+# connect the registry to the cluster network
+# (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
+
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | "${KUBECTL}" apply --namespace=kube-public -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+
+"${KUBECTL}" wait node "${KIND_CLUSTER_NAME}-control-plane" --for=condition=ready --timeout=90s


### PR DESCRIPTION
# Proposed Changes

- `make tilt-up` spins up local kind cluster and enables local development with Tilt
- it also adds redfish-mockup as a sidecar to the manager and posts server UUID to the registry to make Server `Available`
