### PR TITLE
Use 9443 port for webhook

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -113,7 +113,7 @@ func main() { // nolint: gocyclo
 		"Enforce the first boot probing of a Server even if it is powered on in the Initial state.")
 	flag.BoolVar(&enforcePowerOff, "enforce-power-off", false,
 		"Enforce the power off of a Server when graceful shutdown fails.")
-	flag.IntVar(&webhookPort, "webhook-port", 9445, "The port to use for webhook server.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "The port to use for webhook server.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
     - port: 443
       protocol: TCP
-      targetPort: 9445
+      targetPort: 9443
   selector:
     control-plane: controller-manager
     app.kubernetes.io/name: metal-operator

--- a/dist/chart/templates/_helpers.tpl
+++ b/dist/chart/templates/_helpers.tpl
@@ -14,14 +14,14 @@
 
 
 {{- define "chart.labels" -}}
-{{- if .Chart.AppVersion -}}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-{{- if .Chart.Version }}
+{{- if .Chart.Version -}}
 helm.sh/chart: {{ .Chart.Version | quote }}
 {{- end }}
 app.kubernetes.io/name: {{ include "chart.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -4,10 +4,10 @@ metadata:
   name: metal-operator-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
     control-plane: controller-manager
+    {{- include "chart.labels" . | nindent 4 }}
 spec:
-  replicas:  {{ .Values.controllerManager.replicas }}
+  replicas: {{ .Values.controllerManager.replicas }}
   strategy:
     type: {{ .Values.controllerManager.strategy.type | quote }}
   selector:
@@ -16,76 +16,76 @@ spec:
       control-plane: controller-manager
   template:
     metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: manager
       labels:
-        {{- include "chart.labels" . | nindent 8 }}
         control-plane: controller-manager
+        {{- include "chart.labels" . | nindent 8 }}
         {{- if and .Values.controllerManager.pod .Values.controllerManager.pod.labels }}
         {{- range $key, $value := .Values.controllerManager.pod.labels }}
         {{ $key }}: {{ $value }}
         {{- end }}
         {{- end }}
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
     spec:
       containers:
-        - name: manager
-          args:
-            {{- range .Values.controllerManager.manager.args }}
-            - {{ . }}
-            {{- end }}
-          command:
-            - /manager
-          image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag }}
-          {{- if .Values.controllerManager.manager.env }}
-          env:
-            {{- range $key, $value := .Values.controllerManager.manager.env }}
-            - name: {{ $key }}
-              value: {{ $value }}
-            {{- end }}
-          {{- end }}
-          livenessProbe:
-            {{- toYaml .Values.controllerManager.manager.livenessProbe | nindent 12 }}
-          readinessProbe:
-            {{- toYaml .Values.controllerManager.manager.readinessProbe | nindent 12 }}
-          {{- if .Values.webhook.enable }}
-          ports:
-            - containerPort: 9443
-              name: webhook-server
-              protocol: TCP
-          {{- end }}
-          resources:
-            {{- toYaml .Values.controllerManager.manager.resources | nindent 12 }}
-          securityContext:
-            {{- toYaml .Values.controllerManager.manager.securityContext | nindent 12 }}
-          volumeMounts:
-            - mountPath: /etc/macdb/
-              name: macdb
-            {{- if and .Values.webhook.enable .Values.certmanager.enable }}
-            - name: webhook-cert
-              mountPath: /tmp/k8s-webhook-server/serving-certs
-              readOnly: true
-            {{- end }}
-            {{- if and .Values.metrics.enable .Values.certmanager.enable }}
-            - name: metrics-certs
-              mountPath: /tmp/k8s-metrics-server/metrics-certs
-              readOnly: true
-            {{- end }}
+      - name: manager
+        args:
+        {{- range .Values.controllerManager.manager.args }}
+        - {{ . }}
+        {{- end }}
+        command:
+        - /manager
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag }}
+        {{- if .Values.controllerManager.manager.env }}
+        env:
+        {{- range $key, $value := .Values.controllerManager.manager.env }}
+        - name: {{ $key }}
+          value: {{ $value }}
+        {{- end }}
+        {{- end }}
+        livenessProbe:
+          {{- toYaml .Values.controllerManager.manager.livenessProbe | nindent 10 }}
+        readinessProbe:
+          {{- toYaml .Values.controllerManager.manager.readinessProbe | nindent 10 }}
+        {{- if .Values.webhook.enable }}
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        {{- end }}
+        resources:
+          {{- toYaml .Values.controllerManager.manager.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.controllerManager.manager.securityContext | nindent 10 }}
+        volumeMounts:
+        - mountPath: /etc/macdb/
+          name: macdb
+        {{- if and .Values.webhook.enable .Values.certmanager.enable }}
+        - name: webhook-cert
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+        {{- end }}
+        {{- if and .Values.metrics.enable .Values.certmanager.enable }}
+        - name: metrics-certs
+          mountPath: /tmp/k8s-metrics-server/metrics-certs
+          readOnly: true
+        {{- end }}
       securityContext:
         {{- toYaml .Values.controllerManager.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ .Values.controllerManager.serviceAccountName }}
       hostNetwork: {{ .Values.controllerManager.hostNetwork }}
       terminationGracePeriodSeconds: {{ .Values.controllerManager.terminationGracePeriodSeconds }}
       volumes:
-        - name: macdb
-          secret:
-            secretName: macdb
-        {{- if and .Values.webhook.enable .Values.certmanager.enable }}
-        - name: webhook-cert
-          secret:
-            secretName: webhook-server-cert
-        {{- end }}
-        {{- if and .Values.metrics.enable .Values.certmanager.enable }}
-        - name: metrics-certs
-          secret:
-            secretName: metrics-server-cert
-        {{- end }}
+      - name: macdb
+        secret:
+          secretName: macdb
+      {{- if and .Values.webhook.enable .Values.certmanager.enable }}
+      - name: webhook-cert
+        secret:
+          secretName: webhook-server-cert
+      {{- end }}
+      {{- if and .Values.metrics.enable .Values.certmanager.enable }}
+      - name: metrics-certs
+        secret:
+          secretName: metrics-server-cert
+      {{- end }}


### PR DESCRIPTION
# Proposed Changes
- This change is needed as a service generated by helm kubebuilder plugin hardcode 9443 port for webhooks
- I also removed list indentation in manager manifest and changed the order of some fields