### PR TITLE
Revert Option for naming `Servers` as the `BMC` objects and related

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -82,8 +82,6 @@ func main() { // nolint: gocyclo
 		discoveryTimeout                   time.Duration
 		serverMaxConcurrentReconciles      int
 		serverClaimMaxConcurrentReconciles int
-		disableServerNameSuffix            bool
-		migrateServerNames                 bool
 	)
 
 	flag.IntVar(&serverMaxConcurrentReconciles, "server-max-concurrent-reconciles", 5,
@@ -130,10 +128,6 @@ func main() { // nolint: gocyclo
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	flag.BoolVar(&disableServerNameSuffix, "disable-server-name-suffix", false,
-		"If set, will drop the suffix -system-0 for servers, if there is only one system known to the BMC")
-	flag.BoolVar(&migrateServerNames, "migrate-server-names", false,
-		"If set, will do extra checks and allow migration of server names")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -305,11 +299,9 @@ func main() { // nolint: gocyclo
 		os.Exit(1)
 	}
 	if err = (&controller.BMCReconciler{
-		Client:                  mgr.GetClient(),
-		Scheme:                  mgr.GetScheme(),
-		Insecure:                insecure,
-		DisableServerNameSuffix: disableServerNameSuffix,
-		MigrateServerNames:      migrateServerNames,
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Insecure: insecure,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BMC")
 		os.Exit(1)


### PR DESCRIPTION
As this has been solved now on the consumer side of the metal operator.

This reverts commit da635a2da51f86c8eeedebb3407c6c28e42cc1f8. And commit 4b04daeb2b4b41e890dc86a45410320906e85e6a.

# Proposed Changes

- Revert the short name option and migration.