### PR TITLE
Switch port of local docs setup to `9000`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 .PHONY: startdocs
 startdocs: ## Start the local mkdocs based development environment.
 	docker build -t $(IMAGE) -f docs/Dockerfile . --load
-	docker run -p 8000:8000 -v `pwd`/:/docs $(IMAGE)
+	docker run -p 9000:9000 -v `pwd`/:/docs $(IMAGE)
 
 .PHONY: cleandocs
 cleandocs: ## Remove all local mkdocs Docker images (cleanup).

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /docs
 COPY docs/requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-EXPOSE 8000
+EXPOSE 9000
 
 # Start development server by default
 ENTRYPOINT ["mkdocs"]
-CMD ["serve", "--dev-addr=0.0.0.0:8000"]
+CMD ["serve", "--dev-addr=0.0.0.0:9000"]


### PR DESCRIPTION
# Proposed Changes

Switch port of local docs setup to `9000`. It will otherwise collide with the local BMC emulator. 