### PR TITLE
Revert "Make `MACAddress` field in `BMC` `Endpoint` optional"

### DIFF
--- a/api/v1alpha1/endpoint_types.go
+++ b/api/v1alpha1/endpoint_types.go
@@ -10,7 +10,7 @@ import (
 // EndpointSpec defines the desired state of Endpoint
 type EndpointSpec struct {
 	// MACAddress is the MAC address of the endpoint.
-	MACAddress string `json:"macAddress,omitempty"`
+	MACAddress string `json:"macAddress"`
 	// IP is the IP address of the endpoint.
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Schemaless

--- a/config/crd/bases/metal.ironcore.dev_endpoints.yaml
+++ b/config/crd/bases/metal.ironcore.dev_endpoints.yaml
@@ -57,6 +57,7 @@ spec:
                 type: string
             required:
             - ip
+            - macAddress
             type: object
           status:
             description: EndpointStatus defines the observed state of Endpoint


### PR DESCRIPTION
Reverts ironcore-dev/metal-operator#223