### PR TITLE
Allow updates of `{BMC,BIOS}Settings` and `{BMC,BIOS}Version` when `ServerMaintenances` are not yet created

### DIFF
--- a/internal/webhook/v1alpha1/biossettings_webhook.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook.go
@@ -75,7 +75,7 @@ func (v *BIOSSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj
 		return nil, fmt.Errorf("expected a BIOSSettings object for the oldObj but got %T", oldObj)
 	}
 	if oldBIOSSettings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress &&
-		!ShouldAllowForceUpdateInProgress(biossettings) {
+		!ShouldAllowForceUpdateInProgress(biossettings) && oldBIOSSettings.Spec.ServerMaintenanceRef != nil {
 		err := fmt.Errorf("BIOSSettings (%v) is in progress, unable to update %v",
 			oldBIOSSettings.Name,
 			biossettings.Name)

--- a/internal/webhook/v1alpha1/biossettings_webhook_test.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook_test.go
@@ -150,6 +150,10 @@ var _ = Describe("BIOSSettings Webhook", func() {
 			Eventually(UpdateStatus(biosSettingsV1, func() {
 				biosSettingsV1.Status.State = metalv1alpha1.BIOSSettingsStateInProgress
 			})).Should(Succeed())
+			By("mock servermaintenance Creation maintenance")
+			Eventually(Update(biosSettingsV1, func() {
+				biosSettingsV1.Spec.ServerMaintenanceRef = &v1.ObjectReference{Name: "foobar-Maintenance"}
+			})).Should(Succeed())
 			By("Updating an biosSettingsV1 spec, should fail to update when inProgress")
 			biosSettingsV1Updated := biosSettingsV1.DeepCopy()
 			biosSettingsV1Updated.Spec.SettingsMap = map[string]string{"test": "value"}

--- a/internal/webhook/v1alpha1/biosversion_webhook.go
+++ b/internal/webhook/v1alpha1/biosversion_webhook.go
@@ -77,7 +77,7 @@ func (v *BIOSVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 		return nil, fmt.Errorf("expected a BIOSVersion object for the oldObj but got %T", oldObj)
 	}
 	if oldBIOSVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress &&
-		!ShouldAllowForceUpdateInProgress(biosversion) {
+		!ShouldAllowForceUpdateInProgress(biosversion) && oldBIOSVersion.Spec.ServerMaintenanceRef != nil {
 		err := fmt.Errorf("BIOSVersion (%v) is in progress, unable to update %v",
 			oldBIOSVersion.Name,
 			biosversion.Name)

--- a/internal/webhook/v1alpha1/biosversion_webhook_test.go
+++ b/internal/webhook/v1alpha1/biosversion_webhook_test.go
@@ -161,6 +161,10 @@ var _ = Describe("BIOSVersion Webhook", func() {
 			Eventually(UpdateStatus(biosVersionV1, func() {
 				biosVersionV1.Status.State = metalv1alpha1.BIOSVersionStateInProgress
 			})).Should(Succeed())
+			By("mock servermaintenance Creation maintenance")
+			Eventually(Update(biosVersionV1, func() {
+				biosVersionV1.Spec.ServerMaintenanceRef = &v1.ObjectReference{Name: "foobar-Maintenance"}
+			})).Should(Succeed())
 			By("Updating an biosVersion V1 spec, should fail to update when inProgress")
 			biosVersionV1Updated := biosVersionV1.DeepCopy()
 			biosVersionV1Updated.Spec.Version = "P712"

--- a/internal/webhook/v1alpha1/bmcsettings_webhook.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook.go
@@ -74,7 +74,7 @@ func (v *BMCSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 		return nil, fmt.Errorf("expected a BMCSettings object for the oldObj but got %T", oldObj)
 	}
 	if oldBMCSettings.Status.State == metalv1alpha1.BMCSettingsStateInProgress &&
-		!ShouldAllowForceUpdateInProgress(bmcSettings) {
+		!ShouldAllowForceUpdateInProgress(bmcSettings) && oldBMCSettings.Spec.ServerMaintenanceRefs != nil {
 		err := fmt.Errorf("BMCSettings (%v) is in progress, unable to update %v",
 			oldBMCSettings.Name,
 			bmcSettings.Name)

--- a/internal/webhook/v1alpha1/bmcsettings_webhook_test.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook_test.go
@@ -130,6 +130,12 @@ var _ = Describe("BMCSettings Webhook", func() {
 			Eventually(UpdateStatus(BMCSettingsV1, func() {
 				BMCSettingsV1.Status.State = metalv1alpha1.BMCSettingsStateInProgress
 			})).Should(Succeed())
+			By("mock servermaintenance Creation maintenance")
+			Eventually(Update(BMCSettingsV1, func() {
+				BMCSettingsV1.Spec.ServerMaintenanceRefs = []metalv1alpha1.ServerMaintenanceRefItem{
+					{ServerMaintenanceRef: &v1.ObjectReference{Name: "foobar-Maintenance"}},
+				}
+			})).Should(Succeed())
 			By("Updating an bmcSettings V1 spec, should fail to update when inProgress")
 			bmcSettingsV1Updated := BMCSettingsV1.DeepCopy()
 			bmcSettingsV1Updated.Spec.SettingsMap = map[string]string{"test": "value"}

--- a/internal/webhook/v1alpha1/bmcversion_webhook.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook.go
@@ -71,7 +71,7 @@ func (v *BMCVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj, 
 		return nil, fmt.Errorf("expected a BMCVersion object for the oldObj but got %T", oldObj)
 	}
 	if oldBMCVersion.Status.State == metalv1alpha1.BMCVersionStateInProgress &&
-		!ShouldAllowForceUpdateInProgress(bmcversion) {
+		!ShouldAllowForceUpdateInProgress(bmcversion) && oldBMCVersion.Spec.ServerMaintenanceRefs != nil {
 		err := fmt.Errorf("BMCVersion (%v) is in progress, unable to update %v",
 			oldBMCVersion.Name,
 			bmcversion.Name)

--- a/internal/webhook/v1alpha1/bmcversion_webhook_test.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook_test.go
@@ -129,6 +129,12 @@ var _ = Describe("BMCVersion Webhook", func() {
 			Eventually(UpdateStatus(BMCVersionV1, func() {
 				BMCVersionV1.Status.State = metalv1alpha1.BMCVersionStateInProgress
 			})).Should(Succeed())
+			By("mock servermaintenance Creation maintenance")
+			Eventually(Update(BMCVersionV1, func() {
+				BMCVersionV1.Spec.ServerMaintenanceRefs = []metalv1alpha1.ServerMaintenanceRefItem{
+					{ServerMaintenanceRef: &v1.ObjectReference{Name: "foobar-Maintenance"}},
+				}
+			})).Should(Succeed())
 			By("Updating an biosSettingsV1 spec, should fail to update when inProgress")
 			BMCVersionV1Updated := BMCVersionV1.DeepCopy()
 			BMCVersionV1Updated.Spec.Version = "P72"


### PR DESCRIPTION
Fixes #416