### PR TITLE
Transition unclaimed `Servers` from `Maintenance` to `Initial` state

### DIFF
--- a/docs/concepts/servers.md
+++ b/docs/concepts/servers.md
@@ -76,17 +76,19 @@ stateDiagram-v2
     Initial --> Discovery : Server object created
     Discovery --> Available : Discovery complete
     Available --> Reserved : ServerClaim created
+    Reserved --> Maintenance : Maintenance initiated
+    Maintenance --> Reserved : Maintenance complete
     Reserved --> Cleanup : ServerClaim removed
     Cleanup --> Available : Cleanup complete
     Available --> Maintenance : Maintenance initiated
-    Maintenance --> Available : Maintenance complete
+    Maintenance --> Initial : Maintenance complete
     Available --> Error : Error detected
     Reserved --> Error : Error detected
     Discovery --> Error : Error detected
     Cleanup --> Error : Error detected
     Maintenance --> Error : Error detected
     Error --> Maintenance : Enter maintenance to fix error
-    Error --> Available : Error resolved
+    Error --> Initial : Error resolved
 ```
 
 ## Interaction with BMC

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -461,7 +461,7 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, log logr.Log
 
 func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, log logr.Logger, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	if server.Spec.ServerMaintenanceRef == nil && server.Spec.ServerClaimRef == nil {
-		return r.patchServerState(ctx, server, metalv1alpha1.ServerStateAvailable)
+		return r.patchServerState(ctx, server, metalv1alpha1.ServerStateInitial)
 	}
 	if server.Spec.ServerMaintenanceRef == nil && server.Spec.ServerClaimRef != nil {
 		return r.patchServerState(ctx, server, metalv1alpha1.ServerStateReserved)


### PR DESCRIPTION
# Fixes
If maintenance is removed from a server, the server state should go to state INITIAL instead of AVAILABLE (if there is no claim on this server). Otherwise we could miss the discovery step. It could also make sense to go back to initial in case hardware changed during maintenance.

Flow:

Server state: 
Initial -> Maintenance -> Initial
Available -> Maintenance -> Initial
Reserved -> Maintenance -> Reserved.


