### PR TITLE
Customization of default discovery Ignition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ FROM gcr.io/distroless/static:nonroot AS manager
 LABEL source_repository="https://github.com/ironcore-dev/metal-operator"
 WORKDIR /
 COPY --from=manager-builder /workspace/manager .
+COPY config/manager/ignition-template.yaml /etc/metal-operator/ignition-template.yaml
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -61,16 +61,16 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	"$(CONTROLLER_GEN)" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen goimports ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
-	$(GOIMPORTS) -w .
+	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	"$(GOIMPORTS)" -w .
 
 .PHONY: fmt
 fmt: goimports ## Run goimports against code.
-	$(GOIMPORTS) -w .
+	"$(GOIMPORTS)" -w .
 
 .PHONY: vet
 vet: ## Run go vet against code.
@@ -81,8 +81,8 @@ check-gen: generate manifests docs helm fmt ## Run code generation, manifests ge
 
 .PHONY: test-only
 test-only: setup-envtest ginkgo ## Run tests without generating manifests or code.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	$(GINKGO) --fail-fast --cover --coverprofile=cover.out --skip-package=e2e ./...
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" \
+	"$(GINKGO)" --fail-fast --cover --coverprofile=cover.out --skip-package=e2e ./...
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest test-only ## Run tests.
@@ -125,15 +125,15 @@ stopbmc: ## Stop BMC emulator
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
-	$(GOLANGCI_LINT) run --max-same-issues=0
+	"$(GOLANGCI_LINT)" run --max-same-issues=0
 
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
-	$(GOLANGCI_LINT) run --fix
+	"$(GOLANGCI_LINT)" run --fix
 
 .PHONY: lint-config
 lint-config: golangci-lint ## Verify golangci-lint linter configuration
-	$(GOLANGCI_LINT) config verify
+	"$(GOLANGCI_LINT)" config verify
 
 .PHONY: startdocs
 startdocs: ## Start the local mkdocs based development environment.
@@ -146,11 +146,11 @@ cleandocs: ## Remove all local mkdocs Docker images (cleanup).
 
 .PHONY: add-license
 add-license: addlicense ## Add license headers to all go files.
-	find . -name '*.go' -exec $(ADDLICENSE) -f hack/license-header.txt {} +
+	find . -name '*.go' -exec "$(ADDLICENSE)" -f hack/license-header.txt {} +
 
 .PHONY: check-license
 check-license: addlicense ## Check that every file has a license header present.
-	find . -name '*.go' -exec $(ADDLICENSE) -check -c 'IronCore authors' {} +
+	find . -name '*.go' -exec "$(ADDLICENSE)" -check -c 'IronCore authors' {} +
 
 .PHONY: check
 check: generate manifests add-license fmt lint test # Generate manifests, code, lint, add licenses, test
@@ -159,7 +159,7 @@ check: generate manifests add-license fmt lint test # Generate manifests, code, 
 
 .PHONY: docs
 docs: crd-ref-docs ## Run go generate to generate API reference documentation.
-	$(CRD_REF_DOCS) --source-path=./api/v1alpha1 --config=./hack/api-reference/config.yaml --renderer=markdown --output-path=./docs/api-reference/api.md
+	"$(CRD_REF_DOCS)" --source-path=./api/v1alpha1 --config=./hack/api-reference/config.yaml --renderer=markdown --output-path=./docs/api-reference/api.md
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
@@ -213,8 +213,8 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG}
-	$(KUSTOMIZE) build config/default > dist/install.yaml
+	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${CONTROLLER_IMG}
+	"$(KUSTOMIZE)" build config/default > dist/install.yaml
 
 ##@ Deployment
 
@@ -224,29 +224,29 @@ endif
 
 .PHONY: install
 install: manifests kustomize kubectl ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	"$(KUSTOMIZE)" build config/crd | "$(KUBECTL)" apply -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	"$(KUSTOMIZE)" build config/crd | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${CONTROLLER_IMG}
+	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" apply -f -
 
 .PHONY: e2e-deploy
 e2e-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG}
-	$(KUSTOMIZE) build config/e2e-metrics-validation | $(KUBECTL) apply -f -
+	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${CONTROLLER_IMG}
+	"$(KUSTOMIZE)" build config/e2e-metrics-validation | "$(KUBECTL)" apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: helm
 helm: manifests kubebuilder
-	$(KUBEBUILDER) edit --plugins=helm/v1-alpha
+	"$(KUBEBUILDER)" edit --plugins=helm/v1-alpha
 
 ##@ Dependencies
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,6 +78,7 @@ func main() { // nolint: gocyclo
 		webhookPort                        int
 		enforceFirstBoot                   bool
 		enforcePowerOff                    bool
+		discoveryIgnitionPath              string
 		serverResyncInterval               time.Duration
 		maintenanceResyncInterval          time.Duration
 		powerPollingInterval               time.Duration
@@ -117,6 +118,8 @@ func main() { // nolint: gocyclo
 		"Defines the duration which the bmc waits before reconciling again when bmc has been reset.")
 	flag.DurationVar(&maintenanceResyncInterval, "maintenance-resync-interval", 2*time.Minute,
 		"Defines the interval at which the CRD performing maintenance is polled during server maintenance task.")
+	flag.StringVar(&discoveryIgnitionPath, "discovery-ignition-path", "/etc/metal-operator/ignition-template.yaml",
+		"Path to the ignition template file.")
 	flag.StringVar(&registryURL, "registry-url", "", "The URL of the registry.")
 	flag.StringVar(&registryProtocol, "registry-protocol", "http", "The protocol to use for the registry.")
 	flag.IntVar(&registryPort, "registry-port", 10000, "The port to use for the registry.")
@@ -368,6 +371,7 @@ func main() { // nolint: gocyclo
 		EnforcePowerOff:         enforcePowerOff,
 		MaxConcurrentReconciles: serverMaxConcurrentReconciles,
 		Conditions:              conditionutils.NewAccessor(conditionutils.AccessorOptions{}),
+		DiscoveryIgnitionPath:   discoveryIgnitionPath,
 		BMCOptions: bmc.Options{
 			BasicAuth:               true,
 			PowerPollingInterval:    powerPollingInterval,

--- a/config/manager/ignition-template.yaml
+++ b/config/manager/ignition-template.yaml
@@ -1,0 +1,44 @@
+variant: fcos
+version: "1.3.0"
+systemd:
+  units:
+    - name: docker-install.service
+      enabled: true
+      contents: |-
+        [Unit]
+        Description=Install Docker
+        Before=metalprobe.service
+        [Service]
+        Restart=on-failure
+        RestartSec=20
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/bin/apt-get update
+        ExecStart=/usr/bin/apt-get install docker.io docker-cli -y
+        [Install]
+        WantedBy=multi-user.target
+    - name: docker.service
+      enabled: true
+    - name: metalprobe.service
+      enabled: true
+      contents: |-
+        [Unit]
+        Description=Run Metalprobe Docker Container
+        [Service]
+        Restart=on-failure
+        RestartSec=20
+        ExecStartPre=-/usr/bin/docker stop metalprobe
+        ExecStartPre=-/usr/bin/docker rm metalprobe
+        ExecStartPre=/usr/bin/docker pull {{.Image}}
+        ExecStart=/usr/bin/docker run --network host --privileged --name metalprobe {{.Image}} {{.Flags}}
+        ExecStop=/usr/bin/docker stop metalprobe
+        [Install]
+        WantedBy=multi-user.target
+storage:
+  files: []
+passwd:
+  users:
+    - name: metal
+      password_hash: {{.PasswordHash}}
+      groups: [ "wheel" ]
+      ssh_authorized_keys: [ {{.SSHPublicKey}} ]

--- a/dist/chart/templates/configmap/ignition-template.yaml
+++ b/dist/chart/templates/configmap/ignition-template.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ignition.override }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chart.name" . }}-ignition-template
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+data:
+  # The Ignition template has the following parameters substituted at runtime:
+  # {{.Image}} - The Docker image to run for metalprobe
+  # {{.Flags}} - The flags to pass to the metalprobe container, this includes --registry-url and --server-uuid
+  # {{.SSHPublicKey}} - The SSH public key for the 'metal' user
+  # {{.PasswordHash}} - The password hash for the 'metal' user
+  ignition-template.yaml: |
+{{ .Values.ignition.template | indent 4 }}
+{{- end }}

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -64,6 +64,10 @@ spec:
         {{- if .Values.controllerManager.dnsRecordTemplate.enabled }}
         - mountPath: /etc/metal-operator/dns
           name: dns-record-template
+        {{- end }}
+        {{- if .Values.ignition.override }}
+        - name: ignition-template
+          mountPath: /etc/metal-operator
           readOnly: true
         {{- end }}
         {{- if and .Values.webhook.enable .Values.certmanager.enable }}
@@ -96,6 +100,11 @@ spec:
       - name: dns-record-template
         configMap:
           name: dns-record-template
+      {{- end }}
+      {{- if .Values.ignition.override }}
+      - name: ignition-template
+        configMap:
+          name: {{ include "chart.name" . }}-ignition-template
       {{- end }}
       {{- if and .Values.webhook.enable .Values.certmanager.enable }}
       - name: webhook-cert

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -91,3 +91,14 @@ certmanager:
 # [NETWORK POLICIES]: To enable NetworkPolicies set true
 networkPolicy:
   enable: false
+
+# [IGNITION]: Ignition template configuration
+# By default, the operator uses a template file baked into the container at /etc/metal-operator/ignition-template.yaml
+# Enable this to override the template by mounting a ConfigMap at that location
+ignition:
+  # Set to true to override the default ignition template with a custom one.
+  override: false
+  # Template content that can be customized - this will be created as a ConfigMap
+  # and mounted to override the default template
+  # template: |
+    

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -75,6 +75,197 @@ helm uninstall metal-operator
 
 This will remove all the resources associated with the Metal Operator.
 
+## Ignition Template Customization
+
+The metal-operator uses [Ignition](https://coreos.github.io/ignition/) templates to configure bare metal servers during their first boot. The operator includes a default template file in the container at `/etc/metal-operator/ignition-template.yaml`. You can optionally override this template by mounting a ConfigMap at the same location.
+
+### Configuration
+
+The ignition configuration is controlled by the `ignition` section in `values.yaml`:
+
+```yaml
+ignition:
+  override: false       # Enable/disable ignition ConfigMap override (default: false)
+  template: |           # The actual Ignition template content (only used when override: true)
+    # Your custom Ignition template here
+```
+
+**Default Behavior**: When `ignition.override: false` (default), the operator uses the template file in the container image at `/etc/metal-operator/ignition-template.yaml`.
+
+**Override Behavior**: When `ignition.override: true`, a ConfigMap is created and mounted to `/etc/metal-operator/ignition-template.yaml`, replacing the default template file.
+
+### Template Variables
+
+Your custom template must include these template variables for proper operation:
+
+- <span v-pre>`{{.Image}}`</span> - Docker image for the metalprobe container
+- <span v-pre>`{{.Flags}}`</span> - Command-line flags for metalprobe (includes --registry-url and --server-uuid)
+- <span v-pre>`{{.SSHPublicKey}}`</span> - SSH public key for server access
+- <span v-pre>`{{.PasswordHash}}`</span> - Bcrypt hash of the user password
+
+### Example: Custom Template
+
+```yaml
+ignition:
+  override: true
+  template: |
+    variant: fcos
+    version: "1.3.0"
+    systemd:
+      units:
+        - name: metalprobe.service
+          enabled: true
+          contents: |-
+            [Unit]
+            Description=Metal Probe Service
+            [Service]
+            Restart=on-failure
+            ExecStartPre=/usr/bin/docker pull {{.Image}}
+            ExecStart=/usr/bin/docker run --name metalprobe {{.Image}} {{.Flags}}
+            [Install]
+            WantedBy=multi-user.target
+    passwd:
+      users:
+        - name: metal
+          password_hash: {{.PasswordHash}}
+          groups: [ "wheel" ]
+          ssh_authorized_keys: [ {{.SSHPublicKey}} ]
+```
+
+### Using Default Template (Recommended)
+
+```bash
+helm install metal-operator dist/chart
+```
+
+This uses the template file in the container image. No ConfigMap is created, and the operator works immediately with the default configuration.
+
+### Using Custom Template Override
+
+1. Enable ignition customization:
+```bash
+helm install metal-operator dist/chart --set ignition.override=true
+```
+
+2. Or create a custom values file:
+```bash
+cp dist/chart/values.yaml my-values.yaml
+# Edit my-values.yaml with your customizations
+```
+
+3. Deploy with custom values:
+```bash
+helm install metal-operator dist/chart -f my-values.yaml
+```
+
+### Upgrading Template
+
+To update just the template content:
+
+```bash
+helm upgrade metal-operator dist/chart -f my-values.yaml
+```
+
+The ConfigMap will be updated and new server provisioning will use the updated template.
+
+### Advanced Customization
+
+#### Adding Custom Services
+
+You can add additional systemd services to the template:
+
+```yaml
+systemd:
+  units:
+    - name: my-custom-service.service
+      enabled: true
+      contents: |-
+        [Unit]
+        Description=My Custom Service
+        [Service]
+        Type=simple
+        ExecStart=/usr/local/bin/my-script.sh
+        [Install]
+        WantedBy=multi-user.target
+```
+
+#### Custom Storage Configuration
+
+Modify the storage section to add custom files and filesystems:
+
+```yaml
+storage:
+  files:
+    - path: /etc/my-config.conf
+      mode: 0644
+      contents:
+        inline: |
+          # My custom configuration
+          key=value
+  filesystems:
+    - name: data
+      device: /dev/sdb
+      format: ext4
+```
+
+#### Multiple Users
+
+Add additional users to the system:
+
+```yaml
+passwd:
+  users:
+    - name: metal
+      password_hash: {{.PasswordHash}}
+      groups: [ "wheel" ]
+      ssh_authorized_keys: [ {{.SSHPublicKey}} ]
+    - name: admin
+      password_hash: {{.PasswordHash}}
+      groups: [ "wheel", "sudo" ]
+      ssh_authorized_keys: [ {{.SSHPublicKey}} ]
+```
+
+### Troubleshooting
+
+#### Template File Not Found
+
+If you see errors about template file not being found:
+
+1. Verify the default file exists in the container:
+```bash
+kubectl exec -n <namespace> deployment/metal-operator-controller-manager -- ls -la /etc/metal-operator/
+```
+
+2. If using ConfigMap override, verify it was created and mounted:
+```bash
+kubectl get configmap -n <namespace>
+kubectl describe deployment -n <namespace> metal-operator-controller-manager
+```
+
+3. Check the manager logs:
+```bash
+kubectl logs -n <namespace> deployment/metal-operator-controller-manager
+```
+
+#### Template Syntax Errors
+
+If ignition generation fails due to template syntax:
+
+1. Validate your template syntax offline
+2. Check that all required template variables are included
+3. Verify the Ignition format is valid
+4. If using a custom template, ensure the ConfigMap is properly mounted
+
+#### Volume Mount Issues
+
+If the ConfigMap override is not working:
+1. Verify the ConfigMap is mounted correctly:
+```bash
+kubectl describe pod -n <namespace> -l control-plane=controller-manager
+```
+2. Check that `ignition.override: true` is set in values
+3. Verify RBAC permissions include ConfigMap access
+
 ## Additional Information
 
 For more detailed information, refer to the official documentation and Helm chart repository.

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -94,6 +94,7 @@ type ServerReconciler struct {
 	DiscoveryTimeout        time.Duration
 	MaxConcurrentReconciles int
 	Conditions              *conditionutils.Accessor
+	DiscoveryIgnitionPath   string
 }
 
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcs,verbs=get;list;watch
@@ -720,14 +721,20 @@ func (r *ServerReconciler) generateDefaultIgnitionDataForServer(flags string, ss
 		return nil, fmt.Errorf("failed to generate password hash: %w", err)
 	}
 
-	ignitionData, err := ignition.GenerateDefaultIgnitionData(ignition.Config{
+	config := ignition.Config{
 		Image:        r.ProbeImage,
 		Flags:        flags,
 		SSHPublicKey: string(sshPublicKey),
 		PasswordHash: string(passwordHash),
-	})
+	}
+
+	// Load ignition template from file
+	ignitionData, err := ignition.GenerateIgnitionDataFromFile(
+		r.DiscoveryIgnitionPath,
+		config,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate default ignition data: %w", err)
+		return nil, fmt.Errorf("failed to generate ignition data from file %s: %w", r.DiscoveryIgnitionPath, err)
 	}
 
 	return ignitionData, nil
@@ -1143,6 +1150,11 @@ func (r *ServerReconciler) checkLastStatusUpdateAfter(duration time.Duration, se
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Validate DiscoveryIgnitionPath is set and accessible
+	if err := r.validateDiscoveryIgnitionPath(); err != nil {
+		return fmt.Errorf("invalid DiscoveryIgnitionPath configuration: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.MaxConcurrentReconciles,
@@ -1153,6 +1165,20 @@ func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			r.enqueueServerByServerBootConfiguration(),
 		).
 		Complete(r)
+}
+
+// validateDiscoveryIgnitionPath ensures the DiscoveryIgnitionPath is set and accessible
+func (r *ServerReconciler) validateDiscoveryIgnitionPath() error {
+	if r.DiscoveryIgnitionPath == "" {
+		return fmt.Errorf("DiscoveryIgnitionPath is empty; must be set to a valid ignition template file path")
+	}
+
+	// Attempt to validate file accessibility by performing a test read
+	if err := ignition.ValidateIgnitionTemplatePath(r.DiscoveryIgnitionPath); err != nil {
+		return fmt.Errorf("DiscoveryIgnitionPath %q is not accessible or not a valid template: %w", r.DiscoveryIgnitionPath, err)
+	}
+
+	return nil
 }
 
 func (r *ServerReconciler) enqueueServerByServerBootConfiguration() handler.EventHandler {

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -25,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
@@ -192,12 +195,16 @@ var _ = Describe("Server Controller", func() {
 		err = bcrypt.CompareHashAndPassword([]byte(passwordHash), sshSecret.Data[SSHKeyPairSecretPasswordKeyName])
 		Expect(err).ToNot(HaveOccurred(), "passwordHash should match the expected password")
 
-		ignitionData, err := ignition.GenerateDefaultIgnitionData(ignition.Config{
-			Image:        "foo:latest",
-			Flags:        "--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
-			SSHPublicKey: string(sshSecret.Data[SSHKeyPairSecretPublicKeyName]),
-			PasswordHash: passwordHash,
-		})
+		// Generate expected ignition data using the same template file the controller uses
+		ignitionData, err := ignition.GenerateIgnitionDataFromFile(
+			filepath.Join("..", "..", "config", "manager", "ignition-template.yaml"),
+			ignition.Config{
+				Image:        "foo:latest",
+				Flags:        "--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				SSHPublicKey: string(sshSecret.Data[SSHKeyPairSecretPublicKeyName]),
+				PasswordHash: passwordHash,
+			},
+		)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(Object(ignitionSecret)).Should(SatisfyAll(
@@ -386,12 +393,16 @@ var _ = Describe("Server Controller", func() {
 
 		Expect(bcrypt.CompareHashAndPassword([]byte(passwordHash), sshSecret.Data[SSHKeyPairSecretPasswordKeyName])).Should(Succeed())
 
-		ignitionData, err := ignition.GenerateDefaultIgnitionData(ignition.Config{
-			Image:        "foo:latest",
-			Flags:        "--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
-			SSHPublicKey: string(sshSecret.Data[SSHKeyPairSecretPublicKeyName]),
-			PasswordHash: passwordHash,
-		})
+		// Generate expected ignition data using the same template file the controller uses
+		ignitionData, err := ignition.GenerateIgnitionDataFromFile(
+			filepath.Join("..", "..", "config", "manager", "ignition-template.yaml"),
+			ignition.Config{
+				Image:        "foo:latest",
+				Flags:        "--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				SSHPublicKey: string(sshSecret.Data[SSHKeyPairSecretPublicKeyName]),
+				PasswordHash: passwordHash,
+			},
+		)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(Object(ignitionSecret)).Should(SatisfyAll(
@@ -917,6 +928,287 @@ var _ = Describe("Server Controller", func() {
 		Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
 		Expect(k8sClient.Delete(ctx, ignitionSecret)).Should(Succeed())
 	})
+
+	Context("File-based Ignition Templates", func() {
+		var bmcSecret *metalv1alpha1.BMCSecret
+		var server *metalv1alpha1.Server
+
+		BeforeEach(func(ctx SpecContext) {
+			By("Creating a BMCSecret")
+			bmcSecret = &metalv1alpha1.BMCSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-server-",
+				},
+				Data: map[string][]byte{
+					"username": []byte("foo"),
+					"password": []byte("bar"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+			By("Creating a Server with inline BMC configuration")
+			server = &metalv1alpha1.Server{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "server-",
+				},
+				Spec: metalv1alpha1.ServerSpec{
+					SystemUUID: "38947555-7742-3448-3784-823347823834",
+					BMC: &metalv1alpha1.BMCAccess{
+						Protocol: metalv1alpha1.Protocol{
+							Name: metalv1alpha1.ProtocolRedfishLocal,
+							Port: MockServerPort,
+						},
+						Address: MockServerIP,
+						BMCSecretRef: v1.LocalObjectReference{
+							Name: bmcSecret.Name,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		})
+
+		AfterEach(func(ctx SpecContext) {
+			By("Cleaning up test resources")
+			if server != nil {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, server))).To(Succeed())
+			}
+			if bmcSecret != nil {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcSecret))).To(Succeed())
+			}
+		})
+
+		It("Should use custom file template when available", func(ctx SpecContext) {
+			By("Creating a custom ignition template file")
+			customTemplate := `variant: fcos
+version: "1.4.0"
+systemd:
+  units:
+    - name: custom-metalprobe.service
+      enabled: true
+      contents: |-
+        [Unit]
+        Description=Custom Metal Probe Service
+        [Service]
+        Restart=on-failure
+        RestartSec=30
+        ExecStartPre=/usr/bin/docker pull {{.Image}}
+        ExecStart=/usr/bin/docker run --network host --privileged --name custom-metalprobe {{.Image}} {{.Flags}}
+        ExecStop=/usr/bin/docker stop custom-metalprobe
+        [Install]
+        WantedBy=multi-user.target
+passwd:
+  users:
+    - name: custom-metal
+      password_hash: {{.PasswordHash}}
+      groups: [ "wheel", "docker" ]
+      ssh_authorized_keys: [ {{.SSHPublicKey}} ]`
+
+			tmpFile, err := os.CreateTemp("", "ignition-template-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(os.Remove, tmpFile.Name())
+
+			_, err = tmpFile.WriteString(customTemplate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tmpFile.Close()).To(Succeed())
+
+			By("Creating a ServerReconciler with file path")
+			reconciler := &ServerReconciler{
+				Client:                k8sClient,
+				Scheme:                k8sClient.Scheme(),
+				RegistryURL:           registryURL,
+				ManagerNamespace:      ns.Name,
+				ProbeImage:            "foo:latest",
+				DiscoveryIgnitionPath: tmpFile.Name(),
+			}
+
+			By("Generating ignition data with custom file")
+			ignitionData, err := reconciler.generateDefaultIgnitionDataForServer(
+				"--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				[]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC test@example.com"),
+				[]byte("testpassword"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ignitionData).NotTo(BeEmpty())
+
+			ignitionStr := string(ignitionData)
+			Expect(ignitionStr).To(ContainSubstring("version: \"1.4.0\""))
+			Expect(ignitionStr).To(ContainSubstring("custom-metalprobe.service"))
+			Expect(ignitionStr).To(ContainSubstring("Custom Metal Probe Service"))
+			Expect(ignitionStr).To(ContainSubstring("custom-metal"))
+			Expect(ignitionStr).To(ContainSubstring("RestartSec=30"))
+		})
+
+		It("Should fallback with error when file is missing", func(ctx SpecContext) {
+			By("Creating a ServerReconciler with non-existent file path")
+			reconciler := &ServerReconciler{
+				Client:                k8sClient,
+				Scheme:                k8sClient.Scheme(),
+				RegistryURL:           registryURL,
+				ManagerNamespace:      ns.Name,
+				ProbeImage:            "foo:latest",
+				DiscoveryIgnitionPath: "/nonexistent/path/ignition.yaml",
+			}
+
+			By("Generating ignition data (should fail)")
+			_, err := reconciler.generateDefaultIgnitionDataForServer(
+				"--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				[]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC test@example.com"),
+				[]byte("testpassword"),
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to generate ignition data from file"))
+		})
+
+		It("Should fail when file template is invalid", func(ctx SpecContext) {
+			By("Creating a file with invalid template")
+			invalidTemplate := `variant: fcos
+systemd:
+  units:
+    - name: broken-service
+      contents: {{.InvalidTemplateField}}`
+
+			tmpFile, err := os.CreateTemp("", "invalid-template-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(os.Remove, tmpFile.Name())
+
+			_, err = tmpFile.WriteString(invalidTemplate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tmpFile.Close()).To(Succeed())
+
+			By("Creating a ServerReconciler with invalid template file")
+			reconciler := &ServerReconciler{
+				Client:                k8sClient,
+				Scheme:                k8sClient.Scheme(),
+				RegistryURL:           registryURL,
+				ManagerNamespace:      ns.Name,
+				ProbeImage:            "foo:latest",
+				DiscoveryIgnitionPath: tmpFile.Name(),
+			}
+
+			By("Generating ignition data (should fail)")
+			_, err = reconciler.generateDefaultIgnitionDataForServer(
+				"--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				[]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC test@example.com"),
+				[]byte("testpassword"),
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to generate ignition data from file"))
+		})
+
+		It("Should use default ignition template from file", func(ctx SpecContext) {
+			By("Creating a default ignition template file")
+			defaultTemplate := `variant: fcos
+version: "1.3.0"
+systemd:
+  units:
+    - name: metalprobe.service
+      enabled: true
+      contents: |-
+        [Unit]
+        Description=Metal Probe Service
+        [Service]
+        ExecStart=/usr/bin/docker run --name metalprobe {{.Image}} {{.Flags}}
+        [Install]
+        WantedBy=multi-user.target
+passwd:
+  users:
+    - name: metal
+      password_hash: {{.PasswordHash}}
+      ssh_authorized_keys: [ {{.SSHPublicKey}} ]`
+
+			tmpFile, err := os.CreateTemp("", "default-ignition-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(os.Remove, tmpFile.Name())
+
+			_, err = tmpFile.WriteString(defaultTemplate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tmpFile.Close()).To(Succeed())
+
+			By("Creating a ServerReconciler with default file path")
+			reconciler := &ServerReconciler{
+				Client:                k8sClient,
+				Scheme:                k8sClient.Scheme(),
+				RegistryURL:           registryURL,
+				ManagerNamespace:      ns.Name,
+				ProbeImage:            "foo:latest",
+				DiscoveryIgnitionPath: tmpFile.Name(),
+			}
+
+			By("Generating ignition data (should use default template)")
+			ignitionData, err := reconciler.generateDefaultIgnitionDataForServer(
+				"--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				[]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC test@example.com"),
+				[]byte("testpassword"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ignitionData).NotTo(BeEmpty())
+
+			// Should contain default template content
+			ignitionStr := string(ignitionData)
+			Expect(ignitionStr).To(ContainSubstring("version: \"1.3.0\""))
+			Expect(ignitionStr).To(ContainSubstring("metalprobe.service"))
+			Expect(ignitionStr).To(ContainSubstring("name: metal"))
+		})
+
+		It("Should create server with custom ignition template file end-to-end", func(ctx SpecContext) {
+			By("Creating a custom ignition template file")
+			customTemplate := `variant: fcos
+version: "1.5.0"
+systemd:
+  units:
+    - name: e2e-custom-probe.service
+      enabled: true
+      contents: |-
+        [Unit]
+        Description=E2E Custom Probe Service
+        [Service]
+        Restart=always
+        ExecStart=/usr/bin/docker run --name e2e-probe {{.Image}} {{.Flags}}
+        [Install]
+        WantedBy=multi-user.target
+passwd:
+  users:
+    - name: e2e-user
+      password_hash: {{.PasswordHash}}
+      ssh_authorized_keys: [ {{.SSHPublicKey}} ]`
+
+			tmpFile, err := os.CreateTemp("", "e2e-ignition-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(os.Remove, tmpFile.Name())
+
+			_, err = tmpFile.WriteString(customTemplate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tmpFile.Close()).To(Succeed())
+
+			By("Creating a reconciler with custom ignition template path")
+			customReconciler := &ServerReconciler{
+				Client:                k8sClient,
+				Scheme:                k8sClient.Scheme(),
+				RegistryURL:           registryURL,
+				ManagerNamespace:      ns.Name,
+				ProbeImage:            "custom-probe:v1.0.0",
+				Insecure:              true,
+				DiscoveryIgnitionPath: tmpFile.Name(),
+			}
+
+			By("Generating ignition data with custom template")
+			ignitionData, err := customReconciler.generateDefaultIgnitionDataForServer(
+				"--registry-url=http://localhost:30000 --server-uuid=e2e-test-12345",
+				[]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC test@example.com"),
+				[]byte("testpassword"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ignitionData).NotTo(BeEmpty())
+
+			ignitionStr := string(ignitionData)
+			Expect(ignitionStr).To(ContainSubstring("version: \"1.5.0\""), "Should use custom template version")
+			Expect(ignitionStr).To(ContainSubstring("e2e-custom-probe.service"), "Should use custom service name")
+			Expect(ignitionStr).To(ContainSubstring("E2E Custom Probe Service"), "Should use custom description")
+			Expect(ignitionStr).To(ContainSubstring("e2e-user"), "Should use custom username")
+			Expect(ignitionStr).To(ContainSubstring("custom-probe:v1.0.0"), "Should include custom probe image")
+		})
+	})
 })
 
 func deleteRegistrySystemIfExists(systemUUID string) {
@@ -929,8 +1221,8 @@ func deleteRegistrySystemIfExists(systemUUID string) {
 		if err != nil {
 			return
 		}
-		client := &http.Client{}
-		resp, err := client.Do(req)
+		httpClient := &http.Client{}
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			return
 		}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -198,7 +198,8 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 				PowerPollingTimeout:  200 * time.Millisecond,
 				BasicAuth:            true,
 			},
-			DiscoveryTimeout: time.Second, // Force timeout to be quick for tests
+			DiscoveryTimeout:      time.Second, // Force timeout to be quick for tests
+			DiscoveryIgnitionPath: filepath.Join("..", "..", "config", "manager", "ignition-template.yaml"),
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
 		Expect((&ServerClaimReconciler{

--- a/internal/ignition/default_test.go
+++ b/internal/ignition/default_test.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package ignition
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestIgnition(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ignition Suite")
+}
+
+var _ = Describe("Ignition Template Generation", func() {
+	var (
+		testConfig Config
+	)
+
+	BeforeEach(func() {
+		testConfig = Config{
+			Image:        "test-image:latest",
+			Flags:        "--test-flag=value",
+			SSHPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... test@example.com",
+			PasswordHash: "$2a$10$abcdefghijklmnopqrstuvwxyz",
+		}
+	})
+
+	Context("GenerateIgnitionDataFromFile", func() {
+		It("should generate ignition data from file template", func() {
+			customTemplate := `variant: fcos
+version: "1.4.0"
+systemd:
+  units:
+    - name: custom-service.service
+      enabled: true
+      contents: |-
+        [Unit]
+        Description=Custom Service
+        [Service]
+        ExecStart=/usr/bin/docker run {{.Image}} {{.Flags}}
+        [Install]
+        WantedBy=multi-user.target
+passwd:
+  users:
+    - name: custom-user
+      password_hash: {{.PasswordHash}}
+      ssh_authorized_keys: [ {{.SSHPublicKey}} ]`
+
+			tmpFile, err := os.CreateTemp("", "ignition-template-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(os.Remove, tmpFile.Name())
+
+			_, err = tmpFile.WriteString(customTemplate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tmpFile.Close()).To(Succeed())
+
+			data, err := GenerateIgnitionDataFromFile(tmpFile.Name(), testConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data).NotTo(BeEmpty())
+
+			ignitionStr := string(data)
+			Expect(ignitionStr).To(ContainSubstring("version: \"1.4.0\""))
+			Expect(ignitionStr).To(ContainSubstring("custom-service.service"))
+			Expect(ignitionStr).To(ContainSubstring("test-image:latest"))
+			Expect(ignitionStr).To(ContainSubstring("custom-user"))
+		})
+
+		It("should return error when file does not exist", func() {
+			_, err := GenerateIgnitionDataFromFile("/nonexistent/path/file.yaml", testConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to read file"))
+		})
+
+		It("should return error when template is invalid", func() {
+			invalidTemplate := `variant: fcos
+systemd:
+  units:
+    - name: broken-service
+      contents: {{.InvalidTemplate}}`
+
+			tmpFile, err := os.CreateTemp("", "invalid-template-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(os.Remove, tmpFile.Name())
+
+			_, err = tmpFile.WriteString(invalidTemplate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tmpFile.Close()).To(Succeed())
+
+			_, err = GenerateIgnitionDataFromFile(tmpFile.Name(), testConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("executing template failed"))
+		})
+
+		It("should return error when file path is empty", func() {
+			_, err := GenerateIgnitionDataFromFile("", testConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("file path must be specified"))
+		})
+	})
+
+	Context("generateIgnitionDataFromTemplate", func() {
+		It("should render custom template correctly", func() {
+			customTemplate := `
+image: {{.Image}}
+flags: {{.Flags}}
+user_key: {{.SSHPublicKey}}
+password: {{.PasswordHash}}`
+
+			data, err := generateIgnitionDataFromTemplate(customTemplate, testConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			result := string(data)
+			Expect(result).To(ContainSubstring("image: test-image:latest"))
+			Expect(result).To(ContainSubstring("flags: --test-flag=value"))
+			Expect(result).To(ContainSubstring("user_key: " + testConfig.SSHPublicKey))
+			Expect(result).To(ContainSubstring("password: " + testConfig.PasswordHash))
+		})
+
+		It("should handle template parsing errors", func() {
+			invalidTemplate := `{{.UnknownField}}`
+			_, err := generateIgnitionDataFromTemplate(invalidTemplate, testConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("executing template failed"))
+		})
+	})
+})

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -45,39 +45,53 @@ func (a *Agent) Init(ctx context.Context) error {
 	}
 	systeminfo, err := collectSystemInfoData()
 	if err != nil {
-		return err
+		a.log.Error(err, "System info collection skipped (DMI/SMBIOS not accessible)")
+		// Continue without system info - use empty struct
+		systeminfo = registry.DMI{}
 	}
 
 	cpuInfos, err := collectCPUInfoData()
 	if err != nil {
-		return err
+		a.log.Error(err, "CPU info collection skipped")
+		// Continue without CPU info
+		cpuInfos = []registry.CPUInfo{}
 	}
 
 	LLDPInfo, err := collectLLDPInfo(ctx, a.LLDPSyncInterval, a.LLDPSyncDuration)
 	if err != nil {
-		a.log.Error(err, "failed to collect LLDP info")
-		return err
+		a.log.Error(err, "LLDP info collection skipped (lldpctl not available or failed)")
+		// Continue without LLDP info - it's optional
+		LLDPInfo = registry.LLDP{}
+	} else {
+		a.log.Info("Collected LLDP info", "interfaces", len(LLDPInfo.Interfaces))
 	}
-	a.log.Info("Collected LLDP info", "interfaces", len(LLDPInfo.Interfaces))
 
 	blockDevices, err := collectStorageInfoData()
 	if err != nil {
-		return err
+		a.log.Error(err, "Storage info collection skipped")
+		// Continue without storage info
+		blockDevices = []registry.BlockDevice{}
 	}
 
 	memoryDevices, err := collectMemoryInfoData()
 	if err != nil {
-		return err
+		a.log.Error(err, "Memory info collection skipped")
+		// Continue without memory info
+		memoryDevices = []registry.MemoryDevice{}
 	}
 
 	nics, err := collectNICInfoData()
 	if err != nil {
-		return err
+		a.log.Error(err, "NIC info collection skipped")
+		// Continue without NIC info
+		nics = []registry.NIC{}
 	}
 
 	pciDevices, err := collectPCIDevicesInfoData()
 	if err != nil {
-		return err
+		a.log.Error(err, "PCI devices info collection skipped")
+		// Continue without PCI device info
+		pciDevices = []registry.PCIDevice{}
 	}
 
 	a.Server = &registry.Server{


### PR DESCRIPTION
# Proposed Changes

The current default ignition is hardcoded. This change allows it to be optionally overridden by a ConfigMap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for customizable Ignition templates via a new configuration flag and provide a default template included in the manager image.

* **Documentation**
  * Add detailed Ignition template customization guide with Helm examples, required template variables, and troubleshooting.

* **Improvements**
  * Make probe data collection more resilient by treating certain collection errors as non-fatal.

* **Chores / Tests**
  * Harden build recipes for safer tool invocation and add unit tests covering file-based Ignition template handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->