### PR TITLE
Fixes issue 367: maintenance will no longer kept around when server is deleted

### DIFF
--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -291,7 +291,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		))
 	})
 
-	It("Should automatically delete the maintance if the ref server is gone", func(ctx SpecContext) {
+	It("Should automatically delete the maintenance if the ref server is gone", func(ctx SpecContext) {
 
 		By("Creating an ServerMaintenance object")
 		serverMaintenance := &metalv1alpha1.ServerMaintenance{


### PR DESCRIPTION
Fixes #

when bmc/server gets deleted which has a maintenance reference, the maintenance CRD will be automatically deleted now.

https://github.com/ironcore-dev/metal-operator/issues/367