### PR TITLE
Change resource naming scheme

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -9,7 +9,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -4,8 +4,6 @@
 package controller
 
 import (
-	"fmt"
-
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,7 +35,7 @@ var _ = Describe("BMC Controller", func() {
 		By("Ensuring that the BMC will be removed")
 		bmc := &metalv1alpha1.BMC{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("bmc-%s", endpoint.Name),
+				Name: endpoint.Name,
 			},
 		}
 		DeferCleanup(k8sClient.Delete, bmc)
@@ -63,7 +61,7 @@ var _ = Describe("BMC Controller", func() {
 		By("Ensuring that the BMC resource has been created for an endpoint")
 		bmc := &metalv1alpha1.BMC{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("bmc-%s", endpoint.Name),
+				Name: endpoint.Name,
 			},
 		}
 		Eventually(Object(bmc)).Should(SatisfyAll(
@@ -99,7 +97,7 @@ var _ = Describe("BMC Controller", func() {
 				BlockOwnerDeletion: ptr.To(true),
 			})),
 			HaveField("Spec.UUID", "38947555-7742-3448-3784-823347823834"),
-			HaveField("Spec.BMCRef.Name", GetBMCNameFromEndpoint(endpoint)),
+			HaveField("Spec.BMCRef.Name", endpoint.Name),
 		))
 	})
 })

--- a/internal/controller/bmcutils.go
+++ b/internal/controller/bmcutils.go
@@ -114,13 +114,5 @@ func GetBMCCredentialsFromSecret(secret *metalv1alpha1.BMCSecret) (string, strin
 }
 
 func GetServerNameFromBMCandIndex(index int, bmc *metalv1alpha1.BMC) string {
-	return fmt.Sprintf("compute-%d-%s", index, bmc.Name)
-}
-
-func GetBMCNameFromEndpoint(endpoint *metalv1alpha1.Endpoint) string {
-	return fmt.Sprintf("bmc-%s", endpoint.Name)
-}
-
-func GetBMCSecretNameFromEndpoint(endpoint *metalv1alpha1.Endpoint) string {
-	return fmt.Sprintf("bmc-%s", endpoint.Name)
+	return fmt.Sprintf("%s-%s-%d", bmc.Name, "system", index)
 }

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -146,8 +146,7 @@ func (r *EndpointReconciler) applyBMC(ctx context.Context, log logr.Logger, endp
 			Kind:       "BMC",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			// TODO: make name prefix configurable
-			Name: fmt.Sprintf("bmc-%s", endpoint.Name),
+			Name: endpoint.Name,
 		},
 		Spec: metalv1alpha1.BMCSpec{
 			EndpointRef: corev1.LocalObjectReference{
@@ -187,7 +186,7 @@ func (r *EndpointReconciler) applyBMCSecret(ctx context.Context, log logr.Logger
 			Kind:       "BMCSecret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: GetBMCSecretNameFromEndpoint(endpoint),
+			Name: endpoint.Name,
 		},
 		Data: map[string][]byte{
 			"username": []byte(base64.StdEncoding.EncodeToString([]byte(m.DefaultCredentials[0].Username))),

--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Endpoints Controller", func() {
 		By("Ensuring that the BMC secret has been created")
 		bmcSecret := &metalv1alpha1.BMCSecret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: GetBMCSecretNameFromEndpoint(endpoint),
+				Name: endpoint.Name,
 			},
 		}
 		Eventually(Object(bmcSecret)).Should(SatisfyAll(
@@ -56,7 +56,7 @@ var _ = Describe("Endpoints Controller", func() {
 		By("By ensuring that the BMC object has been created")
 		bmc := &metalv1alpha1.BMC{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: GetBMCNameFromEndpoint(endpoint),
+				Name: endpoint.Name,
 			},
 		}
 		Eventually(Object(bmc)).Should(SatisfyAll(

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Server Controller", func() {
 		By("Ensuring that the BMC resource has been created for an endpoint")
 		bmc = &metalv1alpha1.BMC{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("bmc-%s", endpoint.Name),
+				Name: endpoint.Name,
 			},
 		}
 		Eventually(Get(bmc)).Should(Succeed())
@@ -63,7 +63,7 @@ var _ = Describe("Server Controller", func() {
 		By("Ensuring that the Server resource has been created")
 		server := &metalv1alpha1.Server{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("compute-0-%s", bmc.Name),
+				Name: fmt.Sprintf("%s-system-0", bmc.Name),
 			},
 		}
 		Eventually(Object(server)).Should(SatisfyAll(


### PR DESCRIPTION
# Proposed Changes

Use the `Endpoints` name as the name for the detected `BMC`. `Servers` will be prefixed with the `Endpoint` name followed by a `-system-idx`.

E.g.: `Endpoint` `compute-10` -> `BMC` `compute-10` (`BMCSecret` `compute-10`) -> `Server` `compute-10-system-0`

Attention: This is a breaking change and you will need to remove all resources managed by the operator. Otherwise there will be duplicates created under a different name.

Fixes #65 