### PR TITLE
Install `docker-cli` in `metalprobe` service 

### DIFF
--- a/internal/ignition/default.go
+++ b/internal/ignition/default.go
@@ -34,7 +34,7 @@ systemd:
         Type=oneshot
         RemainAfterExit=yes
         ExecStart=/usr/bin/apt-get update
-        ExecStart=/usr/bin/apt-get install docker.io -y
+        ExecStart=/usr/bin/apt-get install docker.io docker-cli -y
         [Install]
         WantedBy=multi-user.target
     - name: docker.service


### PR DESCRIPTION
# Proposed Changes

- `docker-cli` is now a [separate package](https://metadata.ftp-master.debian.org/changelogs//main/d/docker.io/docker.io_26.1.5+dfsg1-4_changelog)
- it will be added to gardenlinux upstream releases starting tomorrow