### PR TITLE
Restructure `metalctl` documentation

### DIFF
--- a/docs/usage/metalctl.md
+++ b/docs/usage/metalctl.md
@@ -1,20 +1,19 @@
-# metalctl move
+# metalctl
 
-The `metalctl move` command allows to move the metal Custom Resources, like e.g. Endpoint, BMC, Server, etc. from one
+## move
+
+The `metalctl move` command allows to move the metal Custom Resources, like e.g. `Endpoint`, `BMC`, `Server`, etc. from one
 cluster to another.
-
 
 > Warning!:
 > Before running `metalctl move`, the user should take care of preparing the target cluster, including also installing
 > all the required Custom Resources Definitions.
-
 
 You can use:
 
 ```bash
 metalctl move --source-kubeconfig="path-to-source-kubeconfig.yaml" --target-kubeconfig="path-to-target-kubeconfig.yaml"
 ```
-
 to move the metal Custom Resources existing in all namespaces of the source cluster. In case you want to move the metal
 Custom Resources defined in a single namespace, you can use the `--namespace` flag.
 
@@ -35,8 +34,7 @@ several limitation for this scenario, like e.g. the implementation assumes the c
 move operation, and possible race conditions happening while the cluster is upgrading, scaling up, remediating etc. has
 never been investigated nor addressed.
 
-
-## Pivot
+### Pivot
 
 Pivoting is a process for moving the Custom Resources and install Custom Resource Definitions from a source cluster to
 a target cluster.
@@ -46,8 +44,7 @@ This can now be achieved with the following procedure:
 1. Use `make install` to install the metal Custom Resource Definitions into the target cluster
 2. Use `metalctl move` to move the metal Custom Resources from a source cluster to a target cluster
 
-
-## Dry run
+### Dry run
 
 With `--dry-run` option you can dry-run the move action by only printing logs without taking any actual actions. Use
 `--verbose` flag to enable verbose logging.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,12 +56,12 @@ nav:
     - Servers: concepts/servers.md
     - ServerBootConfigurations: concepts/serverbootconfigurations.md
     - ServerClaims: concepts/serverclaims.md
+- Usage:
+  - metalctl: usage/metalctl.md
 - Development Guide:
   - Local Setup: development/dev_setup.md
   - Documentation: development/dev_docs.md
 - API Reference: api-reference/api.md
-- Usage: 
-  - Metalctl: usage/metalctl.md
 
 extra:
   social:


### PR DESCRIPTION
# Proposed Changes

Move the `metalctl` usage documentation up in the navigation.
