### PR TITLE
Add kustomization for managing remote clusters

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,7 +24,10 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 # - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+# - ../prometheus
+# [REMOTE-CLUSTER] To configure the operator against a remote cluster, uncomment all sections with 'REMOTE-CLUSTER'.
+# Another patch is necesscary to inject the remote kubeconfig into the secret.
+# - remote_kubeconfig.yaml
 
 patches:
 # Protect the /metrics endpoint by putting it behind auth.
@@ -34,7 +37,11 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- path: manager_webhook_patch.yaml
+# - path: manager_webhook_patch.yaml
+
+# [REMOTE-CLUSTER] To configure the operator against a remote cluster, uncomment all sections with 'REMOTE-CLUSTER'.
+# Another patch is necesscary to inject the remote kubeconfig into the secret.
+# - path: manager_remote_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.

--- a/config/default/manager_remote_patch.yaml
+++ b/config/default/manager_remote_patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --kubeconfig=/kubeconfig/kubeconfig
+        name: manager
+        volumeMounts:
+        - name: remote-kubeconfig
+          mountPath: /kubeconfig
+          readOnly: true
+      volumes:
+      - name: remote-kubeconfig
+        secret:
+          secretName: remote-kubeconfig

--- a/config/default/remote_kubeconfig.yaml
+++ b/config/default/remote_kubeconfig.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: remote-kubeconfig
+data:
+  kubeconfig: ""


### PR DESCRIPTION
# Proposed Changes

- Add kustomization for configuring the metal-operator against a remote cluster. The kubeconfig is intended to by supplied by the user via an additional kustomize overlay.