### PR TITLE
Order resource deletions in controller tests properly

### DIFF
--- a/internal/controller/bmcsecret_controller_test.go
+++ b/internal/controller/bmcsecret_controller_test.go
@@ -4,8 +4,6 @@
 package controller
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -21,15 +19,13 @@ var _ = Describe("BMCSecret Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
 
-		ctx := context.Background()
-
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: "default",
 		}
 		bmcsecret := &metalv1alpha1.BMCSecret{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("creating the custom resource for the Kind BMCSecret")
 			err := k8sClient.Get(ctx, typeNamespacedName, bmcsecret)
 			if err != nil && errors.IsNotFound(err) {
@@ -38,13 +34,12 @@ var _ = Describe("BMCSecret Controller", func() {
 						Name:      resourceName,
 						Namespace: "default",
 					},
-					// TODO(user): Specify other spec details if needed.
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			// TODO(user): Cleanup logic after each test, like removing the resource instance.
 			resource := &metalv1alpha1.BMCSecret{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
@@ -53,7 +48,8 @@ var _ = Describe("BMCSecret Controller", func() {
 			By("Cleanup the specific resource instance BMCSecret")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
-		It("should successfully reconcile the resource", func() {
+
+		It("should successfully reconcile the resource", func(ctx SpecContext) {
 			By("Reconciling the created resource")
 			controllerReconciler := &BMCSecretReconciler{
 				Client: k8sClient,
@@ -63,7 +59,7 @@ var _ = Describe("BMCSecret Controller", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(Succeed())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})

--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -14,13 +14,17 @@ import (
 )
 
 var _ = Describe("Endpoints Controller", func() {
-	_ = SetupTest()
+	ns := SetupTest()
+
+	AfterEach(func(ctx SpecContext) {
+		DeleteAllMetalResources(ctx, ns.Name)
+	})
 
 	It("should successfully create a BMC secret and BMC object from endpoint", func(ctx SpecContext) {
 		By("Creating an Endpoints object")
 		endpoint := &metalv1alpha1.Endpoint{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-",
+				GenerateName: "test-endpoint-",
 			},
 			Spec: metalv1alpha1.EndpointSpec{
 				// emulator BMC mac address
@@ -49,7 +53,6 @@ var _ = Describe("Endpoints Controller", func() {
 				metalv1alpha1.BMCSecretUsernameKeyName: []byte("foo"),
 				metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
 			}))))
-		DeferCleanup(k8sClient.Delete, bmcSecret)
 
 		By("By ensuring that the BMC object has been created")
 		bmc := &metalv1alpha1.BMC{

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -28,11 +28,15 @@ import (
 var _ = Describe("Server Controller", func() {
 	ns := SetupTest()
 
+	AfterEach(func(ctx SpecContext) {
+		DeleteAllMetalResources(ctx, ns.Name)
+	})
+
 	It("Should initialize a Server from Endpoint", func(ctx SpecContext) {
 		By("Creating an Endpoint object")
 		endpoint := &metalv1alpha1.Endpoint{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-",
+				GenerateName: "test-server-",
 			},
 			Spec: metalv1alpha1.EndpointSpec{
 				// emulator BMC mac address
@@ -41,7 +45,6 @@ var _ = Describe("Server Controller", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, endpoint)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, endpoint)
 
 		By("Ensuring that the BMC resource has been created for an endpoint")
 		bmc := &metalv1alpha1.BMC{
@@ -50,7 +53,6 @@ var _ = Describe("Server Controller", func() {
 			},
 		}
 		Eventually(Get(bmc)).Should(Succeed())
-		DeferCleanup(k8sClient.Delete, bmc)
 
 		By("Ensuring that the BMCSecret will be removed")
 		bmcSecret := &metalv1alpha1.BMCSecret{
@@ -59,7 +61,6 @@ var _ = Describe("Server Controller", func() {
 			},
 		}
 		Eventually(Get(bmcSecret)).Should(Succeed())
-		DeferCleanup(k8sClient.Delete, bmcSecret)
 
 		By("Ensuring that the Server resource has been created")
 		server := &metalv1alpha1.Server{
@@ -90,7 +91,6 @@ var _ = Describe("Server Controller", func() {
 			HaveField("Status.State", metalv1alpha1.ServerStateDiscovery),
 			HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
 		))
-		DeferCleanup(k8sClient.Delete, server)
 
 		By("Ensuring the boot configuration has been created")
 		bootConfig := &metalv1alpha1.ServerBootConfiguration{
@@ -238,7 +238,7 @@ var _ = Describe("Server Controller", func() {
 		By("Creating a BMCSecret")
 		bmcSecret := &metalv1alpha1.BMCSecret{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-",
+				GenerateName: "test-server-",
 			},
 			Data: map[string][]byte{
 				"username": []byte("foo"),
@@ -246,7 +246,6 @@ var _ = Describe("Server Controller", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, bmcSecret)
 
 		By("Creating a Server with inline BMC configuration")
 		server := &metalv1alpha1.Server{
@@ -269,7 +268,6 @@ var _ = Describe("Server Controller", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, server)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, server)
 
 		By("Ensuring the boot configuration has been created")
 		bootConfig := &metalv1alpha1.ServerBootConfiguration{

--- a/internal/controller/serverbootconfiguration_controller_test.go
+++ b/internal/controller/serverbootconfiguration_controller_test.go
@@ -21,7 +21,7 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 		By("Creating a Server object")
 		server = &metalv1alpha1.Server{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-",
+				GenerateName: "test-severbootconfig-",
 				Annotations: map[string]string{
 					metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationIgnore,
 				},
@@ -29,7 +29,10 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 			Spec: metalv1alpha1.ServerSpec{},
 		}
 		Expect(k8sClient.Create(ctx, server)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, server)
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		DeleteAllMetalResources(ctx, ns.Name)
 	})
 
 	It("should successfully add the boot configuration ref to server", func(ctx SpecContext) {
@@ -45,7 +48,6 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, config)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, config)
 
 		Eventually(Object(config)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerBootConfigurationStatePending),

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -56,6 +56,38 @@ func TestControllers(t *testing.T) {
 	RunSpecs(t, "Controller Suite")
 }
 
+func DeleteAllMetalResources(ctx context.Context, namespace string) {
+	var serverClaim metalv1alpha1.ServerClaim
+	Expect(k8sClient.DeleteAllOf(ctx, &serverClaim, client.InNamespace(namespace))).To(Succeed())
+	var serverClaimList metalv1alpha1.ServerClaimList
+	Eventually(ObjectList(&serverClaimList)).Should(HaveField("Items", BeEmpty()))
+
+	var endpoint metalv1alpha1.Endpoint
+	Expect(k8sClient.DeleteAllOf(ctx, &endpoint)).To(Succeed())
+	var endpointList metalv1alpha1.EndpointList
+	Eventually(ObjectList(&endpointList)).Should(HaveField("Items", BeEmpty()))
+
+	var bmc metalv1alpha1.BMC
+	Expect(k8sClient.DeleteAllOf(ctx, &bmc)).To(Succeed())
+	var bmcList metalv1alpha1.BMCList
+	Eventually(ObjectList(&bmcList)).Should(HaveField("Items", BeEmpty()))
+
+	var serverBootConfiguration metalv1alpha1.ServerBootConfiguration
+	Expect(k8sClient.DeleteAllOf(ctx, &serverBootConfiguration, client.InNamespace(namespace))).To(Succeed())
+	var serverBootConfigurationList metalv1alpha1.ServerBootConfigurationList
+	Eventually(ObjectList(&serverBootConfigurationList)).Should(HaveField("Items", BeEmpty()))
+
+	var server metalv1alpha1.Server
+	Expect(k8sClient.DeleteAllOf(ctx, &server)).To(Succeed())
+	var serverList metalv1alpha1.ServerList
+	Eventually(ObjectList(&serverList)).Should(HaveField("Items", BeEmpty()))
+
+	var bmcSecret metalv1alpha1.BMCSecret
+	Expect(k8sClient.DeleteAllOf(ctx, &bmcSecret)).To(Succeed())
+	var bmcSecretList metalv1alpha1.BMCSecretList
+	Eventually(ObjectList(&bmcSecretList)).Should(HaveField("Items", BeEmpty()))
+}
+
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 


### PR DESCRIPTION
# Proposed Changes

- Order deletion in test properly, so that resource creating dependent resource are deleted first
- Attach the suite to some objects to identify resource leaks, if any, more easily