### PR TITLE
Option for naming `Servers` as the `BMC` objects

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -82,6 +82,7 @@ func main() { // nolint: gocyclo
 		discoveryTimeout                   time.Duration
 		serverMaxConcurrentReconciles      int
 		serverClaimMaxConcurrentReconciles int
+		disableServerNameSuffix            bool
 	)
 
 	flag.IntVar(&serverMaxConcurrentReconciles, "server-max-concurrent-reconciles", 5,
@@ -128,6 +129,8 @@ func main() { // nolint: gocyclo
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.BoolVar(&disableServerNameSuffix, "disable-server-name-suffix", false,
+		"If set, will drop the suffix -system-0 for servers, if there is only one system known to the BMC")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -299,9 +302,10 @@ func main() { // nolint: gocyclo
 		os.Exit(1)
 	}
 	if err = (&controller.BMCReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Insecure: insecure,
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Insecure:                insecure,
+		DisableServerNameSuffix: disableServerNameSuffix,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BMC")
 		os.Exit(1)


### PR DESCRIPTION
# Summary

While the redfish standard supports an API with multiple systems managed by one endpoint (such as Cisco IMC and others), an often use-case is to communicate with the BMC directly.

In Netbox, one usually models the system managed by the BMC and the BMC itself is just an attribute on the system.

The expectation in these circumstances is, that the Server is not a child of the BMC (i.e. suffix -system-0), but they are both belonging to the same server (i.e. have the same name).

## Proposed Changes

- Add an optional command line flag  `--disable-server-name-suffix` to the BMC CRD, which allows as an opt-in to name the Server as the BMC object (provided there is only one system reported by the BMC).

