### PR TITLE
Add label to docs container

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:24-alpine
 
+LABEL project=metal_operator
+
 # Install bash (optional but useful)
 RUN apk add --no-cache bash
 


### PR DESCRIPTION
# Proposed Changes

Add label to docs container in order to allow `make cleandocs` to remove stale container instances.