### PR TITLE
Add 3D `Server` visualizer command to `metalctl`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,7 @@ GEN_CRD_API_REFERENCE_DOCS ?= $(LOCALBIN)/gen-crd-api-reference-docs
 KUBEBUILDER ?= $(LOCALBIN)/kubebuilder
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GOIMPORTS ?= $(LOCALBIN)/goimports
+METALCTL ?= $(LOCALBIN)/metalctl
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
@@ -318,6 +319,10 @@ $(GEN_CRD_API_REFERENCE_DOCS): $(LOCALBIN)
 kubebuilder: $(KUBEBUILDER) ## Download kubebuilder locally if necessary.
 $(KUBEBUILDER): $(LOCALBIN)
 	$(call go-install-tool,$(KUBEBUILDER),sigs.k8s.io/kubebuilder/v4,$(KUBEBUILDER_VERSION))
+
+.PHONY: metalctl
+metalctl: $(METALCTL) ## Build metalctl locally if necessary.
+	go build -o $(METALCTL) ./cmd/metalctl
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -22,6 +22,7 @@ path = [
     "hack/**",
     "package.json",
     "package-lock.json",
+    "internal/cmd/visualizer/index.html",
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 SAP SE or an SAP affiliate company and IronCore contributors"

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -18,6 +18,12 @@ const (
 
 	// PowerOff indicates that the device is powered off.
 	PowerOff Power = "Off"
+
+	// TopologyHeightUnit is the annotation key for the height unit of a server in a rack.
+	TopologyHeightUnit = "topology.metal.ironcore.dev/heightunit"
+
+	// TopologyRack is the annotation key for the rack of a server.
+	TopologyRack = "topology.metal.ironcore.dev/rack"
 )
 
 // ServerPowerState defines the possible power states for a server.

--- a/cmd/metalctl/app/app.go
+++ b/cmd/metalctl/app/app.go
@@ -4,11 +4,10 @@
 package app
 
 import (
-	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	metalv1alphav1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	"github.com/spf13/cobra"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -31,5 +30,6 @@ func NewCommand() *cobra.Command {
 	}
 	root.AddCommand(NewMoveCommand())
 	root.AddCommand(NewConsoleCommand())
+	root.AddCommand(NewVisualizationCommand())
 	return root
 }

--- a/cmd/metalctl/app/visualizer.go
+++ b/cmd/metalctl/app/visualizer.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"log"
+
+	cmdclient "github.com/ironcore-dev/metal-operator/internal/cmd/client"
+	"github.com/ironcore-dev/metal-operator/internal/cmd/visualizer"
+	"github.com/spf13/cobra"
+)
+
+var (
+	port int
+)
+
+func NewVisualizationCommand() *cobra.Command {
+	visualizerCmd := &cobra.Command{
+		Use:   "visualizer",
+		Short: "Visualize server topology",
+		RunE:  runVisualizer,
+		Aliases: []string{
+			"viz",
+		},
+	}
+
+	visualizerCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig.")
+	visualizerCmd.Flags().IntVar(&port, "port", 8080, "Port to run the web server on")
+
+	return visualizerCmd
+}
+
+func runVisualizer(_ *cobra.Command, _ []string) error {
+	log.Println("A 3D visualizer for server resources")
+
+	c, err := cmdclient.CreateClient(kubeconfig, scheme)
+	if err != nil {
+		log.Fatalf("Error creating kubernetes client: %v", err)
+	}
+
+	vis := visualizer.NewVisualizer(c, port)
+
+	return vis.StartAndServe()
+}

--- a/config/samples/topology/rack1/server1.yaml
+++ b/config/samples/topology/rack1/server1.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "1"
+    topology.metal.ironcore.dev/heightunit: "1"
+  name: server-1-1
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack1/server10.yaml
+++ b/config/samples/topology/rack1/server10.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "1"
+    topology.metal.ironcore.dev/heightunit: "10"
+  name: server-1-10
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack1/server2.yaml
+++ b/config/samples/topology/rack1/server2.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "1"
+    topology.metal.ironcore.dev/heightunit: "2"
+  name: server-1-2
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "On"

--- a/config/samples/topology/rack1/server3.yaml
+++ b/config/samples/topology/rack1/server3.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "1"
+    topology.metal.ironcore.dev/heightunit: "3"
+  name: server-1-3
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack1/server4.yaml
+++ b/config/samples/topology/rack1/server4.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "1"
+    topology.metal.ironcore.dev/heightunit: "4"
+  name: server-1-4
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack1/server5.yaml
+++ b/config/samples/topology/rack1/server5.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "1"
+    topology.metal.ironcore.dev/heightunit: "5"
+  name: server-1-5
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack1/server6.yaml
+++ b/config/samples/topology/rack1/server6.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "1"
+    topology.metal.ironcore.dev/heightunit: "6"
+  name: server-1-6
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack1/server7.yaml
+++ b/config/samples/topology/rack1/server7.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "1"
+    topology.metal.ironcore.dev/heightunit: "7"
+  name: server-1-7
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack1/server8.yaml
+++ b/config/samples/topology/rack1/server8.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "1"
+    topology.metal.ironcore.dev/heightunit: "8"
+  name: server-1-8
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack1/server9.yaml
+++ b/config/samples/topology/rack1/server9.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "1"
+    topology.metal.ironcore.dev/heightunit: "9"
+  name: server-1-9
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack2/server1.yaml
+++ b/config/samples/topology/rack2/server1.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "2"
+    topology.metal.ironcore.dev/heightunit: "1"
+  name: server-2-1
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack2/server10.yaml
+++ b/config/samples/topology/rack2/server10.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "2"
+    topology.metal.ironcore.dev/heightunit: "10"
+  name: server-2-10
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack2/server2.yaml
+++ b/config/samples/topology/rack2/server2.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "2"
+    topology.metal.ironcore.dev/heightunit: "2"
+  name: server-2-2
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack2/server3.yaml
+++ b/config/samples/topology/rack2/server3.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "2"
+    topology.metal.ironcore.dev/heightunit: "3"
+  name: server-2-3
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack2/server4.yaml
+++ b/config/samples/topology/rack2/server4.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "2"
+    topology.metal.ironcore.dev/heightunit: "4"
+  name: server-2-4
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack2/server5.yaml
+++ b/config/samples/topology/rack2/server5.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "2"
+    topology.metal.ironcore.dev/heightunit: "5"
+  name: server-2-5
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack2/server6.yaml
+++ b/config/samples/topology/rack2/server6.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "2"
+    topology.metal.ironcore.dev/heightunit: "6"
+  name: server-2-6
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack2/server7.yaml
+++ b/config/samples/topology/rack2/server7.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "2"
+    topology.metal.ironcore.dev/heightunit: "7"
+  name: server-2-7
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack2/server8.yaml
+++ b/config/samples/topology/rack2/server8.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "2"
+    topology.metal.ironcore.dev/heightunit: "8"
+  name: server-2-8
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack2/server9.yaml
+++ b/config/samples/topology/rack2/server9.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "2"
+    topology.metal.ironcore.dev/heightunit: "9"
+  name: server-2-9
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack3/server1.yaml
+++ b/config/samples/topology/rack3/server1.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "3"
+    topology.metal.ironcore.dev/heightunit: "1"
+  name: server-3-1
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack3/server10.yaml
+++ b/config/samples/topology/rack3/server10.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "3"
+    topology.metal.ironcore.dev/heightunit: "10"
+  name: server-3-10
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack3/server2.yaml
+++ b/config/samples/topology/rack3/server2.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "3"
+    topology.metal.ironcore.dev/heightunit: "2"
+  name: server-3-2
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack3/server3.yaml
+++ b/config/samples/topology/rack3/server3.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "3"
+    topology.metal.ironcore.dev/heightunit: "3"
+  name: server-3-3
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack3/server4.yaml
+++ b/config/samples/topology/rack3/server4.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "3"
+    topology.metal.ironcore.dev/heightunit: "4"
+  name: server-3-4
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack3/server5.yaml
+++ b/config/samples/topology/rack3/server5.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "3"
+    topology.metal.ironcore.dev/heightunit: "5"
+  name: server-3-5
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack3/server6.yaml
+++ b/config/samples/topology/rack3/server6.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "3"
+    topology.metal.ironcore.dev/heightunit: "6"
+  name: server-3-6
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack3/server7.yaml
+++ b/config/samples/topology/rack3/server7.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "3"
+    topology.metal.ironcore.dev/heightunit: "7"
+  name: server-3-7
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack3/server8.yaml
+++ b/config/samples/topology/rack3/server8.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "3"
+    topology.metal.ironcore.dev/heightunit: "8"
+  name: server-3-8
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/config/samples/topology/rack3/server9.yaml
+++ b/config/samples/topology/rack3/server9.yaml
@@ -1,0 +1,13 @@
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
+metadata:
+  labels:
+    topology.metal.ironcore.dev/rack: "3"
+    topology.metal.ironcore.dev/heightunit: "9"
+  name: server-3-9
+spec:
+  uuid: "12345"
+  bmcRef:
+    name: sample-bmc
+  power: "Off"
+  indicatorLED: "Off"

--- a/docs/usage/metalctl.md
+++ b/docs/usage/metalctl.md
@@ -10,6 +10,20 @@ go install https://github.com/ironcore-dev/metal-operator/cmd/metalctl@latest
 
 ## Commands
 
+### visualizer, vis
+
+The `metalctl visualalizer` (or `metalctl vis`) command allows you to visualize the topology of your bare metal `Server`s.
+
+To run the visualizer run
+
+```bash
+metalctl visualizer --kubeconfig="path-to-kubeconfig.yaml"
+```
+
+In order to access the 3D visualization, open your browser and navigate to `http://localhost:8080`.
+
+You can configure the port by setting the `--port` flag.
+
 ### console
 
 The `metalctl console` command allows you to access the serial console of a `Server`.

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+// ServerInfo represents information about a server in the data center.
+type ServerInfo struct {
+	Name         string `json:"name"`
+	Rack         string `json:"rack"`
+	HeightUnit   int    `json:"heightUnit"`
+	Power        string `json:"power"`
+	IndicatorLED string `json:"indicatorLED"`
+	State        string `json:"state"`
+}

--- a/internal/cmd/client/client.go
+++ b/internal/cmd/client/client.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func CreateClient(kubeconfig string, scheme *runtime.Scheme) (client.Client, error) {
+	if len(kubeconfig) == 0 {
+		kubeconfig = os.Getenv("KUBECONFIG")
+		if kubeconfig == "" {
+			fmt.Println("Error: --kubeconfig flag or KUBECONFIG environment variable must be set")
+			os.Exit(1)
+		}
+	}
+
+	clientConfig, err := config.GetConfigWithContext("")
+	if err != nil {
+		return nil, fmt.Errorf("failed getting client config: %w", err)
+	}
+
+	k8sClient, err := client.New(clientConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed creating client: %w", err)
+	}
+	return k8sClient, nil
+}

--- a/internal/cmd/visualizer/index.html
+++ b/internal/cmd/visualizer/index.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kubernetes 3D Server Rack Visualizer</title>
+    <style>
+        body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #1a1a1a; color: #fff; }
+        canvas { display: block; }
+        #tooltip {
+            position: absolute;
+            display: none;
+            padding: 12px;
+            background: rgba(0, 0, 0, 0.8);
+            border-radius: 8px;
+            color: #fff;
+            pointer-events: none;
+            white-space: pre;
+            font-family: 'Courier New', Courier, monospace;
+            border: 1px solid #444;
+        }
+        #header {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            font-size: 24px;
+            font-weight: bold;
+            text-shadow: 0 0 5px #000;
+        }
+    </style>
+</head>
+<body>
+<div id="header">Server Visualizer</div>
+<div id="tooltip"></div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+<script>
+    // main.js (embedded)
+    document.addEventListener('DOMContentLoaded', () => {
+        let scene, camera, renderer, controls, cameraTargetSet = false;
+        let INTERSECTED;
+        const raycaster = new THREE.Raycaster();
+        const mouse = new THREE.Vector2();
+        const serverObjects = [];
+        const tooltip = document.getElementById('tooltip');
+        const rackGroup = new THREE.Group(); // Group to hold all rack and server objects
+
+        // --- Constants for Visualization ---
+        const RACK_WIDTH = 10;
+        const RACK_DEPTH = 15;
+        const RACK_SPACING = 5;
+        const SERVER_HEIGHT = 0.8; // Height of 1U
+        const SERVER_MARGIN = 0.1; // Margin between servers
+        const REFRESH_INTERVAL = 5000; // 5 seconds
+
+        function init() {
+            // --- Scene Setup ---
+            scene = new THREE.Scene();
+            scene.background = new THREE.Color(0x1a1a1a);
+            scene.fog = new THREE.Fog(0x1a1a1a, 50, 200);
+            scene.add(rackGroup);
+
+            // --- Camera Setup ---
+            camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+            camera.position.set(20, 30, 60);
+
+            // --- Renderer Setup ---
+            renderer = new THREE.WebGLRenderer({ antialias: true });
+            renderer.setSize(window.innerWidth, window.innerHeight);
+            renderer.setPixelRatio(window.devicePixelRatio);
+            renderer.shadowMap.enabled = true;
+            document.body.appendChild(renderer.domElement);
+
+            // --- Lighting ---
+            const ambientLight = new THREE.AmbientLight(0xcccccc, 0.5);
+            scene.add(ambientLight);
+
+            const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
+            directionalLight.position.set(-30, 50, 50);
+            directionalLight.castShadow = true;
+            directionalLight.shadow.mapSize.width = 2048;
+            directionalLight.shadow.mapSize.height = 2048;
+            scene.add(directionalLight);
+
+            // --- Controls ---
+            controls = new THREE.OrbitControls(camera, renderer.domElement);
+            controls.enableDamping = true;
+            controls.dampingFactor = 0.05;
+            controls.screenSpacePanning = false;
+            controls.minDistance = 10;
+            controls.maxDistance = 200;
+            controls.maxPolarAngle = Math.PI / 2;
+
+            // The camera target will now be set dynamically in visualizeServers().
+
+            // --- Ground Plane ---
+            const planeGeometry = new THREE.PlaneGeometry(500, 500);
+            const planeMaterial = new THREE.MeshStandardMaterial({ color: 0x222222, roughness: 0.9 });
+            const plane = new THREE.Mesh(planeGeometry, planeMaterial);
+            plane.rotation.x = -Math.PI / 2;
+            plane.position.y = -0.5;
+            plane.receiveShadow = true;
+            scene.add(plane);
+
+            // --- Event Listeners ---
+            window.addEventListener('resize', onWindowResize, false);
+            document.addEventListener('mousemove', onMouseMove, false);
+
+            // --- Data Fetching ---
+            fetchServers(); // Initial fetch
+            setInterval(fetchServers, REFRESH_INTERVAL); // Refresh periodically
+
+            animate();
+        }
+
+        function clearScene() {
+            // Clear previous objects before redrawing
+            while(rackGroup.children.length > 0){
+                const child = rackGroup.children[0];
+                // Dispose of geometry and material to free up GPU memory
+                if (child.geometry) child.geometry.dispose();
+                if (child.material) {
+                    if (Array.isArray(child.material)) {
+                        child.material.forEach(m => m.dispose());
+                    } else {
+                        child.material.dispose();
+                    }
+                }
+                rackGroup.remove(child);
+            }
+            rackGroup.position.set(0, 0, 0);
+            serverObjects.length = 0; // Clear the array for intersection checks
+        }
+
+        function fetchServers() {
+            fetch('/api/servers')
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error('Failed to fetch server data');
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    clearScene();
+                    if (data) {
+                        visualizeServers(data);
+                    }
+                })
+                .catch(error => {
+                    console.error('Error fetching servers:', error);
+                    // Display error message on screen
+                    const errorDiv = document.createElement('div');
+                    errorDiv.style.position = 'absolute';
+                    errorDiv.style.top = '50%';
+                    errorDiv.style.left = '50%';
+                    errorDiv.style.transform = 'translate(-50%, -50%)';
+                    errorDiv.style.color = 'red';
+                    errorDiv.style.fontSize = '18px';
+                    errorDiv.textContent = 'Could not fetch server data. Is kubectl proxy running and are servers available?';
+                    document.body.appendChild(errorDiv);
+                });
+        }
+
+        function visualizeServers(servers) {
+            const racks = {};
+            servers.forEach(server => {
+                if (!racks[server.rack]) {
+                    racks[server.rack] = [];
+                }
+                racks[server.rack].push(server);
+            });
+
+            Object.keys(racks).sort((a,b) => a - b).forEach((rackId, index) => {
+                const rackX = index * (RACK_WIDTH + RACK_SPACING);
+
+                // Create rack frame (optional, for visual context)
+                const rackHeight = 50; // A typical rack height
+                const frameMaterial = new THREE.LineBasicMaterial({ color: 0x555555 });
+                const points = [];
+                points.push(new THREE.Vector3(rackX - RACK_WIDTH / 2, 0, -RACK_DEPTH / 2));
+                points.push(new THREE.Vector3(rackX - RACK_WIDTH / 2, rackHeight, -RACK_DEPTH / 2));
+                points.push(new THREE.Vector3(rackX + RACK_WIDTH / 2, rackHeight, -RACK_DEPTH / 2));
+                points.push(new THREE.Vector3(rackX + RACK_WIDTH / 2, 0, -RACK_DEPTH / 2));
+                const geometry = new THREE.BufferGeometry().setFromPoints(points);
+                const rackFrame = new THREE.Line(geometry, frameMaterial);
+                rackGroup.add(rackFrame);
+
+                // Add rack label
+                const loader = new THREE.FontLoader();
+                loader.load('https://cdn.jsdelivr.net/npm/three@0.128.0/examples/fonts/helvetiker_regular.typeface.json', function (font) {
+                    const textGeo = new THREE.TextGeometry('Rack ' + rackId, {
+                        font: font,
+                        size: 2,
+                        height: 0.1,
+                    });
+                    const textMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff });
+                    const textMesh = new THREE.Mesh(textGeo, textMaterial);
+                    textMesh.position.set(rackX - RACK_WIDTH / 2, rackHeight + 2, -RACK_DEPTH / 2);
+                    rackGroup.add(textMesh);
+                });
+
+                racks[rackId].forEach(server => {
+                    const serverGeometry = new THREE.BoxGeometry(RACK_WIDTH, SERVER_HEIGHT, RACK_DEPTH);
+
+                    let color = 0x666666; // Default color (Off)
+                    if (server.power.toLowerCase() === 'on') {
+                        color = 0x00ff00; // Green for On
+                    }
+                    if (server.indicatorLED.toLowerCase() === 'blinking') {
+                        color = 0x0000ff; // Blue for Blinking
+                    }
+
+                    const serverMaterial = new THREE.MeshStandardMaterial({
+                        color: color,
+                        roughness: 0.6,
+                        metalness: 0.2
+                    });
+
+                    const serverMesh = new THREE.Mesh(serverGeometry, serverMaterial);
+                    serverMesh.castShadow = true;
+                    serverMesh.receiveShadow = true;
+
+                    // Position server in the rack
+                    const serverY = (server.heightUnit * (SERVER_HEIGHT + SERVER_MARGIN));
+                    serverMesh.position.set(rackX, serverY, 0);
+
+                    // Store server data in the mesh for tooltip
+                    serverMesh.userData = server;
+
+                    rackGroup.add(serverMesh);
+                    serverObjects.push(serverMesh);
+                });
+            });
+
+            // After populating the group, adjust its position and the camera target.
+            if (rackGroup.children.length > 0) {
+                // 1. Calculate the bounding box of the entire group.
+                const boundingBox = new THREE.Box3().setFromObject(rackGroup);
+
+                // 2. Calculate the vector needed to move the group's lower-left-front corner to the origin.
+                const offset = boundingBox.min.clone().negate();
+
+                // 3. Apply this offset to the entire group of racks and servers.
+                rackGroup.position.copy(offset);
+
+                // 4. On the first run, set the camera to look at the new center of the scene.
+                if (!cameraTargetSet) {
+                    const newCenter = new THREE.Vector3();
+                    // Get the center of the original box and apply the same offset to find the new center point.
+                    boundingBox.getCenter(newCenter).add(offset);
+
+                    controls.target.copy(newCenter);
+                    controls.update(); // Important: update controls after changing the target
+                    cameraTargetSet = true; // Set flag to prevent this from running again on refresh
+                }
+            }
+        }
+
+        function onWindowResize() {
+            camera.aspect = window.innerWidth / window.innerHeight;
+            camera.updateProjectionMatrix();
+            renderer.setSize(window.innerWidth, window.innerHeight);
+        }
+
+        function onMouseMove(event) {
+            event.preventDefault();
+            mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+            mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+
+            tooltip.style.left = (event.clientX + 15) + 'px';
+            tooltip.style.top = (event.clientY + 15) + 'px';
+        }
+
+        function animate() {
+            requestAnimationFrame(animate);
+            controls.update();
+
+            // Blinking effect for servers with indicatorLED
+            const time = Date.now() * 0.005;
+            serverObjects.forEach(obj => {
+                if (obj.userData.indicatorLED && obj.userData.indicatorLED.toLowerCase() === 'blinking') {
+                    obj.material.emissive.setHex( (time * 5) % 2 > 1 ? 0x0000ff : 0x000000 );
+                }
+            });
+
+            // --- Intersection / Tooltip Logic ---
+            raycaster.setFromCamera(mouse, camera);
+            const intersects = raycaster.intersectObjects(serverObjects);
+
+            if (intersects.length > 0) {
+                if (INTERSECTED != intersects[0].object) {
+                    if (INTERSECTED) INTERSECTED.material.emissive.setHex(INTERSECTED.currentHex);
+                    INTERSECTED = intersects[0].object;
+                    INTERSECTED.currentHex = INTERSECTED.material.emissive.getHex();
+                    INTERSECTED.material.emissive.setHex(0x555555);
+
+                    tooltip.style.display = 'block';
+                    const server = INTERSECTED.userData;
+                    tooltip.innerHTML = `Name: ${server.name}
+Rack: ${server.rack}
+Height Unit: ${server.heightUnit}
+Power: ${server.power}
+Indicator LED: ${server.indicatorLED || 'N/A'}
+State: ${server.state || 'N/A'}`;
+                }
+            } else {
+                if (INTERSECTED) INTERSECTED.material.emissive.setHex(INTERSECTED.currentHex);
+                INTERSECTED = null;
+                tooltip.style.display = 'none';
+            }
+
+            renderer.render(scene, camera);
+        }
+
+        init();
+    });
+</script>
+</body>
+</html>

--- a/internal/cmd/visualizer/visualizer.go
+++ b/internal/cmd/visualizer/visualizer.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package visualizer
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	"github.com/ironcore-dev/metal-operator/internal/cmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//go:embed index.html
+var indexHTML string
+
+type Visualizer struct {
+	Client  client.Client
+	Address string
+}
+
+// NewVisualizer creates and returns a new Visualizer instance.
+func NewVisualizer(c client.Client, port int) *Visualizer {
+	return &Visualizer{
+		Client:  c,
+		Address: fmt.Sprintf("localhost:%d", port),
+	}
+}
+
+// StartAndServe initializes the HTTP routes and starts the server.
+// It also handles graceful shutdown on interrupt signals.
+func (v *Visualizer) StartAndServe() error {
+	url := fmt.Sprintf("http://%s", v.Address)
+
+	http.HandleFunc("/", serveFrontend)
+	http.HandleFunc("/api/servers", v.handleGetServers())
+
+	srv := &http.Server{
+		Addr:    v.Address,
+		Handler: nil,
+	}
+
+	stopChan := make(chan os.Signal, 1)
+	signal.Notify(stopChan, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		log.Printf("Server listening on %s. Press Ctrl+C to stop.", url)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("Failed to start server: %v", err)
+		}
+	}()
+
+	<-stopChan
+
+	log.Println("Shutting down server...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("Server shutdown failed: %v", err)
+	}
+
+	log.Println("Server gracefully stopped.")
+	return nil
+}
+
+// handleGetServers creates an HTTP handler to list Server resources.
+func (v *Visualizer) handleGetServers() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		serverList := &metalv1alpha1.ServerList{}
+		if err := v.Client.List(ctx, serverList); err != nil {
+			http.Error(w, fmt.Sprintf("Failed to list servers: %v", err), http.StatusInternalServerError)
+			log.Printf("Error listing servers: %v", err)
+			return
+		}
+
+		var servers []api.ServerInfo
+		for _, item := range serverList.Items {
+			server, err := parseServerToServerInfo(&item)
+			if err != nil {
+				log.Printf("Skipping server due to parsing error: %v", err)
+				continue
+			}
+			servers = append(servers, server)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(servers); err != nil {
+			http.Error(w, "Failed to encode servers to JSON", http.StatusInternalServerError)
+			log.Printf("Error encoding JSON: %v", err)
+		}
+	}
+}
+
+// serveFrontend handles serving the embedded index.html.
+func serveFrontend(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html")
+	_, err := fmt.Fprint(w, indexHTML)
+	if err != nil {
+		http.Error(w, "Failed to serve frontend", http.StatusInternalServerError)
+		return
+	}
+}
+
+// parseServerToServerInfo extracts the required fields from a Server object.
+func parseServerToServerInfo(server *metalv1alpha1.Server) (api.ServerInfo, error) {
+	var info api.ServerInfo
+	info.Name = server.GetName()
+
+	// Extract labels
+	labels := server.GetLabels()
+	rack, ok := labels[metalv1alpha1.TopologyRack]
+	if ok {
+		info.Rack = rack
+	}
+
+	heightUnitStr, ok := labels[metalv1alpha1.TopologyHeightUnit]
+	if ok {
+		heightUnit, err := strconv.Atoi(heightUnitStr)
+		if err != nil {
+			return info, fmt.Errorf("could not parse heightunit label for server %s: %w", info.Name, err)
+		}
+		info.HeightUnit = heightUnit
+	}
+
+	info.Power = string(server.Status.PowerState)
+	info.IndicatorLED = string(server.Spec.IndicatorLED)
+	info.State = string(server.Status.State)
+
+	return info, nil
+}


### PR DESCRIPTION
# Proposed Changes

Add a 3d visualizer sub-command to `metalctl`.

The visualization is derived from the following topology labels on the `Server` resources:

```go
// TopologyHeightUnit is the annotation key for the height unit of a server in a rack.
TopologyHeightUnit = "topology.metal.ironcore.dev/heightunit"
// TopologyRack is the annotation key for the rack of a server.
TopologyRack = "topology.metal.ironcore.dev/rack"
```

## Usage

Install the `metalctl` via

```shell
make metalctl
```

Run the `metalctl viz` command against a cluster: (alternatively `metalctl visualizer`)

```shell
./bin/metalctl viz --kubeconfig=~/.home/config
```

Alternatively you can set the `KUBECONFIG` env var.

The visualizer can be accessed by clicking on the link presented to you:

```shell
./bin/metalctl viz --kubeconfig=~/.home/config            
2025/08/26 11:16:45 kubectl-visualizer: A 3D visualizer for server resources
2025/08/26 11:16:45 Server listening on http://localhost:8080. Press Ctrl+C to stop.
```

Example:
<img width="737" height="844" alt="Screenshot 2025-08-26 at 14 13 07" src="https://github.com/user-attachments/assets/3c040eb2-3411-46b4-a853-80a4f5c8453d" />

An example rack topology has been added to `config/samples/topology` and can be applied to a `kind` based local setup.