### PR TITLE
Fix typo in `SSHKeyPairSecretPasswordKeyName`

### DIFF
--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -53,7 +53,7 @@ const (
 	// SSHKeyPairSecretPublicKeyName is the key name for the public key in the SSH key pair secret
 	SSHKeyPairSecretPublicKeyName = "pub"
 	// SSHKeyPairSecretPasswordKeyName is the key name for the password in the SSH key pair secret
-	SShKeyPairSecretPasswordKeyName = "password"
+	SSHKeyPairSecretPasswordKeyName = "password"
 	// ServerFinalizer is the finalizer for the server
 	ServerFinalizer = "metal.ironcore.dev/server"
 	// InternalAnnotationTypeKeyName is the key name for the internal annotation type
@@ -571,7 +571,7 @@ func (r *ServerReconciler) applyDefaultIgnitionForServer(ctx context.Context, lo
 		Data: map[string][]byte{
 			SSHKeyPairSecretPublicKeyName:   sshPublicKey,
 			SSHKeyPairSecretPrivateKeyName:  sshPrivateKey,
-			SShKeyPairSecretPasswordKeyName: password,
+			SSHKeyPairSecretPasswordKeyName: password,
 		},
 	}
 	if err := controllerutil.SetControllerReference(bootConfig, sshSecret, r.Scheme); err != nil {

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Server Controller", func() {
 			})),
 			HaveField("Data", HaveKeyWithValue(SSHKeyPairSecretPrivateKeyName, Not(BeNil()))),
 			HaveField("Data", HaveKeyWithValue(SSHKeyPairSecretPublicKeyName, Not(BeEmpty()))),
-			HaveField("Data", HaveKeyWithValue(SShKeyPairSecretPasswordKeyName, Not(BeNil()))),
+			HaveField("Data", HaveKeyWithValue(SSHKeyPairSecretPasswordKeyName, Not(BeNil()))),
 		))
 		_, err := ssh.ParsePrivateKey(sshSecret.Data[SSHKeyPairSecretPrivateKeyName])
 		Expect(err).NotTo(HaveOccurred())
@@ -160,7 +160,7 @@ var _ = Describe("Server Controller", func() {
 		passwordHash, ok := user["password_hash"].(string)
 		Expect(ok).To(BeTrue(), "password_hash should be a string")
 
-		err = bcrypt.CompareHashAndPassword([]byte(passwordHash), sshSecret.Data[SShKeyPairSecretPasswordKeyName])
+		err = bcrypt.CompareHashAndPassword([]byte(passwordHash), sshSecret.Data[SSHKeyPairSecretPasswordKeyName])
 		Expect(err).ToNot(HaveOccurred(), "passwordHash should match the expected password")
 
 		ignitionData, err := ignition.GenerateDefaultIgnitionData(ignition.Config{
@@ -304,7 +304,7 @@ var _ = Describe("Server Controller", func() {
 			})),
 			HaveField("Data", HaveKeyWithValue(SSHKeyPairSecretPublicKeyName, Not(BeEmpty()))),
 			HaveField("Data", HaveKeyWithValue(SSHKeyPairSecretPrivateKeyName, Not(BeEmpty()))),
-			HaveField("Data", HaveKeyWithValue(SShKeyPairSecretPasswordKeyName, Not(BeEmpty()))),
+			HaveField("Data", HaveKeyWithValue(SSHKeyPairSecretPasswordKeyName, Not(BeEmpty()))),
 		))
 		_, err := ssh.ParsePrivateKey(sshSecret.Data[SSHKeyPairSecretPrivateKeyName])
 		Expect(err).NotTo(HaveOccurred())
@@ -338,7 +338,7 @@ var _ = Describe("Server Controller", func() {
 		passwordHash, ok := user["password_hash"].(string)
 		Expect(ok).To(BeTrue(), "password_hash should be a string")
 
-		Expect(bcrypt.CompareHashAndPassword([]byte(passwordHash), sshSecret.Data[SShKeyPairSecretPasswordKeyName])).Should(Succeed())
+		Expect(bcrypt.CompareHashAndPassword([]byte(passwordHash), sshSecret.Data[SSHKeyPairSecretPasswordKeyName])).Should(Succeed())
 
 		ignitionData, err := ignition.GenerateDefaultIgnitionData(ignition.Config{
 			Image:        "foo:latest",


### PR DESCRIPTION
# Proposed Changes

 Fix typo in `SSHKeyPairSecretPasswordKeyName`.