### PR TITLE
Apply `BMC` labels to `Server` on creation

### DIFF
--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/ironcore-dev/controller-utils/clientutils"
+	"github.com/ironcore-dev/controller-utils/metautils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/ironcore-dev/metal-operator/bmc"
 	"github.com/ironcore-dev/metal-operator/internal/bmcutils"
@@ -164,7 +165,7 @@ func (r *BMCReconciler) discoverServers(ctx context.Context, log logr.Logger, bm
 		server.Name = bmcutils.GetServerNameFromBMCandIndex(i, bmcObj)
 
 		opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, server, func() error {
-			server.Labels = mergeLabels(bmcObj.Labels, server.Labels)
+			metautils.SetLabels(server, bmcObj.Labels)
 			server.Spec.UUID = strings.ToLower(s.UUID)
 			server.Spec.SystemUUID = strings.ToLower(s.UUID)
 			server.Spec.BMCRef = &v1.LocalObjectReference{Name: bmcObj.Name}
@@ -186,14 +187,4 @@ func (r *BMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&metalv1alpha1.Server{}).
 		// TODO: add watches for Endpoints and BMCSecrets
 		Complete(r)
-}
-
-func mergeLabels(bmcLabels, serverLabels map[string]string) map[string]string {
-	if serverLabels == nil {
-		serverLabels = make(map[string]string)
-	}
-	for key, value := range bmcLabels {
-		serverLabels[key] = value
-	}
-	return serverLabels
 }

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -164,6 +164,7 @@ func (r *BMCReconciler) discoverServers(ctx context.Context, log logr.Logger, bm
 		server.Name = bmcutils.GetServerNameFromBMCandIndex(i, bmcObj)
 
 		opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, server, func() error {
+			server.Labels = mergeLabels(bmcObj.Labels, server.Labels)
 			server.Spec.UUID = strings.ToLower(s.UUID)
 			server.Spec.SystemUUID = strings.ToLower(s.UUID)
 			server.Spec.BMCRef = &v1.LocalObjectReference{Name: bmcObj.Name}
@@ -185,4 +186,14 @@ func (r *BMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&metalv1alpha1.Server{}).
 		// TODO: add watches for Endpoints and BMCSecrets
 		Complete(r)
+}
+
+func mergeLabels(bmcLabels, serverLabels map[string]string) map[string]string {
+	if serverLabels == nil {
+		serverLabels = make(map[string]string)
+	}
+	for key, value := range bmcLabels {
+		serverLabels[key] = value
+	}
+	return serverLabels
 }

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -105,10 +105,15 @@ var _ = Describe("BMC Controller", func() {
 		Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, bmcSecret)
 
+		bmcLabels := map[string]string{
+			"foo": "bar",
+		}
+
 		By("Creating a BMC resource")
 		bmc := &metalv1alpha1.BMC{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-",
+				Labels:       bmcLabels,
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
@@ -151,6 +156,7 @@ var _ = Describe("BMC Controller", func() {
 				Controller:         ptr.To(true),
 				BlockOwnerDeletion: ptr.To(true),
 			})),
+			HaveField("ObjectMeta.Labels", bmcLabels),
 			HaveField("Spec.UUID", "38947555-7742-3448-3784-823347823834"),
 			HaveField("Spec.SystemUUID", "38947555-7742-3448-3784-823347823834"),
 			HaveField("Spec.BMCRef.Name", bmc.Name),


### PR DESCRIPTION
If `BMC` is created by outside tooling and common labels are applied, it would be good if `Server` inherits them.