### PR TITLE
Use lower-case `Server` UUIDs

### DIFF
--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -399,7 +399,7 @@ func (r *RedfishBMC) getSystemByUUID(systemUUID string) (*redfish.ComputerSystem
 		return nil, err
 	}
 	for _, system := range systems {
-		if system.UUID == systemUUID {
+		if strings.ToLower(system.UUID) == systemUUID {
 			return system, nil
 		}
 	}

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -166,7 +167,7 @@ func (r *BMCReconciler) discoverServers(ctx context.Context, log logr.Logger, bm
 				Name: GetServerNameFromBMCandIndex(i, bmcObj),
 			},
 			Spec: metalv1alpha1.ServerSpec{
-				UUID:   s.UUID,
+				UUID:   strings.ToLower(s.UUID), // always use lower-case uuids
 				BMCRef: &v1.LocalObjectReference{Name: bmcObj.Name},
 			},
 		}


### PR DESCRIPTION
# Proposed Changes

Use lower-case `Server` UUIDs.

Fixes #160 