### PR TITLE
Remove `Completed` state from `ServerMaintenance`

### DIFF
--- a/api/v1alpha1/servermaintenance_types.go
+++ b/api/v1alpha1/servermaintenance_types.go
@@ -62,8 +62,6 @@ const (
 	// ServerMaintenanceStateInMaintenance specifies that the server is in maintenance.
 	ServerMaintenanceStateInMaintenance ServerMaintenanceState = "InMaintenance"
 	// ServerMaintenanceStateCompleted specifies that the server maintenance has been completed.
-	ServerMaintenanceStateCompleted ServerMaintenanceState = "Completed"
-	// ServerMaintenanceStateFailed specifies that the server maintenance has failed.
 	ServerMaintenanceStateFailed ServerMaintenanceState = "Failed"
 )
 

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcs.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcs.yaml
@@ -179,6 +179,9 @@ spec:
                       This port is used by the specified protocol to establish connections.
                     format: int32
                     type: integer
+                  scheme:
+                    description: Scheme specifies the scheme used for communication.
+                    type: string
                 required:
                 - name
                 - port

--- a/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
@@ -134,6 +134,9 @@ spec:
                           This port is used by the specified protocol to establish connections.
                         format: int32
                         type: integer
+                      scheme:
+                        description: Scheme specifies the scheme used for communication.
+                        type: string
                     required:
                     - name
                     - port

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -2169,11 +2169,8 @@ ServerBootConfigurationTemplate
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;Completed&#34;</p></td>
+<tbody><tr><td><p>&#34;Failed&#34;</p></td>
 <td><p>ServerMaintenanceStateCompleted specifies that the server maintenance has been completed.</p>
-</td>
-</tr><tr><td><p>&#34;Failed&#34;</p></td>
-<td><p>ServerMaintenanceStateFailed specifies that the server maintenance has failed.</p>
 </td>
 </tr><tr><td><p>&#34;InMaintenance&#34;</p></td>
 <td><p>ServerMaintenanceStateInMaintenance specifies that the server is in maintenance.</p>

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -187,14 +187,9 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		Eventually(Object(serverMaintenance)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance),
 		))
-		By("Setting ServerMaintenance to Completed")
-		Eventually(UpdateStatus(serverMaintenance, func() {
-			serverMaintenance.Status.State = metalv1alpha1.ServerMaintenanceStateCompleted
-		})).Should(Succeed())
+		By("Deleting ServerMaintenance to finish the maintennce on the server")
+		Eventually(k8sClient.Delete).WithArguments(ctx, serverMaintenance).Should(Succeed())
 
-		Eventually(Object(serverMaintenance)).Should(SatisfyAll(
-			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateCompleted),
-		))
 		By("Checking the Server is not in maintenance and cleaned up")
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
@@ -266,20 +261,8 @@ var _ = Describe("ServerMaintenance Controller", func() {
 			HaveField("Status.State", metalv1alpha1.ServerStateMaintenance),
 		))
 
-		By("Setting first ServerMaintenance to Completed")
-		Eventually(UpdateStatus(serverMaintenance01, func() {
-			serverMaintenance01.Status.State = metalv1alpha1.ServerMaintenanceStateCompleted
-		})).Should(Succeed())
-
-		Eventually(Object(serverMaintenance01)).Should(SatisfyAll(
-			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateCompleted),
-		))
-
-		Eventually(Object(server)).Should(SatisfyAll(
-			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
-			HaveField("Spec.ServerMaintenanceRef", BeNil()),
-			HaveField("Spec.MaintenanceBootConfigurationRef", BeNil()),
-		))
+		By("Deleting first ServerMaintenance to finish the maintennce on the server")
+		Eventually(k8sClient.Delete).WithArguments(ctx, serverMaintenance01).Should(Succeed())
 
 		Eventually(Object(serverMaintenance02)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance),

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -207,7 +207,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		serverMaintenance01 := &metalv1alpha1.ServerMaintenance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-server-maintenance",
+				Name:      "test-server-maintenance01",
 				Namespace: ns.Name,
 				Annotations: map[string]string{
 					metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "test-maintenance",
@@ -248,9 +248,26 @@ var _ = Describe("ServerMaintenance Controller", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, serverMaintenance01)).To(Succeed())
+		By("Checking the ServerMaintenanceRef")
+		Eventually(Object(server)).Should(SatisfyAll(
+			HaveField("Spec.ServerMaintenanceRef", Not(BeNil())),
+			HaveField("Spec.MaintenanceBootConfigurationRef", Not(BeNil())),
+		))
 		Eventually(Object(serverMaintenance01)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance),
 		))
+		bootConfig := &metalv1alpha1.ServerBootConfiguration{}
+		Eventually(k8sClient.Get).WithArguments(ctx, types.NamespacedName{
+			Name:      server.Spec.MaintenanceBootConfigurationRef.Name,
+			Namespace: server.Spec.MaintenanceBootConfigurationRef.Namespace,
+		}, bootConfig).Should(Succeed())
+
+		By("Patching the boot configuration to a Ready state")
+		Eventually(UpdateStatus(bootConfig, func() {
+			bootConfig.Status.State = metalv1alpha1.ServerBootConfigurationStateReady
+		})).Should(Succeed())
+
+		By("Creating a second ServerMaintenance object")
 		Expect(k8sClient.Create(ctx, serverMaintenance02)).To(Succeed())
 		Eventually(Object(serverMaintenance02)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStatePending),
@@ -259,6 +276,10 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		By("Checking the Server is in maintenance")
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerStateMaintenance),
+		))
+		By("Checking the second ServerMaintenance is still pending")
+		Eventually(Object(serverMaintenance02)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStatePending),
 		))
 
 		By("Deleting first ServerMaintenance to finish the maintennce on the server")


### PR DESCRIPTION
# Proposed Changes

- No need to set Maintenance to completed once finished. Just delete the Maintenance CRD to remove server from maintenance.
- Set serverMaintenanceRef earlier, once maintenance got approved
