### PR TITLE
Add `instance-type` annotation constant

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -8,4 +8,6 @@ const (
 	OperationAnnotation = "metal.ironcore.dev/operation"
 	// OperationAnnotationIgnore skips the reconciliation of a resource if set to true.
 	OperationAnnotationIgnore = "ignore"
+	// InstanceTypeAnnotation is used to specify the type of Server.
+	InstanceTypeAnnotation = "metal.ironcore.dev/instance-type"
 )


### PR DESCRIPTION
# Proposed Changes

Introduce an instance type annotation constant which can be used across the stack which can be used to identify the instance type of a server.