### PR TITLE
Fix `ServerClaim` with label selector claiming multiple servers

### DIFF
--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -601,6 +601,11 @@ var _ = Describe("Server Claiming", MustPassRepeatedly(5), func() {
 		}
 	}
 
+	BeforeEach(func(ctx SpecContext) {
+		var server metalv1alpha1.Server
+		Expect(k8sClient.DeleteAllOf(ctx, &server)).To(Succeed())
+	})
+
 	It("binds four out of ten server for four best effort claims", func(ctx SpecContext) {
 		for range 10 {
 			makeServer(ctx)


### PR DESCRIPTION
# Proposed Changes

- Fix claiming multiple available servers when having multiple unbound `ServerClaims` using label selectors.
- Add tests for multiple `Servers` and/or `ServerClaims`.