### PR TITLE
Make `MACAddress` field in `BMC` `InlineEndpoint` optional

### DIFF
--- a/api/v1alpha1/endpoint_types.go
+++ b/api/v1alpha1/endpoint_types.go
@@ -10,7 +10,7 @@ import (
 // EndpointSpec defines the desired state of Endpoint
 type EndpointSpec struct {
 	// MACAddress is the MAC address of the endpoint.
-	MACAddress string `json:"macAddress"`
+	MACAddress string `json:"macAddress,omitempty"`
 	// IP is the IP address of the endpoint.
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Schemaless

--- a/config/crd/bases/metal.ironcore.dev_endpoints.yaml
+++ b/config/crd/bases/metal.ironcore.dev_endpoints.yaml
@@ -57,7 +57,6 @@ spec:
                 type: string
             required:
             - ip
-            - macAddress
             type: object
           status:
             description: EndpointStatus defines the observed state of Endpoint


### PR DESCRIPTION
# Proposed Changes

- when using `InlineEndpoints` we only need to add BMC IP address - and mac is only required when relying on macdb
