### PR TITLE
fix: BCMSecret checks data only, but not stringData

### DIFF
--- a/internal/bmcutils/bmcutils.go
+++ b/internal/bmcutils/bmcutils.go
@@ -5,12 +5,18 @@ package bmcutils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/ironcore-dev/metal-operator/bmc"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	BmcSecretUsernameKey = "username"
+	BmcSecretPasswordKey = "password"
 )
 
 func GetProtocolScheme(scheme metalv1alpha1.ProtocolScheme, insecure bool) metalv1alpha1.ProtocolScheme {
@@ -25,15 +31,30 @@ func GetProtocolScheme(scheme metalv1alpha1.ProtocolScheme, insecure bool) metal
 
 func GetBMCCredentialsFromSecret(secret *metalv1alpha1.BMCSecret) (string, string, error) {
 	// TODO: use constants for secret keys
-	username, ok := secret.Data["username"]
-	if !ok {
-		return "", "", fmt.Errorf("no username found in the BMC secret")
+	username, err := getValueFromSecret(secret, BmcSecretUsernameKey)
+	if err != nil {
+		return "", "", err
 	}
-	password, ok := secret.Data["password"]
-	if !ok {
-		return "", "", fmt.Errorf("no password found in the BMC secret")
+	password, err := getValueFromSecret(secret, BmcSecretPasswordKey)
+	if err != nil {
+		return "", "", err
 	}
-	return string(username), string(password), nil
+	return username, password, nil
+}
+
+func getValueFromSecret(secret *metalv1alpha1.BMCSecret, key string) (string, error) {
+	if secret == nil {
+		return "", errors.New("secret cannot be nil")
+	}
+	value, ok := secret.Data[key]
+	if ok {
+		return string(value), nil
+	}
+	valueStr, ok := secret.StringData[key]
+	if ok {
+		return valueStr, nil
+	}
+	return "", fmt.Errorf("cannot find value in BMCSecret '%s' for key '%s' in data nor in stringData", secret.Name, key)
 }
 
 func GetBMCFromBMCName(ctx context.Context, c client.Client, bmcName string) (*metalv1alpha1.BMC, error) {


### PR DESCRIPTION
# Issue
When creating `BMCSecret` with `stringData` as described [metal_v1alpha1_bmcsecret.yaml](https://github.com/ironcore-dev/metal-operator/blob/main/config/samples/metal_v1alpha1_bmcsecret.yaml)

The data under `stringData` field is ignored.

# Fixes 
* Read data from both fields `stringData` and `data`.