### PR TITLE
Handle multiple mocked server in unit testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,4 @@ jobs:
 
       - name: Running Tests
         run: |
-          go mod tidy
-          make test
+          make test-only

--- a/bmc/mockup.go
+++ b/bmc/mockup.go
@@ -13,41 +13,51 @@ import (
 type RedfishMockUps struct {
 	mu sync.RWMutex
 
-	BIOSSettingAttr       map[string]map[string]any
-	PendingBIOSSetting    map[string]map[string]any
-	BIOSVersion           string
-	BIOSUpgradingVersion  string
-	BIOSUpgradeTaskIndex  int
+	BIOSSettingAttr       map[string]map[string]map[string]any
+	PendingBIOSSetting    map[string]map[string]map[string]any
+	BIOSVersion           map[string]string
+	BIOSUpgradingVersion  map[string]string
+	BIOSUpgradeTaskIndex  map[string]int
 	BIOSUpgradeTaskStatus []redfish.Task
 
-	BMCSettingAttr    map[string]map[string]any
-	PendingBMCSetting map[string]map[string]any
+	BMCSettingAttr    map[string]map[string]map[string]any
+	PendingBMCSetting map[string]map[string]map[string]any
 
-	BMCVersion           string
-	BMCUpgradingVersion  string
-	BMCUpgradeTaskIndex  int
+	BMCVersion           map[string]string
+	BMCUpgradingVersion  map[string]string
+	BMCUpgradeTaskIndex  map[string]int
 	BMCUpgradeTaskStatus []redfish.Task
 
-	SimulateUnvailableBMC bool
+	SimulateUnvailableBMC map[string]bool
 }
 
 func (r *RedfishMockUps) InitializeDefaults() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.BIOSSettingAttr = map[string]map[string]any{
-		"abc":       {"type": "string", "reboot": false, "value": "bar"},
-		"fooreboot": {"type": "integer", "reboot": true, "value": 123},
+	r.BIOSSettingAttr = map[string]map[string]map[string]any{
+		"default": {
+			"abc":       {"type": "string", "reboot": false, "value": "bar"},
+			"fooreboot": {"type": "integer", "reboot": true, "value": 123},
+		},
 	}
-	r.BMCSettingAttr = map[string]map[string]any{
-		"abc":       {"type": redfish.StringAttributeType, "reboot": false, "value": "bar"},
-		"fooreboot": {"type": redfish.IntegerAttributeType, "reboot": true, "value": 123},
+	r.BMCSettingAttr = map[string]map[string]map[string]any{
+		"default": {
+			"abc":       {"type": redfish.StringAttributeType, "reboot": false, "value": "bar"},
+			"fooreboot": {"type": redfish.IntegerAttributeType, "reboot": true, "value": 123},
+		},
 	}
-	r.PendingBIOSSetting = map[string]map[string]any{}
-	r.BIOSVersion = ""
-	r.BIOSUpgradingVersion = ""
+	r.PendingBIOSSetting = map[string]map[string]map[string]any{}
+	r.BIOSVersion = map[string]string{
+		"default": "",
+	}
+	r.BIOSUpgradingVersion = map[string]string{
+		"default": "",
+	}
 
-	r.BIOSUpgradeTaskIndex = 0
+	r.BIOSUpgradeTaskIndex = map[string]int{
+		"default": 0,
+	}
 	r.BIOSUpgradeTaskStatus = []redfish.Task{
 		{
 			TaskState:       redfish.NewTaskState,
@@ -79,12 +89,18 @@ func (r *RedfishMockUps) InitializeDefaults() {
 		},
 	}
 
-	r.PendingBMCSetting = map[string]map[string]any{}
+	r.PendingBMCSetting = map[string]map[string]map[string]any{}
 
-	r.BMCVersion = ""
-	r.BMCUpgradingVersion = ""
+	r.BMCVersion = map[string]string{
+		"default": "",
+	}
+	r.BMCUpgradingVersion = map[string]string{
+		"default": "",
+	}
 
-	r.BMCUpgradeTaskIndex = 0
+	r.BMCUpgradeTaskIndex = map[string]int{
+		"default": 0,
+	}
 	r.BMCUpgradeTaskStatus = []redfish.Task{
 		{
 			TaskState:       redfish.NewTaskState,
@@ -116,25 +132,29 @@ func (r *RedfishMockUps) InitializeDefaults() {
 		},
 	}
 
-	r.SimulateUnvailableBMC = false
+	r.SimulateUnvailableBMC = map[string]bool{
+		"default": false,
+	}
 }
 
 func (r *RedfishMockUps) ResetBIOSSettings() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.BIOSSettingAttr = map[string]map[string]any{
-		"abc":       {"type": "string", "reboot": false, "value": "bar"},
-		"fooreboot": {"type": "integer", "reboot": true, "value": 123},
+	r.BIOSSettingAttr = map[string]map[string]map[string]any{
+		"default": {
+			"abc":       {"type": "string", "reboot": false, "value": "bar"},
+			"fooreboot": {"type": "integer", "reboot": true, "value": 123},
+		},
 	}
-	r.PendingBIOSSetting = map[string]map[string]any{}
+	r.PendingBIOSSetting = map[string]map[string]map[string]any{}
 }
 
 func (r *RedfishMockUps) ResetPendingBIOSSetting() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.PendingBIOSSetting = map[string]map[string]any{}
+	r.PendingBIOSSetting = map[string]map[string]map[string]any{}
 }
 
 func (r *RedfishMockUps) ResetBIOSVersionUpdate() {
@@ -143,33 +163,44 @@ func (r *RedfishMockUps) ResetBIOSVersionUpdate() {
 
 	// NOTE: We do not call r.ResetBIOSSettings() here to avoid locking twice (deadlock/panic).
 	// Instead, we copy the logic directly, or ensure ResetBIOSSettings() does not lock itself.
-	r.BIOSSettingAttr = map[string]map[string]any{
-		"abc":       {"type": "string", "reboot": false, "value": "bar"},
-		"fooreboot": {"type": "integer", "reboot": true, "value": 123},
-	}
-	r.PendingBIOSSetting = map[string]map[string]any{}
 
-	r.BIOSUpgradeTaskIndex = 0
-	r.BIOSUpgradingVersion = ""
-	r.BIOSVersion = ""
+	r.BIOSSettingAttr = map[string]map[string]map[string]any{
+		"default": {
+			"abc":       {"type": "string", "reboot": false, "value": "bar"},
+			"fooreboot": {"type": "integer", "reboot": true, "value": 123},
+		},
+	}
+	r.PendingBIOSSetting = map[string]map[string]map[string]any{}
+
+	r.BIOSUpgradeTaskIndex = map[string]int{
+		"default": 0,
+	}
+	r.BIOSUpgradingVersion = map[string]string{
+		"default": "",
+	}
+	r.BIOSVersion = map[string]string{
+		"default": "",
+	}
 }
 
 func (r *RedfishMockUps) ResetPendingBMCSetting() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.PendingBMCSetting = map[string]map[string]any{}
+	r.PendingBMCSetting = map[string]map[string]map[string]any{}
 }
 
 func (r *RedfishMockUps) ResetBMCSettings() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.BMCSettingAttr = map[string]map[string]any{
-		"abc":       {"type": redfish.StringAttributeType, "reboot": false, "value": "bar"},
-		"fooreboot": {"type": redfish.IntegerAttributeType, "reboot": true, "value": 123},
+	r.BMCSettingAttr = map[string]map[string]map[string]any{
+		"default": {
+			"abc":       {"type": redfish.StringAttributeType, "reboot": false, "value": "bar"},
+			"fooreboot": {"type": redfish.IntegerAttributeType, "reboot": true, "value": 123},
+		},
 	}
-	r.PendingBMCSetting = map[string]map[string]any{}
+	r.PendingBMCSetting = map[string]map[string]map[string]any{}
 }
 
 func (r *RedfishMockUps) ResetBMCVersionUpdate() {
@@ -177,15 +208,23 @@ func (r *RedfishMockUps) ResetBMCVersionUpdate() {
 	defer r.mu.Unlock()
 
 	// NOTE: Copying logic from ResetBMCSettings to avoid double-locking.
-	r.BMCSettingAttr = map[string]map[string]any{
-		"abc":       {"type": redfish.StringAttributeType, "reboot": false, "value": "bar"},
-		"fooreboot": {"type": redfish.IntegerAttributeType, "reboot": true, "value": 123},
+	r.BMCSettingAttr = map[string]map[string]map[string]any{
+		"default": {
+			"abc":       {"type": redfish.StringAttributeType, "reboot": false, "value": "bar"},
+			"fooreboot": {"type": redfish.IntegerAttributeType, "reboot": true, "value": 123},
+		},
 	}
-	r.PendingBMCSetting = map[string]map[string]any{}
+	r.PendingBMCSetting = map[string]map[string]map[string]any{}
 
-	r.BMCVersion = ""
-	r.BMCUpgradingVersion = ""
-	r.BMCUpgradeTaskIndex = 0
+	r.BMCVersion = map[string]string{
+		"default": "",
+	}
+	r.BMCUpgradingVersion = map[string]string{
+		"default": "",
+	}
+	r.BMCUpgradeTaskIndex = map[string]int{
+		"default": 0,
+	}
 }
 
 func InitMockUp() {

--- a/bmc/redfish_local.go
+++ b/bmc/redfish_local.go
@@ -6,6 +6,7 @@ package bmc
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/ironcore-dev/metal-operator/bmc/common"
@@ -15,7 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var _ BMC = (*RedfishLocalBMC)(nil)
+// A Mutex to protect the shared mock state.
+var mockRWMutex sync.RWMutex
 
 // RedfishLocalBMC implements the BMC interface for Redfish.
 type RedfishLocalBMC struct {
@@ -39,7 +41,9 @@ func NewRedfishLocalBMCClient(ctx context.Context, options Options) (BMC, error)
 
 // setSystemPowerState updates the power state of a system.
 func (r *RedfishLocalBMC) setSystemPowerState(ctx context.Context, systemURI string, state redfish.PowerState) error {
-	// Apply a 150ms delay before performing the power state change.
+	mockRWMutex.Lock()
+	defer mockRWMutex.Unlock()
+
 	time.Sleep(150 * time.Millisecond)
 
 	system, err := r.getSystemFromUri(ctx, systemURI)
@@ -62,6 +66,9 @@ func (r *RedfishLocalBMC) PowerOn(ctx context.Context, systemURI string) error {
 			log.FromContext(ctx).Error(err, "PowerOn failed", "systemURI", systemURI)
 			return
 		}
+
+		mockRWMutex.Lock()
+		defer mockRWMutex.Unlock()
 
 		// Apply pending BIOS settings after a delay (mock for testing).
 		if len(UnitTestMockUps.PendingBIOSSetting) > 0 {
@@ -89,6 +96,9 @@ func (r *RedfishLocalBMC) PowerOff(ctx context.Context, systemURI string) error 
 
 // GetBiosPendingAttributeValues returns pending BIOS attribute values.
 func (r *RedfishLocalBMC) GetBiosPendingAttributeValues(ctx context.Context, systemUUID string) (redfish.SettingsAttributes, error) {
+	mockRWMutex.RLock()
+	defer mockRWMutex.RUnlock()
+
 	pending := UnitTestMockUps.PendingBIOSSetting
 	if len(pending) == 0 {
 		return redfish.SettingsAttributes{}, nil
@@ -103,6 +113,9 @@ func (r *RedfishLocalBMC) GetBiosPendingAttributeValues(ctx context.Context, sys
 
 // SetBiosAttributesOnReset sets BIOS attributes, applying them immediately or on next reset.
 func (r *RedfishLocalBMC) SetBiosAttributesOnReset(ctx context.Context, systemUUID string, attributes redfish.SettingsAttributes) error {
+	mockRWMutex.Lock()
+	defer mockRWMutex.Unlock()
+
 	UnitTestMockUps.ResetPendingBIOSSetting()
 	for key, value := range attributes {
 		if attrData, ok := UnitTestMockUps.BIOSSettingAttr[key]; ok {
@@ -126,6 +139,10 @@ func (r *RedfishLocalBMC) GetBiosAttributeValues(ctx context.Context, systemUUID
 		return nil, nil
 	}
 
+	mockRWMutex.RLock()
+	defer mockRWMutex.RUnlock()
+
+	// The rest of the function now operates on a consistent, locked view of the data.
 	filtered, err := r.getFilteredBiosRegistryAttributes(false, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get filtered BIOS attributes: %w", err)
@@ -182,9 +199,15 @@ func (r *RedfishLocalBMC) GetBiosVersion(ctx context.Context, systemUUID string)
 
 // UpgradeBiosVersion initiates a BIOS upgrade.
 func (r *RedfishLocalBMC) UpgradeBiosVersion(ctx context.Context, manufacturer string, params *redfish.SimpleUpdateParameters) (string, bool, error) {
+	mockRWMutex.Lock()
 	UnitTestMockUps.BIOSUpgradeTaskIndex = 0
 	UnitTestMockUps.BIOSUpgradingVersion = params.ImageURI
+	defer mockRWMutex.Unlock()
+
 	go func() {
+		mockRWMutex.Lock()
+		defer mockRWMutex.Unlock()
+
 		time.Sleep(20 * time.Millisecond)
 		for UnitTestMockUps.BIOSUpgradeTaskIndex < len(UnitTestMockUps.BIOSUpgradeTaskStatus)-1 {
 			time.Sleep(5 * time.Millisecond)
@@ -196,6 +219,9 @@ func (r *RedfishLocalBMC) UpgradeBiosVersion(ctx context.Context, manufacturer s
 
 // GetBiosUpgradeTask retrieves the status of a BIOS upgrade task.
 func (r *RedfishLocalBMC) GetBiosUpgradeTask(ctx context.Context, manufacturer, taskURI string) (*redfish.Task, error) {
+	mockRWMutex.Lock()
+	defer mockRWMutex.Unlock()
+
 	index := UnitTestMockUps.BIOSUpgradeTaskIndex
 	if index >= len(UnitTestMockUps.BIOSUpgradeTaskStatus) {
 		index = len(UnitTestMockUps.BIOSUpgradeTaskStatus) - 1
@@ -210,6 +236,9 @@ func (r *RedfishLocalBMC) GetBiosUpgradeTask(ctx context.Context, manufacturer, 
 // ResetManager resets the BMC with a delay for pending settings.
 func (r *RedfishLocalBMC) ResetManager(ctx context.Context, UUID string, resetType redfish.ResetType) error {
 	go func() {
+		mockRWMutex.Lock()
+		defer mockRWMutex.Unlock()
+
 		if len(UnitTestMockUps.PendingBMCSetting) > 0 {
 			time.Sleep(150 * time.Millisecond)
 			for key, data := range UnitTestMockUps.PendingBMCSetting {
@@ -317,9 +346,15 @@ func (r *RedfishLocalBMC) GetBMCVersion(ctx context.Context, systemUUID string) 
 
 // UpgradeBMCVersion initiates a BMC upgrade.
 func (r *RedfishLocalBMC) UpgradeBMCVersion(ctx context.Context, manufacturer string, params *redfish.SimpleUpdateParameters) (string, bool, error) {
+	mockRWMutex.Lock()
 	UnitTestMockUps.BMCUpgradeTaskIndex = 0
 	UnitTestMockUps.BMCUpgradingVersion = params.ImageURI
+	defer mockRWMutex.Unlock()
+
 	go func() {
+		mockRWMutex.Lock()
+		defer mockRWMutex.Unlock()
+
 		time.Sleep(20 * time.Millisecond)
 		for UnitTestMockUps.BMCUpgradeTaskIndex < len(UnitTestMockUps.BMCUpgradeTaskStatus)-1 {
 			time.Sleep(5 * time.Millisecond)
@@ -331,6 +366,9 @@ func (r *RedfishLocalBMC) UpgradeBMCVersion(ctx context.Context, manufacturer st
 
 // GetBMCUpgradeTask retrieves the status of a BMC upgrade task.
 func (r *RedfishLocalBMC) GetBMCUpgradeTask(ctx context.Context, manufacturer, taskURI string) (*redfish.Task, error) {
+	mockRWMutex.Lock()
+	defer mockRWMutex.Unlock()
+
 	index := UnitTestMockUps.BMCUpgradeTaskIndex
 	if index >= len(UnitTestMockUps.BMCUpgradeTaskStatus) {
 		index = len(UnitTestMockUps.BMCUpgradeTaskStatus) - 1

--- a/internal/controller/biossettingsset_controller_test.go
+++ b/internal/controller/biossettingsset_controller_test.go
@@ -25,16 +25,36 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 
 		BeforeEach(func(ctx SpecContext) {
 			By("Creating a BMCSecret")
-			bmcSecret := &metalv1alpha1.BMCSecret{
+			bmcSecret01 := &metalv1alpha1.BMCSecret{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 				},
 				Data: map[string][]byte{
-					metalv1alpha1.BMCSecretUsernameKeyName: []byte("foo"),
+					metalv1alpha1.BMCSecretUsernameKeyName: []byte("server01"),
 					metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
 				},
 			}
-			Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, bmcSecret01)).To(Succeed())
+			bmcSecret02 := &metalv1alpha1.BMCSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+				Data: map[string][]byte{
+					metalv1alpha1.BMCSecretUsernameKeyName: []byte("servero2"),
+					metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, bmcSecret02)).To(Succeed())
+			bmcSecret03 := &metalv1alpha1.BMCSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+				Data: map[string][]byte{
+					metalv1alpha1.BMCSecretUsernameKeyName: []byte("server03"),
+					metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, bmcSecret03)).To(Succeed())
 
 			By("Creating a Server")
 			server01 = &metalv1alpha1.Server{
@@ -54,7 +74,7 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 						},
 						Address: "127.0.0.1",
 						BMCSecretRef: v1.LocalObjectReference{
-							Name: bmcSecret.Name,
+							Name: bmcSecret01.Name,
 						},
 					},
 				},
@@ -79,7 +99,7 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 						},
 						Address: "127.0.0.1",
 						BMCSecretRef: v1.LocalObjectReference{
-							Name: bmcSecret.Name,
+							Name: bmcSecret02.Name,
 						},
 					},
 				},
@@ -104,7 +124,7 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 						},
 						Address: "127.0.0.1",
 						BMCSecretRef: v1.LocalObjectReference{
-							Name: bmcSecret.Name,
+							Name: bmcSecret03.Name,
 						},
 					},
 				},

--- a/internal/controller/biosversionset_controller_test.go
+++ b/internal/controller/biosversionset_controller_test.go
@@ -28,16 +28,36 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 		BeforeEach(func(ctx SpecContext) {
 			upgradeServerBiosVersion = "P80 v1.45 (12/06/2017)"
 			By("Creating a BMCSecret")
-			bmcSecret := &metalv1alpha1.BMCSecret{
+			bmcSecret01 := &metalv1alpha1.BMCSecret{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 				},
 				Data: map[string][]byte{
-					metalv1alpha1.BMCSecretUsernameKeyName: []byte("foo"),
+					metalv1alpha1.BMCSecretUsernameKeyName: []byte("server01"),
 					metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
 				},
 			}
-			Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, bmcSecret01)).To(Succeed())
+			bmcSecret02 := &metalv1alpha1.BMCSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+				Data: map[string][]byte{
+					metalv1alpha1.BMCSecretUsernameKeyName: []byte("server02"),
+					metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, bmcSecret02)).To(Succeed())
+			bmcSecret03 := &metalv1alpha1.BMCSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+				Data: map[string][]byte{
+					metalv1alpha1.BMCSecretUsernameKeyName: []byte("server03"),
+					metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, bmcSecret03)).To(Succeed())
 
 			By("Creating a Server01")
 			server01 = &metalv1alpha1.Server{
@@ -57,7 +77,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 						},
 						Address: "127.0.0.1",
 						BMCSecretRef: v1.LocalObjectReference{
-							Name: bmcSecret.Name,
+							Name: bmcSecret01.Name,
 						},
 					},
 				},
@@ -82,7 +102,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 						},
 						Address: "127.0.0.1",
 						BMCSecretRef: v1.LocalObjectReference{
-							Name: bmcSecret.Name,
+							Name: bmcSecret02.Name,
 						},
 					},
 				},
@@ -107,7 +127,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 						},
 						Address: "127.0.0.1",
 						BMCSecretRef: v1.LocalObjectReference{
-							Name: bmcSecret.Name,
+							Name: bmcSecret03.Name,
 						},
 					},
 				},

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -446,7 +446,6 @@ var _ = Describe("BMC Reset", func() {
 			DeleteAllMetalResources(ctx, ns.Name)
 		})
 		It("Should create ready conditions when there are bmc connection errors", func(ctx SpecContext) {
-			metalBmc.UnitTestMockUps.SimulateUnvailableBMC = true
 			By("Creating a BMCSecret")
 			bmcSecret := &metalv1alpha1.BMCSecret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -458,6 +457,7 @@ var _ = Describe("BMC Reset", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+			metalBmc.UnitTestMockUps.SimulateUnvailableBMC["foo"] = true
 
 			By("Creating a BMC resource")
 			bmc := &metalv1alpha1.BMC{
@@ -493,7 +493,7 @@ var _ = Describe("BMC Reset", func() {
 				)),
 			)
 
-			metalBmc.UnitTestMockUps.SimulateUnvailableBMC = false
+			metalBmc.UnitTestMockUps.SimulateUnvailableBMC["foo"] = false
 
 			By("Ensuring right conditions are present, after bmc becomes responsive again")
 			Eventually(Object(bmc)).Should(

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -844,7 +844,7 @@ func (r *BMCSettingsReconciler) enqueueBMCSettingsByServerRefs(
 	host := obj.(*metalv1alpha1.Server)
 
 	// return early if hosts are not required states
-	if host.Status.State != metalv1alpha1.ServerStateMaintenance {
+	if host.Status.State != metalv1alpha1.ServerStateMaintenance || host.Spec.ServerMaintenanceRef == nil {
 		return nil
 	}
 

--- a/internal/controller/bmcversionset_controller_test.go
+++ b/internal/controller/bmcversionset_controller_test.go
@@ -19,384 +19,382 @@ import (
 )
 
 var _ = Describe("BMCVersionSet Controller", func() {
-	Context("When reconciling a resource", func() {
-		ns := SetupTest()
+	ns := SetupTest()
 
-		var bmc01 *metalv1alpha1.BMC
-		var bmc02 *metalv1alpha1.BMC
-		var bmc03 *metalv1alpha1.BMC
-		var upgradeServerBMCVersion string
+	var bmc01 *metalv1alpha1.BMC
+	var bmc02 *metalv1alpha1.BMC
+	var bmc03 *metalv1alpha1.BMC
+	var upgradeServerBMCVersion string
 
-		BeforeEach(func(ctx SpecContext) {
-			upgradeServerBMCVersion = "1.46.455b66-rev4"
-			By("Creating a BMCSecret")
-			bmcSecret := &metalv1alpha1.BMCSecret{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-",
+	BeforeEach(func(ctx SpecContext) {
+		upgradeServerBMCVersion = "1.46.455b66-rev4"
+		By("Creating a BMCSecret")
+		bmcSecret := &metalv1alpha1.BMCSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+			Data: map[string][]byte{
+				metalv1alpha1.BMCSecretUsernameKeyName: []byte("foo"),
+				metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+		By("Creating a bmc01")
+		bmc01 = &metalv1alpha1.BMC{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-bmc-01-",
+				Namespace:    ns.Name,
+				Labels: map[string]string{
+					"metal.ironcore.dev/Manufacturer": "foo",
 				},
-				Data: map[string][]byte{
-					metalv1alpha1.BMCSecretUsernameKeyName: []byte("foo"),
-					metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
+			},
+			Spec: metalv1alpha1.BMCSpec{
+				Endpoint: &metalv1alpha1.InlineEndpoint{
+					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					MACAddress: "23:11:8A:33:CF:EA",
 				},
-			}
-			Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
-
-			By("Creating a bmc01")
-			bmc01 = &metalv1alpha1.BMC{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-bmc-01-",
-					Namespace:    ns.Name,
-					Labels: map[string]string{
-						"metal.ironcore.dev/Manufacturer": "foo",
-					},
+				Protocol: metalv1alpha1.Protocol{
+					Name: metalv1alpha1.ProtocolRedfishLocal,
+					Port: 8000,
 				},
-				Spec: metalv1alpha1.BMCSpec{
-					Endpoint: &metalv1alpha1.InlineEndpoint{
-						IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
-						MACAddress: "23:11:8A:33:CF:EA",
-					},
-					Protocol: metalv1alpha1.Protocol{
-						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
-					},
-					BMCSecretRef: v1.LocalObjectReference{
-						Name: bmcSecret.Name,
-					},
+				BMCSecretRef: v1.LocalObjectReference{
+					Name: bmcSecret.Name,
 				},
-			}
-			Expect(k8sClient.Create(ctx, bmc01)).To(Succeed())
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmc01)).To(Succeed())
 
-			By("Creating a bmc02")
-			bmc02 = &metalv1alpha1.BMC{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-bmc-01-",
-					Namespace:    ns.Name,
-					Labels: map[string]string{
-						"metal.ironcore.dev/Manufacturer": "bar",
-					},
-				},
-				Spec: metalv1alpha1.BMCSpec{
-					Endpoint: &metalv1alpha1.InlineEndpoint{
-						IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
-						MACAddress: "23:11:8A:33:CF:EA",
-					},
-					Protocol: metalv1alpha1.Protocol{
-						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
-					},
-					BMCSecretRef: v1.LocalObjectReference{
-						Name: bmcSecret.Name,
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, bmc02)).To(Succeed())
-
-			By("Creating a bmc03")
-			bmc03 = &metalv1alpha1.BMC{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-bmc-01-",
-					Namespace:    ns.Name,
-					Labels: map[string]string{
-						"metal.ironcore.dev/Manufacturer": "bar",
-					},
-				},
-				Spec: metalv1alpha1.BMCSpec{
-					Endpoint: &metalv1alpha1.InlineEndpoint{
-						IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
-						MACAddress: "23:11:8A:33:CF:EA",
-					},
-					Protocol: metalv1alpha1.Protocol{
-						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
-					},
-					BMCSecretRef: v1.LocalObjectReference{
-						Name: bmcSecret.Name,
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, bmc03)).To(Succeed())
-		})
-
-		AfterEach(func(ctx SpecContext) {
-			DeleteAllMetalResources(ctx, ns.Name)
-			bmc.UnitTestMockUps.ResetBMCVersionUpdate()
-		})
-		It("should successfully reconcile the resource", func(ctx SpecContext) {
-			By("Created resource")
-			bmcVersionSet := &metalv1alpha1.BMCVersionSet{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-bmcversion-set-",
-					Namespace:    ns.Name,
-				},
-				Spec: metalv1alpha1.BMCVersionSetSpec{
-					BMCVersionTemplate: metalv1alpha1.BMCVersionTemplate{
-						Version:                 upgradeServerBMCVersion,
-						Image:                   metalv1alpha1.ImageSpec{URI: upgradeServerBMCVersion},
-						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
-					},
-					BMCSelector: metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"metal.ironcore.dev/Manufacturer": "bar",
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, bmcVersionSet)).To(Succeed())
-
-			By("Ensuring that the BMCVersion resource has been created")
-			var bmcVersionList metalv1alpha1.BMCVersionList
-			Eventually(ObjectList(&bmcVersionList)).Should(HaveField("Items", HaveLen(2)))
-
-			By("Checking if the BMCVersion has been created")
-			bmcVersion02 := &metalv1alpha1.BMCVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: bmcVersionList.Items[0].Name,
-				},
-			}
-			Eventually(Get(bmcVersion02)).Should(Succeed())
-
-			By("Checking if the 2nd BMCVersion has been created")
-			bmcVersion03 := &metalv1alpha1.BMCVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: bmcVersionList.Items[1].Name,
-				},
-			}
-			Eventually(Get(bmcVersion03)).Should(Succeed())
-
-			By("Checking if the status has been updated")
-			Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
-				HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 2)),
-				HaveField("Status.AvailableBMCVersion", BeNumerically("==", 2)),
-				HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
-			))
-
-			By("Checking the bmcVersion02 have completed")
-			Eventually(Object(bmcVersion02)).Should(SatisfyAll(
-				HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
-				HaveField("Spec.Version", bmcVersionSet.Spec.BMCVersionTemplate.Version),
-				HaveField("Spec.Image.URI", bmcVersionSet.Spec.BMCVersionTemplate.Image.URI),
-				HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-					APIVersion:         "metal.ironcore.dev/v1alpha1",
-					Kind:               "BMCVersionSet",
-					Name:               bmcVersionSet.Name,
-					UID:                bmcVersionSet.UID,
-					Controller:         ptr.To(true),
-					BlockOwnerDeletion: ptr.To(true),
-				})),
-			))
-
-			By("Checking the bmcVersion03 have completed")
-			Eventually(Object(bmcVersion03)).Should(SatisfyAll(
-				HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
-				HaveField("Spec.Version", bmcVersionSet.Spec.BMCVersionTemplate.Version),
-				HaveField("Spec.Image.URI", bmcVersionSet.Spec.BMCVersionTemplate.Image.URI),
-				HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-					APIVersion:         "metal.ironcore.dev/v1alpha1",
-					Kind:               "BMCVersionSet",
-					Name:               bmcVersionSet.Name,
-					UID:                bmcVersionSet.UID,
-					Controller:         ptr.To(true),
-					BlockOwnerDeletion: ptr.To(true),
-				})),
-			))
-
-			By("Checking if the status has been updated")
-			Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
-				HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 2)),
-				HaveField("Status.AvailableBMCVersion", BeNumerically("==", 2)),
-				HaveField("Status.CompletedBMCVersion", BeNumerically("==", 2)),
-				HaveField("Status.InProgressBMCVersion", BeNumerically("==", 0)),
-				HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
-			))
-
-			By("Deleting the resource")
-			Expect(k8sClient.Delete(ctx, bmcVersionSet)).To(Succeed())
-		})
-
-		It("should successfully reconcile the resource when BMC are deleted/created", func(ctx SpecContext) {
-			By("Create resource")
-			bmcVersionSet := &metalv1alpha1.BMCVersionSet{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-bmcsversion-set-",
-					Namespace:    ns.Name,
-				},
-				Spec: metalv1alpha1.BMCVersionSetSpec{
-					BMCVersionTemplate: metalv1alpha1.BMCVersionTemplate{
-						Version:                 upgradeServerBMCVersion,
-						Image:                   metalv1alpha1.ImageSpec{URI: upgradeServerBMCVersion},
-						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
-					},
-					BMCSelector: metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"metal.ironcore.dev/Manufacturer": "bar",
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, bmcVersionSet)).To(Succeed())
-
-			By("Ensuring that the BMCVersion resource has been created")
-			var bmcVersionList metalv1alpha1.BMCVersionList
-			Eventually(ObjectList(&bmcVersionList)).Should(HaveField("Items", HaveLen(2)))
-
-			By("Checking if the BMCVersion has been created")
-			bmcVersion02 := &metalv1alpha1.BMCVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: bmcVersionList.Items[0].Name,
-				},
-			}
-			Eventually(Get(bmcVersion02)).Should(Succeed())
-
-			By("Checking if the 2nd BMCVersion has been created")
-			bmcVersion03 := &metalv1alpha1.BMCVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: bmcVersionList.Items[1].Name,
-				},
-			}
-			Eventually(Get(bmcVersion03)).Should(Succeed())
-
-			By("Checking if the status has been updated")
-			Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
-				HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 2)),
-				HaveField("Status.AvailableBMCVersion", BeNumerically("==", 2)),
-				HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
-			))
-
-			By("Checking the bmcVersion02 have completed")
-			Eventually(Object(bmcVersion02)).Should(SatisfyAll(
-				HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
-				HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-					APIVersion:         "metal.ironcore.dev/v1alpha1",
-					Kind:               "BMCVersionSet",
-					Name:               bmcVersionSet.Name,
-					UID:                bmcVersionSet.UID,
-					Controller:         ptr.To(true),
-					BlockOwnerDeletion: ptr.To(true),
-				})),
-			))
-
-			By("Checking the bmcVersion03 have completed")
-			Eventually(Object(bmcVersion03)).Should(SatisfyAll(
-				HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
-				HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-					APIVersion:         "metal.ironcore.dev/v1alpha1",
-					Kind:               "BMCVersionSet",
-					Name:               bmcVersionSet.Name,
-					UID:                bmcVersionSet.UID,
-					Controller:         ptr.To(true),
-					BlockOwnerDeletion: ptr.To(true),
-				})),
-			))
-
-			By("Checking if the status has been updated")
-			Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
-				HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 2)),
-				HaveField("Status.AvailableBMCVersion", BeNumerically("==", 2)),
-				HaveField("Status.CompletedBMCVersion", BeNumerically("==", 2)),
-				HaveField("Status.InProgressBMCVersion", BeNumerically("==", 0)),
-				HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
-			))
-
-			BMCToDelete := &metalv1alpha1.BMC{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: bmcVersion02.Spec.BMCRef.Name,
-				},
-			}
-
-			By(fmt.Sprintf("Deleting one of the BMC %v", BMCToDelete.Name))
-			Eventually(Get(BMCToDelete)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, BMCToDelete)).To(Succeed())
-
-			By("Checking if the BMCVersion have been deleted")
-			Eventually(Get(bmcVersion02)).ShouldNot(Succeed())
-			Eventually(Get(bmcVersion03)).Should(Succeed())
-
-			By("Checking if the status has been updated")
-			Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
-				HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 1)),
-				HaveField("Status.AvailableBMCVersion", BeNumerically("==", 1)),
-				HaveField("Status.CompletedBMCVersion", BeNumerically("==", 1)),
-				HaveField("Status.InProgressBMCVersion", BeNumerically("==", 0)),
-				HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
-			))
-
-			By("creating the deleted BMC")
-			BMCToDelete.ResourceVersion = ""
-			BMCToDelete.Spec.BMCSettingRef = nil
-			BMCToDelete.Spec.Endpoint = bmc02.Spec.Endpoint
-			Expect(k8sClient.Create(ctx, BMCToDelete)).Should(Succeed())
-
-			By("Ensuring that the BMCVersion resource has been created")
-			Eventually(ObjectList(&bmcVersionList)).Should(HaveField("Items", HaveLen(2)))
-
-			By("Checking if the BMCVersion has been created")
-			bmcVersion02 = &metalv1alpha1.BMCVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: bmcVersionList.Items[0].Name,
-				},
-			}
-			Eventually(Get(bmcVersion02)).Should(Succeed())
-
-			By("Checking if the 2nd BMCVersion has been created")
-			bmcVersion03 = &metalv1alpha1.BMCVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: bmcVersionList.Items[1].Name,
-				},
-			}
-			Eventually(Get(bmcVersion03)).Should(Succeed())
-
-			By("Checking the bmcVersion02 have completed")
-			Eventually(Object(bmcVersion02)).Should(
-				HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
-			)
-
-			By("Checking if the status has been updated")
-			Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
-				HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 2)),
-				HaveField("Status.AvailableBMCVersion", BeNumerically("==", 2)),
-				HaveField("Status.CompletedBMCVersion", BeNumerically("==", 2)),
-				HaveField("Status.InProgressBMCVersion", BeNumerically("==", 0)),
-				HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
-			))
-
-			By("Updating the label of BMC01")
-			Eventually(Update(bmc01, func() {
-				bmc01.Labels = map[string]string{
+		By("Creating a bmc02")
+		bmc02 = &metalv1alpha1.BMC{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-bmc-01-",
+				Namespace:    ns.Name,
+				Labels: map[string]string{
 					"metal.ironcore.dev/Manufacturer": "bar",
-				}
-			})).Should(Succeed())
-
-			By("Ensuring that the BMCVersion resource has been created")
-			Eventually(ObjectList(&bmcVersionList)).Should(HaveField("Items", HaveLen(3)))
-
-			By("Checking if the 3rd BMCVersion has been created")
-			bmcVersion01 := &metalv1alpha1.BMCVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: bmcVersionList.Items[2].Name,
 				},
+			},
+			Spec: metalv1alpha1.BMCSpec{
+				Endpoint: &metalv1alpha1.InlineEndpoint{
+					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					MACAddress: "23:11:8A:33:CF:EA",
+				},
+				Protocol: metalv1alpha1.Protocol{
+					Name: metalv1alpha1.ProtocolRedfishLocal,
+					Port: 8000,
+				},
+				BMCSecretRef: v1.LocalObjectReference{
+					Name: bmcSecret.Name,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmc02)).To(Succeed())
+
+		By("Creating a bmc03")
+		bmc03 = &metalv1alpha1.BMC{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-bmc-01-",
+				Namespace:    ns.Name,
+				Labels: map[string]string{
+					"metal.ironcore.dev/Manufacturer": "bar",
+				},
+			},
+			Spec: metalv1alpha1.BMCSpec{
+				Endpoint: &metalv1alpha1.InlineEndpoint{
+					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					MACAddress: "23:11:8A:33:CF:EA",
+				},
+				Protocol: metalv1alpha1.Protocol{
+					Name: metalv1alpha1.ProtocolRedfishLocal,
+					Port: 8000,
+				},
+				BMCSecretRef: v1.LocalObjectReference{
+					Name: bmcSecret.Name,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmc03)).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		DeleteAllMetalResources(ctx, ns.Name)
+		bmc.UnitTestMockUps.ResetBMCVersionUpdate()
+	})
+	It("should successfully reconcile the resource", func(ctx SpecContext) {
+		By("Created resource")
+		bmcVersionSet := &metalv1alpha1.BMCVersionSet{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-bmcversion-set-",
+				Namespace:    ns.Name,
+			},
+			Spec: metalv1alpha1.BMCVersionSetSpec{
+				BMCVersionTemplate: metalv1alpha1.BMCVersionTemplate{
+					Version:                 upgradeServerBMCVersion,
+					Image:                   metalv1alpha1.ImageSpec{URI: upgradeServerBMCVersion},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+				BMCSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"metal.ironcore.dev/Manufacturer": "bar",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcVersionSet)).To(Succeed())
+
+		By("Ensuring that the BMCVersion resource has been created")
+		var bmcVersionList metalv1alpha1.BMCVersionList
+		Eventually(ObjectList(&bmcVersionList)).Should(HaveField("Items", HaveLen(2)))
+
+		By("Checking if the BMCVersion has been created")
+		bmcVersion02 := &metalv1alpha1.BMCVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bmcVersionList.Items[0].Name,
+			},
+		}
+		Eventually(Get(bmcVersion02)).Should(Succeed())
+
+		By("Checking if the 2nd BMCVersion has been created")
+		bmcVersion03 := &metalv1alpha1.BMCVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bmcVersionList.Items[1].Name,
+			},
+		}
+		Eventually(Get(bmcVersion03)).Should(Succeed())
+
+		By("Checking if the status has been updated")
+		Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
+			HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 2)),
+			HaveField("Status.AvailableBMCVersion", BeNumerically("==", 2)),
+			HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
+		))
+
+		By("Checking the bmcVersion02 have completed")
+		Eventually(Object(bmcVersion02)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
+			HaveField("Spec.Version", bmcVersionSet.Spec.BMCVersionTemplate.Version),
+			HaveField("Spec.Image.URI", bmcVersionSet.Spec.BMCVersionTemplate.Image.URI),
+			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
+				APIVersion:         "metal.ironcore.dev/v1alpha1",
+				Kind:               "BMCVersionSet",
+				Name:               bmcVersionSet.Name,
+				UID:                bmcVersionSet.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			})),
+		))
+
+		By("Checking the bmcVersion03 have completed")
+		Eventually(Object(bmcVersion03)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
+			HaveField("Spec.Version", bmcVersionSet.Spec.BMCVersionTemplate.Version),
+			HaveField("Spec.Image.URI", bmcVersionSet.Spec.BMCVersionTemplate.Image.URI),
+			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
+				APIVersion:         "metal.ironcore.dev/v1alpha1",
+				Kind:               "BMCVersionSet",
+				Name:               bmcVersionSet.Name,
+				UID:                bmcVersionSet.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			})),
+		))
+
+		By("Checking if the status has been updated")
+		Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
+			HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 2)),
+			HaveField("Status.AvailableBMCVersion", BeNumerically("==", 2)),
+			HaveField("Status.CompletedBMCVersion", BeNumerically("==", 2)),
+			HaveField("Status.InProgressBMCVersion", BeNumerically("==", 0)),
+			HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
+		))
+
+		By("Deleting the resource")
+		Expect(k8sClient.Delete(ctx, bmcVersionSet)).To(Succeed())
+	})
+
+	It("should successfully reconcile the resource when BMC are deleted/created", func(ctx SpecContext) {
+		By("Create resource")
+		bmcVersionSet := &metalv1alpha1.BMCVersionSet{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-bmcsversion-set-",
+				Namespace:    ns.Name,
+			},
+			Spec: metalv1alpha1.BMCVersionSetSpec{
+				BMCVersionTemplate: metalv1alpha1.BMCVersionTemplate{
+					Version:                 upgradeServerBMCVersion,
+					Image:                   metalv1alpha1.ImageSpec{URI: upgradeServerBMCVersion},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+				BMCSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"metal.ironcore.dev/Manufacturer": "bar",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcVersionSet)).To(Succeed())
+
+		By("Ensuring that the BMCVersion resource has been created")
+		var bmcVersionList metalv1alpha1.BMCVersionList
+		Eventually(ObjectList(&bmcVersionList)).Should(HaveField("Items", HaveLen(2)))
+
+		By("Checking if the BMCVersion has been created")
+		bmcVersion02 := &metalv1alpha1.BMCVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bmcVersionList.Items[0].Name,
+			},
+		}
+		Eventually(Get(bmcVersion02)).Should(Succeed())
+
+		By("Checking if the 2nd BMCVersion has been created")
+		bmcVersion03 := &metalv1alpha1.BMCVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bmcVersionList.Items[1].Name,
+			},
+		}
+		Eventually(Get(bmcVersion03)).Should(Succeed())
+
+		By("Checking if the status has been updated")
+		Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
+			HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 2)),
+			HaveField("Status.AvailableBMCVersion", BeNumerically("==", 2)),
+			HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
+		))
+
+		By("Checking the bmcVersion02 have completed")
+		Eventually(Object(bmcVersion02)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
+			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
+				APIVersion:         "metal.ironcore.dev/v1alpha1",
+				Kind:               "BMCVersionSet",
+				Name:               bmcVersionSet.Name,
+				UID:                bmcVersionSet.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			})),
+		))
+
+		By("Checking the bmcVersion03 have completed")
+		Eventually(Object(bmcVersion03)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
+			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
+				APIVersion:         "metal.ironcore.dev/v1alpha1",
+				Kind:               "BMCVersionSet",
+				Name:               bmcVersionSet.Name,
+				UID:                bmcVersionSet.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			})),
+		))
+
+		By("Checking if the status has been updated")
+		Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
+			HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 2)),
+			HaveField("Status.AvailableBMCVersion", BeNumerically("==", 2)),
+			HaveField("Status.CompletedBMCVersion", BeNumerically("==", 2)),
+			HaveField("Status.InProgressBMCVersion", BeNumerically("==", 0)),
+			HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
+		))
+
+		BMCToDelete := &metalv1alpha1.BMC{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bmcVersion02.Spec.BMCRef.Name,
+			},
+		}
+
+		By(fmt.Sprintf("Deleting one of the BMC %v", BMCToDelete.Name))
+		Eventually(Get(BMCToDelete)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, BMCToDelete)).To(Succeed())
+
+		By("Checking if the BMCVersion have been deleted")
+		Eventually(Get(bmcVersion02)).ShouldNot(Succeed())
+		Eventually(Get(bmcVersion03)).Should(Succeed())
+
+		By("Checking if the status has been updated")
+		Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
+			HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 1)),
+			HaveField("Status.AvailableBMCVersion", BeNumerically("==", 1)),
+			HaveField("Status.CompletedBMCVersion", BeNumerically("==", 1)),
+			HaveField("Status.InProgressBMCVersion", BeNumerically("==", 0)),
+			HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
+		))
+
+		By("creating the deleted BMC")
+		BMCToDelete.ResourceVersion = ""
+		BMCToDelete.Spec.BMCSettingRef = nil
+		BMCToDelete.Spec.Endpoint = bmc02.Spec.Endpoint
+		Expect(k8sClient.Create(ctx, BMCToDelete)).Should(Succeed())
+
+		By("Ensuring that the BMCVersion resource has been created")
+		Eventually(ObjectList(&bmcVersionList)).Should(HaveField("Items", HaveLen(2)))
+
+		By("Checking if the BMCVersion has been created")
+		bmcVersion02 = &metalv1alpha1.BMCVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bmcVersionList.Items[0].Name,
+			},
+		}
+		Eventually(Get(bmcVersion02)).Should(Succeed())
+
+		By("Checking if the 2nd BMCVersion has been created")
+		bmcVersion03 = &metalv1alpha1.BMCVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bmcVersionList.Items[1].Name,
+			},
+		}
+		Eventually(Get(bmcVersion03)).Should(Succeed())
+
+		By("Checking the bmcVersion02 have completed")
+		Eventually(Object(bmcVersion02)).Should(
+			HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
+		)
+
+		By("Checking if the status has been updated")
+		Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
+			HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 2)),
+			HaveField("Status.AvailableBMCVersion", BeNumerically("==", 2)),
+			HaveField("Status.CompletedBMCVersion", BeNumerically("==", 2)),
+			HaveField("Status.InProgressBMCVersion", BeNumerically("==", 0)),
+			HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
+		))
+
+		By("Updating the label of BMC01")
+		Eventually(Update(bmc01, func() {
+			bmc01.Labels = map[string]string{
+				"metal.ironcore.dev/Manufacturer": "bar",
 			}
-			Eventually(Get(bmcVersion01)).Should(Succeed())
+		})).Should(Succeed())
 
-			By("Checking if the status has been updated")
-			Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
-				HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 3)),
-				HaveField("Status.AvailableBMCVersion", BeNumerically("==", 3)),
-				HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
-			))
+		By("Ensuring that the BMCVersion resource has been created")
+		Eventually(ObjectList(&bmcVersionList)).Should(HaveField("Items", HaveLen(3)))
 
-			By("Checking the bmcVersion01 have completed")
-			Eventually(Object(bmcVersion01)).Should(
-				HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
-			)
+		By("Checking if the 3rd BMCVersion has been created")
+		bmcVersion01 := &metalv1alpha1.BMCVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bmcVersionList.Items[2].Name,
+			},
+		}
+		Eventually(Get(bmcVersion01)).Should(Succeed())
 
-			By("Checking if the status has been updated")
-			Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
-				HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 3)),
-				HaveField("Status.AvailableBMCVersion", BeNumerically("==", 3)),
-				HaveField("Status.CompletedBMCVersion", BeNumerically("==", 3)),
-				HaveField("Status.InProgressBMCVersion", BeNumerically("==", 0)),
-				HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
-			))
-		})
+		By("Checking if the status has been updated")
+		Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
+			HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 3)),
+			HaveField("Status.AvailableBMCVersion", BeNumerically("==", 3)),
+			HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
+		))
+
+		By("Checking the bmcVersion01 have completed")
+		Eventually(Object(bmcVersion01)).Should(
+			HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
+		)
+
+		By("Checking if the status has been updated")
+		Eventually(Object(bmcVersionSet)).Should(SatisfyAll(
+			HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 3)),
+			HaveField("Status.AvailableBMCVersion", BeNumerically("==", 3)),
+			HaveField("Status.CompletedBMCVersion", BeNumerically("==", 3)),
+			HaveField("Status.InProgressBMCVersion", BeNumerically("==", 0)),
+			HaveField("Status.FailedBMCVersion", BeNumerically("==", 0)),
+		))
 	})
 })

--- a/internal/controller/bmcversionset_controller_test.go
+++ b/internal/controller/bmcversionset_controller_test.go
@@ -29,16 +29,36 @@ var _ = Describe("BMCVersionSet Controller", func() {
 	BeforeEach(func(ctx SpecContext) {
 		upgradeServerBMCVersion = "1.46.455b66-rev4"
 		By("Creating a BMCSecret")
-		bmcSecret := &metalv1alpha1.BMCSecret{
+		bmcSecret01 := &metalv1alpha1.BMCSecret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-",
 			},
 			Data: map[string][]byte{
-				metalv1alpha1.BMCSecretUsernameKeyName: []byte("foo"),
+				metalv1alpha1.BMCSecretUsernameKeyName: []byte("BMC01"),
 				metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
 			},
 		}
-		Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+		Expect(k8sClient.Create(ctx, bmcSecret01)).To(Succeed())
+		bmcSecret02 := &metalv1alpha1.BMCSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+			Data: map[string][]byte{
+				metalv1alpha1.BMCSecretUsernameKeyName: []byte("BMC02"),
+				metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcSecret02)).To(Succeed())
+		bmcSecret03 := &metalv1alpha1.BMCSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+			Data: map[string][]byte{
+				metalv1alpha1.BMCSecretUsernameKeyName: []byte("BMC03"),
+				metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcSecret03)).To(Succeed())
 
 		By("Creating a bmc01")
 		bmc01 = &metalv1alpha1.BMC{
@@ -59,7 +79,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 					Port: 8000,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
-					Name: bmcSecret.Name,
+					Name: bmcSecret01.Name,
 				},
 			},
 		}
@@ -84,7 +104,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 					Port: 8000,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
-					Name: bmcSecret.Name,
+					Name: bmcSecret02.Name,
 				},
 			},
 		}
@@ -109,7 +129,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 					Port: 8000,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
-					Name: bmcSecret.Name,
+					Name: bmcSecret03.Name,
 				},
 			},
 		}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	//+kubebuilder:scaffold:imports
 )
@@ -117,6 +119,8 @@ func deleteAndList(ctx context.Context, obj client.Object, objList client.Object
 }
 
 var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},


### PR DESCRIPTION
# Proposed Changes
 handle multiple mocked server in unit testing. by creating mock data for each mocked server
the distinction is based on bmc user for the mocked server in unit test 