### PR TITLE
Add registry server `Service` to Helm chart

### DIFF
--- a/dist/chart/templates/registry-service/service.yaml
+++ b/dist/chart/templates/registry-service/service.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.registry.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: metal-registry
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: registry
+    port: {{ .Values.registry.port }}
+    protocol: TCP
+    targetPort: {{ .Values.registry.port }}
+  selector:
+    control-plane: controller-manager
+  type: ClusterIP
+{{ end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -44,6 +44,10 @@ controllerManager:
   serviceAccountName: metal-operator-controller-manager
   hostNetwork: true
 
+registry:
+  enabled: false
+  port: 30000
+
 # [RBAC]: To enable RBAC (Permissions) configurations
 rbac:
   enable: true


### PR DESCRIPTION
# Proposed Changes

Add the ability to deploy the registry server service as a configurable option in the helm chart