### PR TITLE
Claim only `PoweredOff` Servers

### DIFF
--- a/internal/controller/serverclaim_controller.go
+++ b/internal/controller/serverclaim_controller.go
@@ -351,6 +351,10 @@ func (r *ServerClaimReconciler) claimServerByReference(ctx context.Context, log 
 		log.V(1).Info("Server not in a claimable state", "Server", server.Name, "ServerState", server.Status.State)
 		return nil, nil
 	}
+	if server.Status.PowerState != metalv1alpha1.ServerOffPowerState {
+		log.V(1).Info("Server is not powered off", "Server", server.Name, "PowerState", server.Status.PowerState)
+		return nil, nil
+	}
 	if claim.Spec.ServerSelector == nil {
 		return server, nil
 	}

--- a/internal/controller/serverclaim_controller.go
+++ b/internal/controller/serverclaim_controller.go
@@ -385,6 +385,10 @@ func (r *ServerClaimReconciler) claimServerBySelector(ctx context.Context, log l
 			log.V(1).Info("Server not in a claimable state", "Server", s.Name, "ServerState", s.Status.State)
 			continue
 		}
+		if s.Status.PowerState != metalv1alpha1.ServerOffPowerState {
+			log.V(1).Info("Server is not powered off", "Server", s.Name, "PowerState", s.Status.PowerState)
+			continue
+		}
 		server = s.DeepCopy()
 		break
 	}


### PR DESCRIPTION
Also do not perform power changes in `Available` state if server is already powered off.

ServerClaim controller may patch the server in parallel to `spec.PowerState: On` which may result in powering on the server in Available state.