### PR TITLE
Introduce `metal.ironcore.dev/reboot-needed` key

### DIFF
--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -9,6 +9,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// ServerMaintenanceNeededKey is used to indicate that a server requires maintenance.
+	ServerMaintenanceNeededKey = "metal.ironcore.dev/maintenance-needed"
+	// ServerRebootNeededKey is used to indicate that a server requires a restart.
+	ServerRebootNeededKey = "metal.ironcore.dev/reboot-needed"
+)
+
 // Power defines the possible power states for a device.
 type Power string
 

--- a/api/v1alpha1/servermaintenance_types.go
+++ b/api/v1alpha1/servermaintenance_types.go
@@ -9,11 +9,9 @@ import (
 )
 
 const (
-	// ServerMaintenanceNeededLabelKey is a label key that is used to indicate that a server requires maintenance.
-	ServerMaintenanceNeededLabelKey = "metal.ironcore.dev/maintenance-needed"
-	// ServerMaintenanceReasonAnnotationKey is an annotation key that is used to store the reason for a server maintenance.
-	ServerMaintenanceReasonAnnotationKey = "metal.ironcore.dev/maintenance-reason"
-	// ServerMaintenanceApprovalKey is an annotation key that is used to store the approval status for a server maintenance.
+	// ServerMaintenanceReasonKey is used to store the reason for a server maintenance.
+	ServerMaintenanceReasonKey = "metal.ironcore.dev/maintenance-reason"
+	// ServerMaintenanceApprovalKey is used to store the approval status for a server maintenance.
 	ServerMaintenanceApprovalKey = "metal.ironcore.dev/maintenance-approval"
 )
 
@@ -21,7 +19,7 @@ const (
 type ServerBootConfigurationTemplate struct {
 	// Name specifies the name of the boot configuration.
 	Name string `json:"name"`
-	// Parameters specifies the parameters to be used for rendering the boot configuration.
+	// Parameters specify the parameters to be used for rendering the boot configuration.
 	Spec ServerBootConfigurationSpec `json:"spec"`
 }
 

--- a/config/crd/bases/metal.ironcore.dev_servermaintenances.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servermaintenances.yaml
@@ -70,7 +70,7 @@ spec:
                     description: Name specifies the name of the boot configuration.
                     type: string
                   spec:
-                    description: Parameters specifies the parameters to be used for
+                    description: Parameters specify the parameters to be used for
                       rendering the boot configuration.
                     properties:
                       ignitionSecretRef:

--- a/dist/chart/templates/crd/metal.ironcore.dev_servermaintenances.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servermaintenances.yaml
@@ -76,7 +76,7 @@ spec:
                     description: Name specifies the name of the boot configuration.
                     type: string
                   spec:
-                    description: Parameters specifies the parameters to be used for
+                    description: Parameters specify the parameters to be used for
                       rendering the boot configuration.
                     properties:
                       ignitionSecretRef:

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1907,7 +1907,7 @@ ServerBootConfigurationSpec
 </em>
 </td>
 <td>
-<p>Parameters specifies the parameters to be used for rendering the boot configuration.</p>
+<p>Parameters specify the parameters to be used for rendering the boot configuration.</p>
 <br/>
 <br/>
 <table>

--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -130,10 +130,10 @@ func (r *ServerMaintenanceReconciler) handlePendingState(ctx context.Context, lo
 		return ctrl.Result{}, nil
 	}
 	claimAnnotations := map[string]string{
-		metalv1alpha1.ServerMaintenanceNeededLabelKey: "true",
+		metalv1alpha1.ServerMaintenanceNeededKey: "true",
 	}
-	if serverMaintenance.Annotations[metalv1alpha1.ServerMaintenanceReasonAnnotationKey] != "" {
-		claimAnnotations[metalv1alpha1.ServerMaintenanceReasonAnnotationKey] = serverMaintenance.Annotations[metalv1alpha1.ServerMaintenanceReasonAnnotationKey]
+	if serverMaintenance.Annotations[metalv1alpha1.ServerMaintenanceReasonKey] != "" {
+		claimAnnotations[metalv1alpha1.ServerMaintenanceReasonKey] = serverMaintenance.Annotations[metalv1alpha1.ServerMaintenanceReasonKey]
 	}
 	if err := r.patchServerClaimAnnotation(ctx, log, serverClaim, claimAnnotations); err != nil {
 		return ctrl.Result{}, err
@@ -334,8 +334,8 @@ func (r *ServerMaintenanceReconciler) cleanup(ctx context.Context, log logr.Logg
 	serverClaimBase := serverClaim.DeepCopy()
 	metautils.DeleteAnnotations(serverClaim, []string{
 		metalv1alpha1.ServerMaintenanceApprovalKey,
-		metalv1alpha1.ServerMaintenanceNeededLabelKey,
-		metalv1alpha1.ServerMaintenanceReasonAnnotationKey,
+		metalv1alpha1.ServerMaintenanceNeededKey,
+		metalv1alpha1.ServerMaintenanceReasonKey,
 	})
 	if err := r.Patch(ctx, serverClaim, client.MergeFrom(serverClaimBase)); err != nil {
 		return fmt.Errorf("failed to patch server claim annotations: %w", err)
@@ -444,7 +444,7 @@ func (r *ServerMaintenanceReconciler) enqueueMaintenanceByClaimRefs() handler.Ev
 		claim := object.(*metalv1alpha1.ServerClaim)
 		var req []reconcile.Request
 		annotations := claim.GetAnnotations()
-		if _, ok := annotations[metalv1alpha1.ServerMaintenanceNeededLabelKey]; !ok {
+		if _, ok := annotations[metalv1alpha1.ServerMaintenanceNeededKey]; !ok {
 			return req
 		}
 

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -68,7 +68,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 				Name:      "test-server-maintenance",
 				Namespace: ns.Name,
 				Annotations: map[string]string{
-					metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "test-maintenance",
+					metalv1alpha1.ServerMaintenanceReasonKey: "test-maintenance",
 				},
 			},
 			Spec: metalv1alpha1.ServerMaintenanceSpec{
@@ -102,7 +102,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 				Name:      "test-server-maintenance",
 				Namespace: ns.Name,
 				Annotations: map[string]string{
-					metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "test-maintenance",
+					metalv1alpha1.ServerMaintenanceReasonKey: "test-maintenance",
 				},
 			},
 			Spec: metalv1alpha1.ServerMaintenanceSpec{
@@ -154,9 +154,9 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		})).Should(Succeed())
 
 		maintenanceLabels := map[string]string{
-			metalv1alpha1.ServerMaintenanceNeededLabelKey:      "true",
-			metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "test-maintenance",
-			metalv1alpha1.ServerMaintenanceApprovalKey:         "true",
+			metalv1alpha1.ServerMaintenanceNeededKey:   "true",
+			metalv1alpha1.ServerMaintenanceReasonKey:   "test-maintenance",
+			metalv1alpha1.ServerMaintenanceApprovalKey: "true",
 		}
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Spec.ServerMaintenanceRef.Name", serverMaintenance.Name),
@@ -198,7 +198,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		))
 		By("Checking the ServerClaim is cleaned up")
 		Eventually(Object(serverClaim)).Should(SatisfyAll(
-			HaveField("ObjectMeta.Annotations", Not(HaveKey(metalv1alpha1.ServerMaintenanceNeededLabelKey))),
+			HaveField("ObjectMeta.Annotations", Not(HaveKey(metalv1alpha1.ServerMaintenanceNeededKey))),
 		))
 	})
 
@@ -210,7 +210,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 				Name:      "test-server-maintenance01",
 				Namespace: ns.Name,
 				Annotations: map[string]string{
-					metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "test-maintenance",
+					metalv1alpha1.ServerMaintenanceReasonKey: "test-maintenance",
 				},
 			},
 			Spec: metalv1alpha1.ServerMaintenanceSpec{
@@ -231,7 +231,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 				Name:      "test-server-maintenance02",
 				Namespace: ns.Name,
 				Annotations: map[string]string{
-					metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "test-maintenance",
+					metalv1alpha1.ServerMaintenanceReasonKey: "test-maintenance",
 				},
 			},
 			Spec: metalv1alpha1.ServerMaintenanceSpec{


### PR DESCRIPTION
# Proposed Changes

Introduce a `Server` reboot key constant which can be used as an annotation key on a `Server` object to indicate that a `Server` needs a reboot.

This key can be used upstream e.g. as `Node` label/annotation to indicate the workload to perform a `Server` reboot.

/cc @nagadeesh-nagaraja 