### PR TITLE
Retry with `ForcePowerOff` if graceful shutdown times out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot AS manager
+LABEL source_repository="https://github.com/ironcore-dev/metal-operator"
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
@@ -41,6 +42,7 @@ USER 65532:65532
 ENTRYPOINT ["/manager"]
 
 FROM gcr.io/distroless/static:nonroot AS probe
+LABEL source_repository="https://github.com/ironcore-dev/metal-operator"
 WORKDIR /
 COPY --from=builder /workspace/metalprobe .
 USER 65532:65532

--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -13,8 +13,11 @@ type BMC interface {
 	// PowerOn powers on the system.
 	PowerOn(systemUUID string) error
 
-	// PowerOff powers off the system.
+	// PowerOff gracefully shuts down the system.
 	PowerOff(systemUUID string) error
+
+	// ForcePowerOff powers off the system.
+	ForcePowerOff(systemUUID string) error
 
 	// Reset performs a reset on the system.
 	Reset(systemUUID string, resetType redfish.ResetType) error

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -74,13 +74,25 @@ func (r *RedfishBMC) PowerOn(systemUUID string) error {
 	return nil
 }
 
-// PowerOff powers off the system using Redfish.
+// PowerOff gracefully shuts down the system using Redfish.
 func (r *RedfishBMC) PowerOff(systemUUID string) error {
 	system, err := r.getSystemByUUID(systemUUID)
 	if err != nil {
 		return fmt.Errorf("failed to get systems: %w", err)
 	}
 	if err := system.Reset(redfish.GracefulShutdownResetType); err != nil {
+		return fmt.Errorf("failed to reset system to power on state: %w", err)
+	}
+	return nil
+}
+
+// ForcePowerOff powers off the system using Redfish.
+func (r *RedfishBMC) ForcePowerOff(systemUUID string) error {
+	system, err := r.getSystemByUUID(systemUUID)
+	if err != nil {
+		return fmt.Errorf("failed to get systems: %w", err)
+	}
+	if err := system.Reset(redfish.ForceOffResetType); err != nil {
 		return fmt.Errorf("failed to reset system to power on state: %w", err)
 	}
 	return nil

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -59,6 +59,7 @@ func main() {
 	var registryResyncInterval time.Duration
 	var webhookPort int
 	var enforceFirstBoot bool
+	var enforcePowerOff bool
 	var serverResyncInterval time.Duration
 	var powerPollingInterval time.Duration
 	var powerPollingTimeout time.Duration
@@ -82,6 +83,8 @@ func main() {
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enforceFirstBoot, "enforce-first-boot", false,
 		"Enforce the first boot probing of a Server even if it is powered on in the Initial state.")
+	flag.BoolVar(&enforcePowerOff, "enforce-power-off", false,
+		"Enforce the power off of a Server when graceful shutdown fails.")
 	flag.IntVar(&webhookPort, "webhook-port", 9445, "The port to use for webhook server.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -212,6 +215,7 @@ func main() {
 		RegistryResyncInterval: registryResyncInterval,
 		ResyncInterval:         serverResyncInterval,
 		EnforceFirstBoot:       enforceFirstBoot,
+		EnforcePowerOff:        enforcePowerOff,
 		PowerPollingInterval:   powerPollingInterval,
 		PowerPollingTimeout:    powerPollingTimeout,
 	}).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
# Proposed Changes
- I observed that in case `Server` is stuck in a failed PXE Boot or in other non-responsive state, `redfish.GracefulShutdownResetType` would not power off the system. 
- So we can retry with `redfish.PushPowerButtonResetType` if above fails.
- Enabled via flag `--enforce-power-off`
