### PR TITLE
Improve resource cleanup in suite tests

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -57,45 +57,34 @@ func TestControllers(t *testing.T) {
 }
 
 func DeleteAllMetalResources(ctx context.Context, namespace string) {
-	var serverClaim metalv1alpha1.ServerClaim
-	Expect(k8sClient.DeleteAllOf(ctx, &serverClaim, client.InNamespace(namespace))).To(Succeed())
-	var serverClaimList metalv1alpha1.ServerClaimList
-	Eventually(ObjectList(&serverClaimList)).Should(HaveField("Items", BeEmpty()))
+	Eventually(deleteAndList(ctx, &metalv1alpha1.ServerClaim{}, &metalv1alpha1.ServerClaimList{}, client.InNamespace(namespace))).Should(
+		HaveField("Items", BeEmpty()))
 
-	var endpoint metalv1alpha1.Endpoint
-	Expect(k8sClient.DeleteAllOf(ctx, &endpoint)).To(Succeed())
-	var endpointList metalv1alpha1.EndpointList
-	Eventually(ObjectList(&endpointList)).Should(HaveField("Items", BeEmpty()))
+	Eventually(deleteAndList(ctx, &metalv1alpha1.Endpoint{}, &metalv1alpha1.EndpointList{})).Should(
+		HaveField("Items", BeEmpty()))
 
-	var bmc metalv1alpha1.BMC
-	Expect(k8sClient.DeleteAllOf(ctx, &bmc)).To(Succeed())
-	var bmcList metalv1alpha1.BMCList
-	Eventually(ObjectList(&bmcList)).Should(HaveField("Items", BeEmpty()))
+	Eventually(deleteAndList(ctx, &metalv1alpha1.BMC{}, &metalv1alpha1.BMCList{})).Should(
+		HaveField("Items", BeEmpty()))
 
-	var serverMaintenance metalv1alpha1.ServerMaintenance
-	Expect(k8sClient.DeleteAllOf(ctx, &serverMaintenance, client.InNamespace(namespace))).To(Succeed())
-	var serverMaintenanceList metalv1alpha1.ServerMaintenanceList
-	Eventually(ObjectList(&serverMaintenanceList)).Should(HaveField("Items", BeEmpty()))
+	Eventually(deleteAndList(ctx, &metalv1alpha1.ServerMaintenance{}, &metalv1alpha1.ServerMaintenanceList{}, client.InNamespace(namespace))).Should(
+		HaveField("Items", BeEmpty()))
 
-	var serverBootConfiguration metalv1alpha1.ServerBootConfiguration
-	Expect(k8sClient.DeleteAllOf(ctx, &serverBootConfiguration, client.InNamespace(namespace))).To(Succeed())
-	var serverBootConfigurationList metalv1alpha1.ServerBootConfigurationList
-	Eventually(ObjectList(&serverBootConfigurationList)).Should(HaveField("Items", BeEmpty()))
+	Eventually(deleteAndList(ctx, &metalv1alpha1.ServerBootConfiguration{}, &metalv1alpha1.ServerBootConfigurationList{}, client.InNamespace(namespace))).Should(
+		HaveField("Items", BeEmpty()))
 
-	var server metalv1alpha1.Server
-	Expect(k8sClient.DeleteAllOf(ctx, &server)).To(Succeed())
-	var serverList metalv1alpha1.ServerList
-	Eventually(ObjectList(&serverList)).Should(HaveField("Items", BeEmpty()))
+	Eventually(deleteAndList(ctx, &metalv1alpha1.Server{}, &metalv1alpha1.ServerList{})).Should(
+		HaveField("Items", BeEmpty()))
 
-	var bmcSecret metalv1alpha1.BMCSecret
-	Expect(k8sClient.DeleteAllOf(ctx, &bmcSecret)).To(Succeed())
-	var bmcSecretList metalv1alpha1.BMCSecretList
-	Eventually(ObjectList(&bmcSecretList)).Should(HaveField("Items", BeEmpty()))
+	Eventually(deleteAndList(ctx, &metalv1alpha1.BMCSecret{}, &metalv1alpha1.BMCSecretList{})).Should(
+		HaveField("Items", BeEmpty()))
 
-	var biosSettings metalv1alpha1.BIOSSettings
-	Expect(k8sClient.DeleteAllOf(ctx, &biosSettings)).To(Succeed())
-	var BIOSSettingsList metalv1alpha1.BIOSSettingsList
-	Eventually(ObjectList(&BIOSSettingsList)).Should(HaveField("Items", BeEmpty()))
+	Eventually(deleteAndList(ctx, &metalv1alpha1.BIOSSettings{}, &metalv1alpha1.BIOSSettingsList{})).Should(
+		HaveField("Items", BeEmpty()))
+}
+
+func deleteAndList(ctx context.Context, obj client.Object, objList client.ObjectList, namespaceOpt ...client.DeleteAllOfOption) func() (client.ObjectList, error) {
+	Expect(k8sClient.DeleteAllOf(ctx, obj, namespaceOpt...)).To(Succeed())
+	return ObjectList(objList)
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
There is a race condition between creating and deleting metal resources. Some reconcilers when having much of work can create resources between they are deleted and an eventual check if they were deleted.

Example of failed jobs with the problem addressed by this PR: 
 - https://github.com/ironcore-dev/metal-operator/actions/runs/14842713004
 - https://github.com/ironcore-dev/metal-operator/actions/runs/14834171365
 - https://github.com/ironcore-dev/metal-operator/actions/runs/14761211131

The reason for tests fail is a timeout in waiting until some metal CR list is empty:
`Eventually(ObjectList(&serverClaimList)).Should(HaveField("Items", BeEmpty()))`

It should be empty as two lines above these resources are deleted with:
`Expect(k8sClient.DeleteAllOf(ctx, &serverClaim, client.InNamespace(namespace))).To(Succeed())`

However in tests the list is never empty and the resource doesn't have deletion timestamp set which indicates it wasn't affected with `DeleteAllOf`. This can happen when after `DeleteAllOf` there is an resource created by one of controllers which run in parallel.


# Proposed Changes

- Add deleting of metal objects in eventually loop to ensure they are deleted




