### PR TITLE
Add handling of `Reset` ad-hoc operation to `Server` type

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -17,7 +17,7 @@ type BMC interface {
 	PowerOff(systemUUID string) error
 
 	// Reset performs a reset on the system.
-	Reset() error
+	Reset(systemUUID string, resetType redfish.ResetType) error
 
 	// SetPXEBootOnce sets the boot device for the next system boot.
 	SetPXEBootOnce(systemUUID string) error

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -87,8 +87,14 @@ func (r *RedfishBMC) PowerOff(systemUUID string) error {
 }
 
 // Reset performs a reset on the system using Redfish.
-func (r *RedfishBMC) Reset() error {
-	// Implementation details...
+func (r *RedfishBMC) Reset(systemUUID string, resetType redfish.ResetType) error {
+	system, err := r.getSystemByUUID(systemUUID)
+	if err != nil {
+		return fmt.Errorf("failed to get systems: %w", err)
+	}
+	if err := system.Reset(resetType); err != nil {
+		return fmt.Errorf("failed to reset system to power on state: %w", err)
+	}
 	return nil
 }
 

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -93,7 +93,7 @@ func (r *RedfishBMC) Reset(systemUUID string, resetType redfish.ResetType) error
 		return fmt.Errorf("failed to get systems: %w", err)
 	}
 	if err := system.Reset(resetType); err != nil {
-		return fmt.Errorf("failed to reset system to power on state: %w", err)
+		return fmt.Errorf("failed to reset system: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -832,12 +832,12 @@ func (r *ServerReconciler) handleAnnotionOperations(ctx context.Context, log log
 	if err := bmcClient.Reset(server.Spec.UUID, redfish.ResetType(operation)); err != nil {
 		return false, fmt.Errorf("failed to reset server: %w", err)
 	}
-	log.V(1).Info("Successfully executed operation", "Operation", operation)
+	log.V(1).Info("Operation completed", "Operation", operation)
 	serverBase := server.DeepCopy()
 	delete(annotations, metalv1alpha1.OperationAnnotation)
 	server.SetAnnotations(annotations)
 	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-		return false, fmt.Errorf("failed to patch Server Annotations: %w", err)
+		return false, fmt.Errorf("failed to patch server annotations: %w", err)
 	}
 	return true, nil
 }

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -828,11 +828,11 @@ func (r *ServerReconciler) handleAnnotionOperations(ctx context.Context, log log
 		return false, fmt.Errorf("failed to create BMC client: %w", err)
 	}
 	defer bmcClient.Logout()
-	log.Info("Handling operation", "Operation", operation)
+	log.V(1).Info("Handling operation", "Operation", operation)
 	if err := bmcClient.Reset(server.Spec.UUID, redfish.ResetType(operation)); err != nil {
 		return false, fmt.Errorf("failed to reset server: %w", err)
 	}
-	log.Info("Successfully executed operation", "Operation", operation)
+	log.V(1).Info("Successfully executed operation", "Operation", operation)
 	serverBase := server.DeepCopy()
 	delete(annotations, metalv1alpha1.OperationAnnotation)
 	server.SetAnnotations(annotations)

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -17,6 +17,7 @@ import (
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/ironcore-dev/metal-operator/internal/api/registry"
 	"github.com/ironcore-dev/metal-operator/internal/ignition"
+	"github.com/stmcginnis/gofish/redfish"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
@@ -38,6 +39,7 @@ const (
 	ServerFinalizer               = "metal.ironcore.dev/server"
 	InternalAnnotationTypeKeyName = "metal.ironcore.dev/type"
 	InternalAnnotationTypeValue   = "Internal"
+	AnnotationOperationKey        = "metal.ironcore.dev/operation"
 )
 
 const (
@@ -125,6 +127,10 @@ func (r *ServerReconciler) reconcile(ctx context.Context, log logr.Logger, serve
 			return ctrl.Result{}, err
 		}
 	}
+	if modified, err := r.handleAnnotionOperations(ctx, log, server); err != nil || modified {
+		return ctrl.Result{}, err
+	}
+	log.V(1).Info("Handled annotation operations")
 
 	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, server, ServerFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
@@ -810,6 +816,31 @@ func (r *ServerReconciler) applyBiosSettings(ctx context.Context, log logr.Logge
 		return nil
 	}
 	return nil
+}
+
+func (r *ServerReconciler) handleAnnotionOperations(ctx context.Context, log logr.Logger, server *metalv1alpha1.Server) (bool, error) {
+	annotations := server.GetAnnotations()
+	operation, ok := annotations[metalv1alpha1.OperationAnnotation]
+	if !ok {
+		return false, nil
+	}
+	bmcClient, err := GetBMCClientForServer(ctx, r.Client, server, r.Insecure)
+	if err != nil {
+		return false, fmt.Errorf("failed to create BMC client: %w", err)
+	}
+	defer bmcClient.Logout()
+	log.Info("Handling operation", "Operation", operation)
+	if err := bmcClient.Reset(server.Spec.UUID, redfish.ResetType(operation)); err != nil {
+		return false, fmt.Errorf("failed to reset server: %w", err)
+	}
+	log.Info("Successfully executed operation", "Operation", operation)
+	serverBase := server.DeepCopy()
+	delete(annotations, metalv1alpha1.OperationAnnotation)
+	server.SetAnnotations(annotations)
+	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+		return false, fmt.Errorf("failed to patch Server Annotations: %w", err)
+	}
+	return true, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -39,7 +39,6 @@ const (
 	ServerFinalizer               = "metal.ironcore.dev/server"
 	InternalAnnotationTypeKeyName = "metal.ironcore.dev/type"
 	InternalAnnotationTypeValue   = "Internal"
-	AnnotationOperationKey        = "metal.ironcore.dev/operation"
 )
 
 const (


### PR DESCRIPTION
very simple implementation, which does not check if the reset api call to the bmc was successful or not.

future improvements:
use Conditions and redfish Events to track the progress of a reset call