### PR TITLE
Fix controllerutil.CreateOrPatch() calls

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )


### PR DESCRIPTION
# Proposed Changes

- Use `mutateFn` of `controllerutil.CreateOrPatch()`, so that it can actually patch objects