### PR TITLE
Update ServerClaimRef in Server instead of Patch

### DIFF
--- a/internal/controller/serverclaim_controller.go
+++ b/internal/controller/serverclaim_controller.go
@@ -198,20 +198,17 @@ func (r *ServerClaimReconciler) ensureObjectRefForServer(ctx context.Context, lo
 		return false, nil
 	}
 
-	if server.Spec.ServerClaimRef == nil {
-		serverBase := server.DeepCopy()
-		server.Spec.ServerClaimRef = &v1.ObjectReference{
-			APIVersion: "metal.ironcore.dev/v1alpha1",
-			Kind:       "ServerClaim",
-			Namespace:  claim.Namespace,
-			Name:       claim.Name,
-			UID:        claim.UID,
-		}
-		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-			return false, fmt.Errorf("failed to patch claim ref for server: %w", err)
-		}
-		log.V(1).Info("Patched ServerClaim reference on Server", "Server", server.Name, "ServerClaimRef", claim.Name)
+	server.Spec.ServerClaimRef = &v1.ObjectReference{
+		APIVersion: "metal.ironcore.dev/v1alpha1",
+		Kind:       "ServerClaim",
+		Namespace:  claim.Namespace,
+		Name:       claim.Name,
+		UID:        claim.UID,
 	}
+	if err := r.Update(ctx, server); err != nil {
+		return false, fmt.Errorf("failed to patch claim ref for server: %w", err)
+	}
+	log.V(1).Info("Updated ServerClaim reference on Server", "Server", server.Name, "ServerClaimRef", claim.Name)
 	return true, nil
 }
 


### PR DESCRIPTION
Patch opts out of the optimistic locking functionality of the kubernetes api, and is therefore doesn't protect against concurrent modifications.

The lock in the controller only protects against concurrent execution of the same function in the same controller, but does nothing to stop concurrent modifications
with any other user of the object.

# Proposed Changes

- Use Update instead of Patch, as the first checks for concurrent modifications.

Fixes #374