### PR TITLE
Wait for `Server` power transition

### DIFF
--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -111,7 +111,7 @@ var _ = BeforeSuite(func() {
 			CertDir: webhookInstallOptions.LocalServingCertDir,
 		}),
 		LeaderElection: false,
-		Metrics:        metricsserver.Options{BindAddress: "0"},
+		Metrics:        metricsserver.Options{BindAddress: ":8081"},
 	})
 	Expect(err).NotTo(HaveOccurred())
 
@@ -122,8 +122,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
-		err = mgr.Start(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(mgr.Start(ctx)).NotTo(HaveOccurred())
 	}()
 
 	// wait for the webhook server to get ready

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -60,7 +60,12 @@ func main() {
 	var webhookPort int
 	var enforceFirstBoot bool
 	var serverResyncInterval time.Duration
+	var powerPollingInterval time.Duration
+	var powerPollingTimeout time.Duration
 
+	flag.DurationVar(&powerPollingInterval, "power-polling-interval", 5*time.Second,
+		"Interval between polling power state")
+	flag.DurationVar(&powerPollingTimeout, "power-polling-timeout", 2*time.Minute, "Timeout for polling power state")
 	flag.DurationVar(&registryResyncInterval, "registry-resync-interval", 10*time.Second,
 		"Defines the interval at which the registry is polled for new server information.")
 	flag.DurationVar(&serverResyncInterval, "server-resync-interval", 30*time.Second,
@@ -207,6 +212,8 @@ func main() {
 		RegistryResyncInterval: registryResyncInterval,
 		ResyncInterval:         serverResyncInterval,
 		EnforceFirstBoot:       enforceFirstBoot,
+		PowerPollingInterval:   powerPollingInterval,
+		PowerPollingTimeout:    powerPollingTimeout,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Server")
 		os.Exit(1)

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -12,6 +12,9 @@ import (
 	"sort"
 	"time"
 
+	"github.com/ironcore-dev/metal-operator/bmc"
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/go-logr/logr"
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
@@ -308,9 +311,6 @@ func (r *ServerReconciler) handleAvailableState(ctx context.Context, log logr.Lo
 	}
 	log.V(1).Info("Ensured initial boot configuration is deleted")
 
-	if err := r.ensureServerPowerState(ctx, log, server); err != nil {
-		return false, fmt.Errorf("failed to ensure server power state: %w", err)
-	}
 	if err := r.ensureIndicatorLED(ctx, log, server); err != nil {
 		return false, fmt.Errorf("failed to ensure server indicator led: %w", err)
 	}
@@ -665,13 +665,34 @@ func (r *ServerReconciler) ensureServerPowerState(ctx context.Context, log logr.
 		if err := bmcClient.PowerOn(server.Spec.UUID); err != nil {
 			return fmt.Errorf("failed to power on server: %w", err)
 		}
+		if err := waitForServerPowerState(ctx, log, bmcClient, server, redfish.OnPowerState); err != nil {
+			return fmt.Errorf("failed to wait for server power on server: %w", err)
+		}
 	case powerOpOff:
 		if err := bmcClient.PowerOff(server.Spec.UUID); err != nil {
 			return fmt.Errorf("failed to power off server: %w", err)
 		}
+		if err := waitForServerPowerState(ctx, log, bmcClient, server, redfish.OffPowerState); err != nil {
+			return fmt.Errorf("failed to wait for server power off server: %w", err)
+		}
 	}
 	log.V(1).Info("Ensured server power state", "PowerState", server.Spec.Power)
 
+	return nil
+}
+
+func waitForServerPowerState(ctx context.Context, log logr.Logger, bmcClient bmc.BMC, server *metalv1alpha1.Server, powerState redfish.PowerState) error {
+	if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		log.V(1).Info("Waiting for Server to reach target power state", "TargetPowerState", powerState)
+		sysInfo, err := bmcClient.GetSystemInfo(server.Spec.UUID)
+		if err != nil {
+			return false, fmt.Errorf("failed to get system info: %w", err)
+		}
+		log.V(1).Info("Read Server power state", "PowerState", sysInfo.PowerState, "TargetPowerState", powerState)
+		return sysInfo.PowerState == powerState, nil
+	}); err != nil {
+		return fmt.Errorf("failed to wait for for server power state: %w", err)
+	}
 	return nil
 }
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -180,6 +180,8 @@ func SetupTest() *corev1.Namespace {
 			RegistryResyncInterval: 50 * time.Millisecond,
 			ResyncInterval:         100 * time.Millisecond,
 			EnforceFirstBoot:       true,
+			PowerPollingInterval:   50 * time.Millisecond,
+			PowerPollingTimeout:    200 * time.Millisecond,
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
 		Expect((&ServerClaimReconciler{

--- a/internal/probe/agent_test.go
+++ b/internal/probe/agent_test.go
@@ -4,16 +4,32 @@
 package probe_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/ironcore-dev/metal-operator/internal/probe"
 
 	"github.com/ironcore-dev/metal-operator/internal/api/registry"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ProbeServer", func() {
+var _ = Describe("ProbeAgent", func() {
+	BeforeEach(func() {
+		By("Starting the probe agent")
+		ctx, cancel := context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+
+		// Initialize your probe agent
+		probeAgent = probe.NewAgent(systemUUID, registryURL)
+		go func() {
+			defer GinkgoRecover()
+			Expect(probeAgent.Start(ctx)).To(Succeed(), "failed to start probe agent")
+		}()
+	})
+
 	It("should ensure the correct endpoints have been registered", func() {
 		By("performing a GET request to the /systems/{uuid} endpoint")
 		var resp *http.Response

--- a/internal/probe/agent_test.go
+++ b/internal/probe/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/ironcore-dev/metal-operator/internal/probe"
 
@@ -23,7 +24,7 @@ var _ = Describe("ProbeAgent", func() {
 		DeferCleanup(cancel)
 
 		// Initialize your probe agent
-		probeAgent = probe.NewAgent(systemUUID, registryURL)
+		probeAgent = probe.NewAgent(systemUUID, registryURL, 100*time.Millisecond)
 		go func() {
 			defer GinkgoRecover()
 			Expect(probeAgent.Start(ctx)).To(Succeed(), "failed to start probe agent")


### PR DESCRIPTION
# Proposed Changes

After changing the powerstate of the `Server` do a periodic polling until the target powerstate of a `Server` is reached.

Fixes #121