### PR TITLE
Add per `BMC` protocol scheme configuration in macdb

### DIFF
--- a/api/v1alpha1/bmc_types.go
+++ b/api/v1alpha1/bmc_types.go
@@ -9,10 +9,15 @@ import (
 )
 
 const (
-	BMCType              = "bmc"
-	ProtocolRedfish      = "Redfish"
+	// BMCType is the type of the BMC resource.
+	BMCType = "bmc"
+
+	// ProtocolRedfish is the Redfish protocol.
+	ProtocolRedfish = "Redfish"
+	// ProtocolRedfishLocal is the RedfishLocal protocol.
 	ProtocolRedfishLocal = "RedfishLocal"
-	ProtocolRedfishKube  = "RedfishKube"
+	// ProtocolRedfishKube is the RedfishKube protocol.
+	ProtocolRedfishKube = "RedfishKube"
 )
 
 // BMCSpec defines the desired state of BMC
@@ -81,6 +86,16 @@ const (
 	ConsoleProtocolNameSSHLenovo ConsoleProtocolName = "SSHLenovo"
 )
 
+// ProtocolScheme is a string that contains the protocol scheme
+type ProtocolScheme string
+
+const (
+	// HTTPProtocolScheme is the http protocol scheme
+	HTTPProtocolScheme ProtocolScheme = "http"
+	// HTTPSProtocolScheme is the https protocol scheme
+	HTTPSProtocolScheme ProtocolScheme = "https"
+)
+
 // Protocol defines the protocol and port used for communicating with the BMC.
 type Protocol struct {
 	// Name specifies the name of the protocol.
@@ -90,6 +105,9 @@ type Protocol struct {
 	// Port specifies the port number used for communication.
 	// This port is used by the specified protocol to establish connections.
 	Port int32 `json:"port"`
+
+	// Scheme specifies the scheme used for communication.
+	Scheme ProtocolScheme `json:"scheme,omitempty"`
 }
 
 // ProtocolName defines the possible names for protocols used for communicating with the BMC.

--- a/config/crd/bases/metal.ironcore.dev_bmcs.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcs.yaml
@@ -158,6 +158,9 @@ spec:
                       This port is used by the specified protocol to establish connections.
                     format: int32
                     type: integer
+                  scheme:
+                    description: Scheme specifies the scheme used for communication.
+                    type: string
                 required:
                 - name
                 - port

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -128,6 +128,9 @@ spec:
                           This port is used by the specified protocol to establish connections.
                         format: int32
                         type: integer
+                      scheme:
+                        description: Scheme specifies the scheme used for communication.
+                        type: string
                     required:
                     - name
                     - port

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1139,6 +1139,19 @@ int32
 This port is used by the specified protocol to establish connections.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>scheme</code><br/>
+<em>
+<a href="#metal.ironcore.dev/v1alpha1.ProtocolScheme">
+ProtocolScheme
+</a>
+</em>
+</td>
+<td>
+<p>Scheme specifies the scheme used for communication.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="metal.ironcore.dev/v1alpha1.ProtocolName">ProtocolName
@@ -1164,6 +1177,29 @@ This port is used by the specified protocol to establish connections.</p>
 </td>
 </tr><tr><td><p>&#34;SSH&#34;</p></td>
 <td><p>ProtocolNameSSH represents the SSH protocol.</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="metal.ironcore.dev/v1alpha1.ProtocolScheme">ProtocolScheme
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#metal.ironcore.dev/v1alpha1.Protocol">Protocol</a>)
+</p>
+<div>
+<p>ProtocolScheme is a string that contains the protocol scheme</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;http&#34;</p></td>
+<td><p>HTTPProtocolScheme is the http protocol scheme</p>
+</td>
+</tr><tr><td><p>&#34;https&#34;</p></td>
+<td><p>HTTPSProtocolScheme is the https protocol scheme</p>
 </td>
 </tr></tbody>
 </table>

--- a/docs/concepts/bmcs.md
+++ b/docs/concepts/bmcs.md
@@ -22,6 +22,7 @@ spec:
   protocol:
     name: Redfish
     port: 8000
+    scheme: http
   consoleProtocol:
     name: SSH
     port: 22
@@ -35,7 +36,7 @@ kind: BMC
 metadata:
   name: my-bmc-inline
 spec:
-  endpoint:
+  access:
     macAddress: "00:1A:2B:3C:4D:5E"
     ip: "192.168.100.10"
   bmcSecretRef:

--- a/internal/api/macdb/macdb.go
+++ b/internal/api/macdb/macdb.go
@@ -3,26 +3,55 @@
 
 package macdb
 
+// MacPrefixes is a list of MacPrefix
 type MacPrefixes struct {
+	// MacPrefixes is a list of MacPrefix
 	MacPrefixes []MacPrefix `json:"macPrefixes"`
 }
 
+// Console is a struct that contains the type and port of the console
 type Console struct {
+	// Type is the type of the console
 	Type string `json:"type"`
-	Port int32  `json:"port"`
+	// Port is the port of the console
+	Port int32 `json:"port"`
 }
 
+// MacPrefix is a struct that contains the mac prefix, manufacturer, protocol, protocol scheme, port, type,
+// default credentials and console
 type MacPrefix struct {
-	MacPrefix          string       `json:"macPrefix"`
-	Manufacturer       string       `json:"manufacturer"`
-	Protocol           string       `json:"protocol"`
-	Port               int32        `json:"port"`
-	Type               string       `json:"type"`
+	// MacPrefix is the mac prefix
+	MacPrefix string `json:"macPrefix"`
+	// Manufacturer is the manufacturer
+	Manufacturer string `json:"manufacturer"`
+	// Protocol is the protocol
+	Protocol string `json:"protocol"`
+	// ProtocolScheme is the protocol scheme (http, https)
+	ProtocolScheme ProtocolScheme `json:"protocolScheme,omitempty"`
+	// Port is the port
+	Port int32 `json:"port"`
+	// Type is the type
+	Type string `json:"type"`
+	// DefaultCredentials is the default credentials
 	DefaultCredentials []Credential `json:"defaultCredentials"`
-	Console            Console      `json:"console,omitempty"`
+	// Console is the console
+	Console Console `json:"console,omitempty"`
 }
 
+// ProtocolScheme is a string that contains the protocol scheme
+type ProtocolScheme string
+
+const (
+	// HTTPProtocolScheme is the http protocol scheme
+	HTTPProtocolScheme ProtocolScheme = "http"
+	// HTTPSProtocolScheme is the https protocol scheme
+	HTTPSProtocolScheme ProtocolScheme = "https"
+)
+
+// Credential is a struct that contains the username and password
 type Credential struct {
+	// Username is the username
 	Username string `json:"username"`
+	// Password is the password
 	Password string `json:"password"`
 }

--- a/internal/api/macdb/macdb.go
+++ b/internal/api/macdb/macdb.go
@@ -3,6 +3,8 @@
 
 package macdb
 
+import metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+
 // MacPrefixes is a list of MacPrefix
 type MacPrefixes struct {
 	// MacPrefixes is a list of MacPrefix
@@ -27,7 +29,7 @@ type MacPrefix struct {
 	// Protocol is the protocol
 	Protocol string `json:"protocol"`
 	// ProtocolScheme is the protocol scheme (http, https)
-	ProtocolScheme ProtocolScheme `json:"protocolScheme,omitempty"`
+	ProtocolScheme metalv1alpha1.ProtocolScheme `json:"protocolScheme,omitempty"`
 	// Port is the port
 	Port int32 `json:"port"`
 	// Type is the type
@@ -37,16 +39,6 @@ type MacPrefix struct {
 	// Console is the console
 	Console Console `json:"console,omitempty"`
 }
-
-// ProtocolScheme is a string that contains the protocol scheme
-type ProtocolScheme string
-
-const (
-	// HTTPProtocolScheme is the http protocol scheme
-	HTTPProtocolScheme ProtocolScheme = "http"
-	// HTTPSProtocolScheme is the https protocol scheme
-	HTTPSProtocolScheme ProtocolScheme = "https"
-)
 
 // Credential is a struct that contains the username and password
 type Credential struct {

--- a/internal/bmcutils/bmcutils.go
+++ b/internal/bmcutils/bmcutils.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetProtocolScheme(protocol metalv1alpha1.Protocol, insecure bool) metalv1alpha1.ProtocolScheme {
-	if protocol.Scheme != "" {
-		return protocol.Scheme
+func GetProtocolScheme(scheme metalv1alpha1.ProtocolScheme, insecure bool) metalv1alpha1.ProtocolScheme {
+	if scheme != "" {
+		return scheme
 	}
 	if insecure {
 		return metalv1alpha1.HTTPProtocolScheme
@@ -89,7 +89,7 @@ func GetBMCClientForServer(ctx context.Context, c client.Client, server *metalv1
 			return nil, fmt.Errorf("failed to get BMC secret: %w", err)
 		}
 
-		protocolScheme := GetProtocolScheme(server.Spec.BMC.Protocol, insecure)
+		protocolScheme := GetProtocolScheme(server.Spec.BMC.Protocol.Scheme, insecure)
 
 		return CreateBMCClient(
 			ctx,
@@ -126,7 +126,7 @@ func GetBMCClientFromBMC(ctx context.Context, c client.Client, bmcObj *metalv1al
 		return nil, fmt.Errorf("failed to get BMC secret: %w", err)
 	}
 
-	protocolScheme := GetProtocolScheme(bmcObj.Spec.Protocol, insecure)
+	protocolScheme := GetProtocolScheme(bmcObj.Spec.Protocol.Scheme, insecure)
 
 	return CreateBMCClient(ctx, c, protocolScheme, bmcObj.Spec.Protocol.Name, address, bmcObj.Spec.Protocol.Port, bmcSecret, options)
 }

--- a/internal/bmcutils/bmcutils.go
+++ b/internal/bmcutils/bmcutils.go
@@ -8,11 +8,20 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/ironcore-dev/metal-operator/bmc"
-
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	"github.com/ironcore-dev/metal-operator/bmc"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func GetProtocolScheme(protocol metalv1alpha1.Protocol, insecure bool) metalv1alpha1.ProtocolScheme {
+	if protocol.Scheme != "" {
+		return protocol.Scheme
+	}
+	if insecure {
+		return metalv1alpha1.HTTPProtocolScheme
+	}
+	return metalv1alpha1.HTTPSProtocolScheme
+}
 
 func GetBMCCredentialsFromSecret(secret *metalv1alpha1.BMCSecret) (string, string, error) {
 	// TODO: use constants for secret keys
@@ -80,10 +89,12 @@ func GetBMCClientForServer(ctx context.Context, c client.Client, server *metalv1
 			return nil, fmt.Errorf("failed to get BMC secret: %w", err)
 		}
 
+		protocolScheme := GetProtocolScheme(server.Spec.BMC.Protocol, insecure)
+
 		return CreateBMCClient(
 			ctx,
 			c,
-			insecure,
+			protocolScheme,
 			server.Spec.BMC.Protocol.Name,
 			server.Spec.BMC.Address,
 			server.Spec.BMC.Protocol.Port,
@@ -115,53 +126,42 @@ func GetBMCClientFromBMC(ctx context.Context, c client.Client, bmcObj *metalv1al
 		return nil, fmt.Errorf("failed to get BMC secret: %w", err)
 	}
 
-	return CreateBMCClient(ctx, c, insecure, bmcObj.Spec.Protocol.Name, address, bmcObj.Spec.Protocol.Port, bmcSecret, options)
+	protocolScheme := GetProtocolScheme(bmcObj.Spec.Protocol, insecure)
+
+	return CreateBMCClient(ctx, c, protocolScheme, bmcObj.Spec.Protocol.Name, address, bmcObj.Spec.Protocol.Port, bmcSecret, options)
 }
 
 func CreateBMCClient(
 	ctx context.Context,
 	c client.Client,
-	insecure bool,
+	protocolScheme metalv1alpha1.ProtocolScheme,
 	bmcProtocol metalv1alpha1.ProtocolName,
 	address string,
 	port int32,
 	bmcSecret *metalv1alpha1.BMCSecret,
 	bmcOptions bmc.BMCOptions,
 ) (bmc.BMC, error) {
-	protocol := "https"
-	if insecure {
-		protocol = "http"
-	}
-
 	var bmcClient bmc.BMC
 	var err error
+
+	bmcOptions.Endpoint = fmt.Sprintf("%s://%s", protocolScheme, net.JoinHostPort(address, fmt.Sprintf("%d", port)))
+	bmcOptions.Username, bmcOptions.Password, err = GetBMCCredentialsFromSecret(bmcSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get credentials from BMC secret: %w", err)
+	}
+
 	switch bmcProtocol {
 	case metalv1alpha1.ProtocolRedfish:
-		bmcOptions.Endpoint = fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(address, fmt.Sprintf("%d", port)))
-		bmcOptions.Username, bmcOptions.Password, err = GetBMCCredentialsFromSecret(bmcSecret)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get credentials from BMC secret: %w", err)
-		}
 		bmcClient, err = bmc.NewRedfishBMCClient(ctx, bmcOptions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Redfish client: %w", err)
 		}
 	case metalv1alpha1.ProtocolRedfishLocal:
-		bmcOptions.Endpoint = fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(address, fmt.Sprintf("%d", port)))
-		bmcOptions.Username, bmcOptions.Password, err = GetBMCCredentialsFromSecret(bmcSecret)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get credentials from BMC secret: %w", err)
-		}
 		bmcClient, err = bmc.NewRedfishLocalBMCClient(ctx, bmcOptions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Redfish client: %w", err)
 		}
 	case metalv1alpha1.ProtocolRedfishKube:
-		bmcOptions.Endpoint = fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(address, fmt.Sprintf("%d", port)))
-		bmcOptions.Username, bmcOptions.Password, err = GetBMCCredentialsFromSecret(bmcSecret)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get credentials from BMC secret: %w", err)
-		}
 		bmcClient, err = bmc.NewRedfishKubeBMCClient(ctx, bmcOptions, c, DefaultKubeNamespace)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Redfish client: %w", err)

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -177,8 +177,9 @@ func (r *EndpointReconciler) applyBMC(ctx context.Context, log logr.Logger, endp
 		spec.EndpointRef = &corev1.LocalObjectReference{Name: endpoint.Name}
 		spec.BMCSecretRef = corev1.LocalObjectReference{Name: secret.Name}
 		spec.Protocol = metalv1alpha1.Protocol{
-			Name: metalv1alpha1.ProtocolName(m.Protocol),
-			Port: m.Port,
+			Name:   metalv1alpha1.ProtocolName(m.Protocol),
+			Port:   m.Port,
+			Scheme: macdbProtocolSchemeToBMCProtocolScheme(m.ProtocolScheme),
 		}
 		spec.ConsoleProtocol = &metalv1alpha1.ConsoleProtocol{
 			Name: metalv1alpha1.ConsoleProtocolName(m.Console.Type),
@@ -192,6 +193,16 @@ func (r *EndpointReconciler) applyBMC(ctx context.Context, log logr.Logger, endp
 	log.V(1).Info("Created or patched BMC", "BMC", bmcObj.Name, "Operation", opResult)
 
 	return nil
+}
+
+func macdbProtocolSchemeToBMCProtocolScheme(scheme macdb.ProtocolScheme) metalv1alpha1.ProtocolScheme {
+	if scheme == macdb.HTTPProtocolScheme {
+		return metalv1alpha1.HTTPProtocolScheme
+	}
+	if scheme == macdb.HTTPSProtocolScheme {
+		return metalv1alpha1.HTTPSProtocolScheme
+	}
+	return ""
 }
 
 func (r *EndpointReconciler) applyBMCSecret(ctx context.Context, log logr.Logger, endpoint *metalv1alpha1.Endpoint, m macdb.MacPrefix) (*metalv1alpha1.BMCSecret, error) {

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -89,8 +89,8 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, log logr.Logger, end
 				Password:  m.DefaultCredentials[0].Password,
 			}
 
-			protocol := r.getProtocol(m)
-			bmcOptions.Endpoint = fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(endpoint.Spec.IP.String(), fmt.Sprintf("%d", m.Port)))
+			protocolScheme := bmcutils.GetProtocolScheme(m.ProtocolScheme, r.Insecure)
+			bmcOptions.Endpoint = fmt.Sprintf("%s://%s", protocolScheme, net.JoinHostPort(endpoint.Spec.IP.String(), fmt.Sprintf("%d", m.Port)))
 
 			switch m.Protocol {
 			case metalv1alpha1.ProtocolRedfish:
@@ -157,16 +157,6 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, log logr.Logger, end
 	log.V(1).Info("Reconciled endpoint")
 
 	return ctrl.Result{}, nil
-}
-
-func (r *EndpointReconciler) getProtocol(m macdb.MacPrefix) metalv1alpha1.ProtocolScheme {
-	if m.ProtocolScheme != "" {
-		return m.ProtocolScheme
-	}
-	if r.Insecure {
-		return metalv1alpha1.HTTPProtocolScheme
-	}
-	return metalv1alpha1.HTTPSProtocolScheme
 }
 
 func (r *EndpointReconciler) applyBMC(ctx context.Context, log logr.Logger, endpoint *metalv1alpha1.Endpoint, secret *metalv1alpha1.BMCSecret, m macdb.MacPrefix) error {

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -159,14 +159,14 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, log logr.Logger, end
 	return ctrl.Result{}, nil
 }
 
-func (r *EndpointReconciler) getProtocol(m macdb.MacPrefix) macdb.ProtocolScheme {
+func (r *EndpointReconciler) getProtocol(m macdb.MacPrefix) metalv1alpha1.ProtocolScheme {
 	if m.ProtocolScheme != "" {
 		return m.ProtocolScheme
 	}
 	if r.Insecure {
-		return macdb.HTTPProtocolScheme
+		return metalv1alpha1.HTTPProtocolScheme
 	}
-	return macdb.HTTPSProtocolScheme
+	return metalv1alpha1.HTTPSProtocolScheme
 }
 
 func (r *EndpointReconciler) applyBMC(ctx context.Context, log logr.Logger, endpoint *metalv1alpha1.Endpoint, secret *metalv1alpha1.BMCSecret, m macdb.MacPrefix) error {
@@ -179,7 +179,7 @@ func (r *EndpointReconciler) applyBMC(ctx context.Context, log logr.Logger, endp
 		spec.Protocol = metalv1alpha1.Protocol{
 			Name:   metalv1alpha1.ProtocolName(m.Protocol),
 			Port:   m.Port,
-			Scheme: macdbProtocolSchemeToBMCProtocolScheme(m.ProtocolScheme),
+			Scheme: m.ProtocolScheme,
 		}
 		spec.ConsoleProtocol = &metalv1alpha1.ConsoleProtocol{
 			Name: metalv1alpha1.ConsoleProtocolName(m.Console.Type),
@@ -193,16 +193,6 @@ func (r *EndpointReconciler) applyBMC(ctx context.Context, log logr.Logger, endp
 	log.V(1).Info("Created or patched BMC", "BMC", bmcObj.Name, "Operation", opResult)
 
 	return nil
-}
-
-func macdbProtocolSchemeToBMCProtocolScheme(scheme macdb.ProtocolScheme) metalv1alpha1.ProtocolScheme {
-	if scheme == macdb.HTTPProtocolScheme {
-		return metalv1alpha1.HTTPProtocolScheme
-	}
-	if scheme == macdb.HTTPSProtocolScheme {
-		return metalv1alpha1.HTTPSProtocolScheme
-	}
-	return ""
 }
 
 func (r *EndpointReconciler) applyBMCSecret(ctx context.Context, log logr.Logger, endpoint *metalv1alpha1.Endpoint, m macdb.MacPrefix) (*metalv1alpha1.BMCSecret, error) {

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -16,6 +16,7 @@ const (
 	fieldOwner = client.FieldOwner("metal.ironcore.dev/controller-manager")
 )
 
+// shouldIgnoreReconciliation checks if the object should be ignored during reconciliation.
 func shouldIgnoreReconciliation(obj client.Object) bool {
 	val, found := obj.GetAnnotations()[metalv1alpha1.OperationAnnotation]
 	if !found {
@@ -24,6 +25,7 @@ func shouldIgnoreReconciliation(obj client.Object) bool {
 	return val == metalv1alpha1.OperationAnnotationIgnore
 }
 
+// GenerateRandomPassword generates a random password of the given length.
 func GenerateRandomPassword(length int) ([]byte, error) {
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	result := make([]byte, length)


### PR DESCRIPTION
# Proposed Changes

Allow the administrator to set in the macdb the protocol for a `BMC` individually. If set, it will have precedence over the globally configured `--insecure` operator flag.