### PR TITLE
Add `MaintenanceBootConfigurationRef` to `Server` type

### DIFF
--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -106,6 +106,11 @@ type ServerSpec struct {
 	// if no boot configuration is specified.
 	BootConfigurationRef *v1.ObjectReference `json:"bootConfigurationRef,omitempty"`
 
+	// MaintenanceBootConfigurationRef is a reference to a MaintenanceConfiguration object that specifies
+	// the boot configuration for this server during maintenance mode. This field is optional and can be omitted
+	// if no maintenance configuration is specified.
+	MaintenanceBootConfigurationRef *v1.ObjectReference `json:"maintenanceBootConfigurationRef,omitempty"`
+
 	// BootOrder specifies the boot order of the server.
 	BootOrder []BootOrder `json:"bootOrder,omitempty"`
 

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -134,6 +134,9 @@ const (
 	// ServerStateReserved indicates that the server is reserved for a specific use or user.
 	ServerStateReserved ServerState = "Reserved"
 
+	// ServerStateMaintenance indicates that the server is in maintenance mode.
+	ServerStateMaintenance ServerState = "Maintenance"
+
 	// ServerStateError indicates that there is an error with the server.
 	ServerStateError ServerState = "Error"
 )

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -807,6 +807,11 @@ func (in *ServerSpec) DeepCopyInto(out *ServerSpec) {
 	}
 	if in.BootConfigurationRef != nil {
 		in, out := &in.BootConfigurationRef, &out.BootConfigurationRef
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
+	if in.MaintenanceBootConfigurationRef != nil {
+		in, out := &in.MaintenanceBootConfigurationRef, &out.MaintenanceBootConfigurationRef
 		*out = new(v1.ObjectReference)
 		**out = **in
 	}

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -223,6 +223,52 @@ spec:
                 description: IndicatorLED specifies the desired state of the server's
                   indicator LED.
                 type: string
+              maintenanceBootConfigurationRef:
+                description: |-
+                  MaintenanceBootConfigurationRef is a reference to a MaintenanceConfiguration object that specifies
+                  the boot configuration for this server during maintenance mode. This field is optional and can be omitted
+                  if no maintenance configuration is specified.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               power:
                 description: Power specifies the desired power state of the server.
                 type: string

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1315,6 +1315,21 @@ if no boot configuration is specified.</p>
 </tr>
 <tr>
 <td>
+<code>maintenanceBootConfigurationRef</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>MaintenanceBootConfigurationRef is a reference to a MaintenanceConfiguration object that specifies
+the boot configuration for this server during maintenance mode. This field is optional and can be omitted
+if no maintenance configuration is specified.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bootOrder</code><br/>
 <em>
 <a href="#metal.ironcore.dev/v1alpha1.BootOrder">
@@ -2310,6 +2325,21 @@ if no boot configuration is specified.</p>
 </tr>
 <tr>
 <td>
+<code>maintenanceBootConfigurationRef</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>MaintenanceBootConfigurationRef is a reference to a MaintenanceConfiguration object that specifies
+the boot configuration for this server during maintenance mode. This field is optional and can be omitted
+if no maintenance configuration is specified.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bootOrder</code><br/>
 <em>
 <a href="#metal.ironcore.dev/v1alpha1.BootOrder">
@@ -2362,6 +2392,9 @@ if no boot configuration is specified.</p>
 </td>
 </tr><tr><td><p>&#34;Initial&#34;</p></td>
 <td><p>ServerStateInitial indicates that the server is in its initial state.</p>
+</td>
+</tr><tr><td><p>&#34;Maintenance&#34;</p></td>
+<td><p>ServerStateMaintenance indicates that the server is in maintenance mode.</p>
 </td>
 </tr><tr><td><p>&#34;Reserved&#34;</p></td>
 <td><p>ServerStateReserved indicates that the server is reserved for a specific use or user.</p>


### PR DESCRIPTION
# Proposed Changes

The `MaintenanceBootConfigurationRef` is used to boot a `Server` into a maintenance mode. This field is superseeding the `BootConfigurationRef` which is used for a regular/discovery boot. The reason to introduce a new field here is, that in case of a `ServerClaim` claiming a `Server` the `ServerBootConfigurationRef` field is set with a reference to a `ServerBootConfiguration` which is generated out of a `ServerClaim`.

/ref https://github.com/ironcore-dev/metal-operator/pull/208

/cc @stefanhipfel 