### PR TITLE
Rename `BMCOptions` to `Options`

### DIFF
--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -35,7 +35,7 @@ const (
 	DefaultPowerPollingTimeout = 5 * time.Minute
 )
 
-// Options BMCOptions contains the options for the BMC redfish client.
+// Options contain the options for the BMC redfish client.
 type Options struct {
 	Endpoint  string
 	Username  string
@@ -356,7 +356,7 @@ func (r *RedfishBMC) GetBiosPendingAttributeValues(
 	}
 
 	// unfortunately, some vendors fill the pending attribute with copy of actual bios attribute
-	// remove if there are same
+	// remove if there are the same
 	if len(tBios.Attributes) == len(tBiosPendingSetting.Attributes) {
 		pendingAttr := redfish.SettingsAttributes{}
 		for key, attr := range tBiosPendingSetting.Attributes {
@@ -448,7 +448,7 @@ func (r *RedfishBMC) getFilteredBiosRegistryAttributes(
 	return
 }
 
-// check if the arrtibutes need to reboot when changed, and are correct type.
+// CheckBiosAttributes checks if the attributes need to reboot when changed and are the correct type.
 func (r *RedfishBMC) CheckBiosAttributes(attrs redfish.SettingsAttributes) (reset bool, err error) {
 	reset = false
 	// filter out immutable, readonly and hidden attributes

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -35,8 +35,8 @@ const (
 	DefaultPowerPollingTimeout = 5 * time.Minute
 )
 
-// BMCOptions contains the options for the BMC redfish client.
-type BMCOptions struct {
+// Options BMCOptions contains the options for the BMC redfish client.
+type Options struct {
 	Endpoint  string
 	Username  string
 	Password  string
@@ -51,7 +51,7 @@ type BMCOptions struct {
 // RedfishBMC is an implementation of the BMC interface for Redfish.
 type RedfishBMC struct {
 	client  *gofish.APIClient
-	options BMCOptions
+	options Options
 }
 
 var pxeBootWithSettingUEFIBootMode = redfish.Boot{
@@ -67,7 +67,7 @@ var pxeBootWithoutSettingUEFIBootMode = redfish.Boot{
 // NewRedfishBMCClient creates a new RedfishBMC with the given connection details.
 func NewRedfishBMCClient(
 	ctx context.Context,
-	options BMCOptions,
+	options Options,
 ) (*RedfishBMC, error) {
 	clientConfig := gofish.ClientConfig{
 		Endpoint:  options.Endpoint,

--- a/bmc/redfish_kube.go
+++ b/bmc/redfish_kube.go
@@ -37,7 +37,7 @@ type RedfishKubeBMC struct {
 // NewRedfishKubeBMCClient creates a new RedfishKubeBMC with the given connection details.
 func NewRedfishKubeBMCClient(
 	ctx context.Context,
-	options BMCOptions,
+	options Options,
 	c client.Client,
 	ns string,
 ) (BMC, error) {

--- a/bmc/redfish_local.go
+++ b/bmc/redfish_local.go
@@ -22,7 +22,7 @@ type RedfishLocalBMC struct {
 // NewRedfishLocalBMCClient creates a new RedfishLocalBMC with the given connection details.
 func NewRedfishLocalBMCClient(
 	ctx context.Context,
-	options BMCOptions,
+	options Options,
 ) (BMC, error) {
 	bmc, err := NewRedfishBMCClient(ctx, options)
 	if err != nil {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -319,7 +319,7 @@ func main() { // nolint: gocyclo
 		EnforceFirstBoot:        enforceFirstBoot,
 		EnforcePowerOff:         enforcePowerOff,
 		MaxConcurrentReconciles: serverMaxConcurrentReconciles,
-		BMCOptions: bmc.BMCOptions{
+		BMCOptions: bmc.Options{
 			BasicAuth:               true,
 			PowerPollingInterval:    powerPollingInterval,
 			PowerPollingTimeout:     powerPollingTimeout,
@@ -368,7 +368,7 @@ func main() { // nolint: gocyclo
 		ManagerNamespace: managerNamespace,
 		Insecure:         insecure,
 		ResyncInterval:   serverResyncInterval,
-		BMCOptions: bmc.BMCOptions{
+		BMCOptions: bmc.Options{
 			BasicAuth:               true,
 			PowerPollingInterval:    powerPollingInterval,
 			PowerPollingTimeout:     powerPollingTimeout,
@@ -392,7 +392,7 @@ func main() { // nolint: gocyclo
 		ManagerNamespace: managerNamespace,
 		Insecure:         insecure,
 		ResyncInterval:   serverResyncInterval,
-		BMCOptions: bmc.BMCOptions{
+		BMCOptions: bmc.Options{
 			BasicAuth:               true,
 			PowerPollingInterval:    powerPollingInterval,
 			PowerPollingTimeout:     powerPollingTimeout,

--- a/internal/bmcutils/bmcutils.go
+++ b/internal/bmcutils/bmcutils.go
@@ -72,7 +72,7 @@ func GetBMCAddressForBMC(ctx context.Context, c client.Client, bmcObj *metalv1al
 
 const DefaultKubeNamespace = "default"
 
-func GetBMCClientForServer(ctx context.Context, c client.Client, server *metalv1alpha1.Server, insecure bool, options bmc.BMCOptions) (bmc.BMC, error) {
+func GetBMCClientForServer(ctx context.Context, c client.Client, server *metalv1alpha1.Server, insecure bool, options bmc.Options) (bmc.BMC, error) {
 	if server.Spec.BMCRef != nil {
 		b := &metalv1alpha1.BMC{}
 		bmcName := server.Spec.BMCRef.Name
@@ -106,7 +106,7 @@ func GetBMCClientForServer(ctx context.Context, c client.Client, server *metalv1
 	return nil, fmt.Errorf("server %s has neither a BMCRef nor a BMC configured", server.Name)
 }
 
-func GetBMCClientFromBMC(ctx context.Context, c client.Client, bmcObj *metalv1alpha1.BMC, insecure bool, options bmc.BMCOptions) (bmc.BMC, error) {
+func GetBMCClientFromBMC(ctx context.Context, c client.Client, bmcObj *metalv1alpha1.BMC, insecure bool, options bmc.Options) (bmc.BMC, error) {
 	var address string
 
 	if bmcObj.Spec.EndpointRef != nil {
@@ -139,7 +139,7 @@ func CreateBMCClient(
 	address string,
 	port int32,
 	bmcSecret *metalv1alpha1.BMCSecret,
-	bmcOptions bmc.BMCOptions,
+	bmcOptions bmc.Options,
 ) (bmc.BMC, error) {
 	var bmcClient bmc.BMC
 	var err error

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -36,7 +36,7 @@ type BiosSettingsReconciler struct {
 	ManagerNamespace string
 	Insecure         bool
 	Scheme           *runtime.Scheme
-	BMCOptions       bmc.BMCOptions
+	BMCOptions       bmc.Options
 	ResyncInterval   time.Duration
 }
 

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -36,7 +36,7 @@ type BIOSVersionReconciler struct {
 	ManagerNamespace string
 	Insecure         bool
 	Scheme           *runtime.Scheme
-	BMCOptions       bmc.BMCOptions
+	BMCOptions       bmc.Options
 	ResyncInterval   time.Duration
 }
 

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -33,7 +33,7 @@ type BMCReconciler struct {
 	client.Client
 	Scheme            *runtime.Scheme
 	Insecure          bool
-	BMCPollingOptions bmc.BMCOptions
+	BMCPollingOptions bmc.Options
 }
 
 //+kubebuilder:rbac:groups=metal.ironcore.dev,resources=endpoints,verbs=get;list;watch

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -32,7 +32,7 @@ type EndpointReconciler struct {
 	Scheme      *runtime.Scheme
 	MACPrefixes *macdb.MacPrefixes
 	Insecure    bool
-	BMCOptions  bmc.BMCOptions
+	BMCOptions  bmc.Options
 }
 
 //+kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcs,verbs=get;list;watch;create;update;patch;delete
@@ -83,7 +83,7 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, log logr.Logger, end
 				return ctrl.Result{}, fmt.Errorf("no default credentials present for BMC %s", endpoint.Spec.MACAddress)
 			}
 
-			bmcOptions := bmc.BMCOptions{
+			bmcOptions := bmc.Options{
 				BasicAuth: true,
 				Username:  m.DefaultCredentials[0].Username,
 				Password:  m.DefaultCredentials[0].Password,

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -85,7 +85,7 @@ type ServerReconciler struct {
 	EnforceFirstBoot        bool
 	EnforcePowerOff         bool
 	ResyncInterval          time.Duration
-	BMCOptions              bmc.BMCOptions
+	BMCOptions              bmc.Options
 	DiscoveryTimeout        time.Duration
 	MaxConcurrentReconciles int
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -220,7 +220,7 @@ func SetupTest() *corev1.Namespace {
 			ResyncInterval:          50 * time.Millisecond,
 			EnforceFirstBoot:        true,
 			MaxConcurrentReconciles: 5,
-			BMCOptions: bmc.BMCOptions{
+			BMCOptions: bmc.Options{
 				PowerPollingInterval: 50 * time.Millisecond,
 				PowerPollingTimeout:  200 * time.Millisecond,
 				BasicAuth:            true,
@@ -251,7 +251,7 @@ func SetupTest() *corev1.Namespace {
 			Insecure:         true,
 			Scheme:           k8sManager.GetScheme(),
 			ResyncInterval:   10 * time.Millisecond,
-			BMCOptions: bmc.BMCOptions{
+			BMCOptions: bmc.Options{
 				PowerPollingInterval: 50 * time.Millisecond,
 				PowerPollingTimeout:  200 * time.Millisecond,
 				BasicAuth:            true,
@@ -264,7 +264,7 @@ func SetupTest() *corev1.Namespace {
 			Insecure:         true,
 			Scheme:           k8sManager.GetScheme(),
 			ResyncInterval:   10 * time.Millisecond,
-			BMCOptions: bmc.BMCOptions{
+			BMCOptions: bmc.Options{
 				PowerPollingInterval: 50 * time.Millisecond,
 				PowerPollingTimeout:  200 * time.Millisecond,
 				BasicAuth:            true,


### PR DESCRIPTION
# Proposed Changes

Rename `BMCOptions` to `Options` as we don't want the package name in the type name.