### PR TITLE
Add `boot-operator` and `maintenance-operator` to tilt setup

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -9,6 +9,8 @@ settings = {
         "kind-metal"
     ],
     "kubectl": "./bin/kubectl",
+    "local_boot_operator": "", # example: "/path/to/boot-operator"
+    "local_maintenance_operator": "", # example: "/path/to/maintenance-operator"
     "boot_image": "ghcr.io/ironcore-dev/boot-operator:latest",
     "cert_manager_version": "v1.15.3",
     "new_args": {
@@ -16,13 +18,24 @@ settings = {
         "--health-probe-bind-address=:8081",
         "--metrics-bind-address=127.0.0.1:8085",
         "--leader-elect",
-#        "--default-ipxe-server-url=http://boot-service:30007",
-#        "--default-kernel-url=http://boot-service:30007/image?imageName=ghcr.io/ironcore-dev/os-images/gardenlinux&version=1443.10&layerName=vmlinuz",
-#        "--default-initrd-url=http://boot-service:30007/image?imageName=ghcr.io/ironcore-dev/os-images/gardenlinux&version=1443.10&layerName=initramfs",
-#        "--default-squashfs-url=http://boot-service:30007/image?imageName=ghcr.io/ironcore-dev/os-images/gardenlinux&version=1443.10&layerName=squashfs",
         "--ipxe-service-url=http://boot-service:30007",
         "--ipxe-service-port=30007",
         "--controllers=ipxebootconfig,serverbootconfigpxe,serverbootconfighttp,httpbootconfig",
+        ],
+        "maintenance": [
+        "--health-probe-bind-address=:8081",
+        "--metrics-bind-address=127.0.0.1:8085",
+        ],
+        "metal": [
+         "--health-probe-bind-address=:8081",
+         "--metrics-bind-address=127.0.0.1:8080",
+         "--leader-elect",
+         "--mac-prefixes-file=/etc/macdb/macdb.yaml",
+         "--probe-image=ghcr.io/ironcore-dev/metalprobe:latest",
+         "--probe-os-image=ghcr.io/ironcore-dev/os-images/gardenlinux:1877.0",
+         "--registry-url=http://127.0.0.1:30000",
+         "--registry-port=30000",
+         "--enforce-first-boot",
         ],
     }
 }
@@ -82,8 +95,38 @@ deploy_cert_manager()
 
 docker_build('controller', '.', target = 'manager')
 
-deploy_boot()
+yaml_metal = kustomize('./config/dev')
+new_args = settings.get("new_args").get("metal")
+if new_args:
+    yaml_metal = encode_yaml_stream(decode_yaml_stream(str(yaml_metal).replace("- args: []", "- args: {}".format(new_args))))
+    print("default metal yaml {}\n".format(yaml_metal))
+k8s_yaml(yaml_metal)
 
-yaml = kustomize('./config/dev')
+if settings.get("local_boot_operator") != "":
+    local_boot_operator = settings.get("local_boot_operator")
+    print("Using local boot-operator from {}".format(local_boot_operator))
+    docker_build('boot-controller', local_boot_operator)
+    yaml_boot = kustomize(local_boot_operator + "/config/dev")
+    new_args = settings.get("new_args").get("boot")
+    if new_args:
+        yaml_boot = encode_yaml_stream(decode_yaml_stream(str(yaml_boot).replace("- args: []", "- args: {}".format(new_args))))
+        print("default boot yaml {}\n".format(yaml_boot))
+    k8s_yaml(yaml_boot)
+else:
+    print("Using remote boot-operator image {}".format(settings.get("boot_image")))
+    deploy_boot()
 
-k8s_yaml(yaml)
+if settings.get("local_maintenance_operator") != "":
+    local_maintenance_operator = settings.get("local_maintenance_operator")
+    print("Using local maintenance-operator from {}".format(local_maintenance_operator))
+    docker_build('maintenance-controller', local_maintenance_operator)
+    yaml_maintenance = kustomize(local_maintenance_operator + '/config/dev')
+    new_args = settings.get("new_args").get("maintenance")
+    if new_args:
+        yaml_maintenance = encode_yaml_stream(decode_yaml_stream(str(yaml_maintenance).replace("- args: []", "- args: {}".format(new_args))))
+        print("default maintenance yaml {}\n".format(yaml_maintenance))
+    k8s_yaml(yaml_maintenance)
+else:
+    print("Using remote maintenance-operator image {}".format(settings.get("boot_image")))
+    # Use the remote images once available
+    # deploy_boot_operator()

--- a/config/dev/manager_patch.yaml
+++ b/config/dev/manager_patch.yaml
@@ -8,16 +8,6 @@ spec:
     spec:
       containers:
       - name: manager
-        args:
-          - --health-probe-bind-address=:8081
-          - --metrics-bind-address=127.0.0.1:8080
-          - --leader-elect
-          - --mac-prefixes-file=/etc/macdb/macdb.yaml
-          - --probe-image=ghcr.io/ironcore-dev/metalprobe:latest
-          - --probe-os-image=ghcr.io/ironcore-dev/os-images/gardenlinux:1877.0
-          - --registry-url=http://127.0.0.1:30000
-          - --registry-port=30000
-          - --enforce-first-boot
         ports:
         - containerPort: 30000
         volumeMounts:


### PR DESCRIPTION
# Proposed Changes
give option to run tilt-up using local boot-operator and maintenace-operator

<img width="1684" height="1025" alt="Screenshot 2025-10-14 at 16 12 41" src="https://github.com/user-attachments/assets/4d196ca4-3816-4543-821e-5a4b408c20b0" />
