### PR TITLE
Validate that the claim in `Server` is not switched directly

### DIFF
--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -83,6 +83,8 @@ type ServerSpec struct {
 
 	// ServerClaimRef is a reference to a ServerClaim object that claims this server.
 	// This field is optional and can be omitted if no claim is associated with this server.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == null || oldSelf == null || self == oldSelf",message="serverClaimRef cannot be switched directly"
 	ServerClaimRef *v1.ObjectReference `json:"serverClaimRef,omitempty"`
 
 	// ServerMaintenanceRef is a reference to a ServerMaintenance object that maintains this server.

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -316,6 +316,9 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: serverClaimRef cannot be switched directly
+                  rule: self == null || oldSelf == null || self == oldSelf
               serverMaintenanceRef:
                 description: ServerMaintenanceRef is a reference to a ServerMaintenance
                   object that maintains this server.

--- a/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
@@ -322,6 +322,9 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: serverClaimRef cannot be switched directly
+                  rule: self == null || oldSelf == null || self == oldSelf
               serverMaintenanceRef:
                 description: ServerMaintenanceRef is a reference to a ServerMaintenance
                   object that maintains this server.


### PR DESCRIPTION
The ServerClaim has first to be released, which would remove the reference in the server, and only then one should claim it again.

This rule should ensure that, and hopefully prevent (#374).

# Proposed Changes

- Prohibit the change of a ServerClaimRef from one ServerClaim to the other before going through "null ".

Fixes #374