### PR TITLE
Fix `BIOSSettings` updates for HPE `Servers`

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -172,7 +172,7 @@ type RegistryEntryAttributes struct {
 	MenuPath      string
 	MinLength     int
 	ReadOnly      bool
-	ResetRequired bool
+	ResetRequired *bool
 	Type          string
 	WriteOnly     bool
 	Value         []AllowedValues

--- a/bmc/mock/server/data/Registries/BiosAttributeRegistry.v1_0_0.json
+++ b/bmc/mock/server/data/Registries/BiosAttributeRegistry.v1_0_0.json
@@ -61,7 +61,6 @@
         "Immutable": false,
         "MenuPath": "./EmbeddedSataSettingsRef",
         "ReadOnly": false,
-        "ResetRequired": true,
         "Type": "Enumeration",
         "Value": [
           {

--- a/bmc/redfish_kube.go
+++ b/bmc/redfish_kube.go
@@ -173,12 +173,13 @@ func (r *RedfishKubeBMC) getFilteredBiosRegistryAttributes(readOnly, immutable b
 
 	filtered := make(map[string]RegistryEntryAttributes)
 	for name, attrData := range UnitTestMockUps.BIOSSettingAttr {
+		resetRequired := attrData["reboot"].(bool)
 		filtered[name] = RegistryEntryAttributes{
 			AttributeName: name,
 			Immutable:     immutable,
 			ReadOnly:      readOnly,
 			Type:          attrData["type"].(string),
-			ResetRequired: attrData["reboot"].(bool),
+			ResetRequired: &resetRequired,
 		}
 	}
 	return filtered, nil

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -46,37 +46,39 @@ type BiosSettingsReconciler struct {
 const (
 	BIOSSettingsFinalizer = "metal.ironcore.dev/biossettings"
 
-	serverMaintenanceCreatedCondition = "ServerMaintenanceCreated"
-	createdServerMaintenanceReason    = "CreatedServerMaintenance"
-	serverMaintenanceDeletedCondition = "ServerMaintenanceDeleted"
-	deleteServerMaintenanceReason     = "DeleteServerMaintenance"
-	pendingVersionUpdateCondition     = "PendingBIOSVersionUpdate"
-	pendingBIOSVersionUpgradeReason   = "PendingBIOSVersionUpgrade"
-	pendingSettingCheckCondition      = "PendingSettingStateCheck"
-	pendingBIOSSettingsFound          = "PendingBIOSSettingsFound"
-	duplicateKeyCheckCondition        = "DuplicateKeysCheck"
-	duplicateKeysFoundReason          = "DuplicateKeysFound"
-	timeoutStartCondition             = "SettingUpdateStartTime"
-	settingsUpdateStartedReason       = "SettingsUpdateStarted"
-	timedOutCondition                 = "TimedOutDuringSettingUpdate"
-	timeoutOutDuringUpdateReason      = "TimeoutOutDuringUpdate"
-	turnServerOnCondition             = "TurnServerOnCondition"
-	serverPoweredOnReason             = "ServerPoweredOn"
-	BMCConditionReset                 = "BMCResetIssued"
-	BMCReasonReset                    = "BMCResetIssued"
-	issueSettingsUpdateCondition      = "IssueSettingsUpdate"
-	issuedBIOSSettingUpdateReason     = "IssuedBIOSSettingUpdate"
-	unknownPendingSettingCondition    = "UnknownPendingSettingStateCheck"
-	unexpectedPendingSettingsReason   = "UnexpectedPendingSettingsPostSettingUpdate"
-	skipRebootCondition               = "SkipServerRebootPostSettingUpdate"
-	skipRebootPostSettingUpdateReason = "SkipRebootPostSettingUpdate"
-	rebootPostSettingUpdateReason     = "RebootPostSettingUpdate"
-	rebootPowerOffCondition           = "RebootPowerOff"
-	rebootPowerOffCompletedReason     = "RebootPowerOffCompleted"
-	rebootPowerOnCondition            = "RebootPowerOn"
-	rebootPowerOnCompletedReason      = "RebootPowerOnCompleted"
-	verifySettingCondition            = "VerifySettingsPostUpdate"
-	verificationCompleteReason        = "VerificationComplete"
+	BIOSServerMaintenanceConditionCreated       = "ServerMaintenanceCreated"
+	BIOSServerMaintenanceReasonCreated          = "ServerMaintenanceHasBeenCreated"
+	BIOSServerMaintenanceConditionDeleted       = "ServerMaintenanceDeleted"
+	BIOSServerMaintenanceReasonDeleted          = "ServerMaintenanceHasBeenDeleted"
+	BIOSVersionUpdateConditionPending           = "BIOSVersionUpdatePending"
+	BIOSVersionUpgradeReasonPending             = "BIOSVersionNeedsTObeUpgraded"
+	BIOSPendingSettingConditionCheck            = "BIOSSettingsCheckPendingSettings"
+	BIOSPendingSettingsReasonFound              = "BIOSPendingSettingsFound"
+	BIOSSettingsConditionDuplicateKey           = "BIOSSettingsDuplicateKeys"
+	BIOSSettingsReasonFoundDuplicateKeys        = "BIOSSettingsDuplicateKeysFound"
+	BIOSSettingConditionUpdateStartTime         = "BIOSSettingUpdateStartTime"
+	BIOSSettingsReasonUpdateStartTime           = "BIOSSettingsUpdateHasStarted"
+	BIOSSettingConditionUpdateTimedOut          = "BIOSSettingsTimedOut"
+	BIOSSettingsReasonUpdateTimedout            = "BIOSSettingsTimedOutDuringUpdate"
+	BIOSSettingsConditionServerPowerOn          = "ServerPowerOnCondition"
+	BIOSSettingsReasonServerPoweredOn           = "ServerPoweredHasBeenPoweredOn"
+	BMCConditionReset                           = "BMCResetIssued"
+	BMCReasonReset                              = "BMCResetIssued"
+	BIOSSettingsConditionIssuedUpdate           = "SettingsUpdateIssued"
+	BIOSSettingReasonIssuedUpdate               = "BIOSSettingUpdateIssued"
+	BIOSSettingsConditionUnknownPendingSettings = "UnknownPendingSettingState"
+	BIOSSettingsReasonUnexpectedPendingSettings = "UnexpectedPendingSettingsPostUpdateHasBeenIssued"
+	BIOSSettingssConditionRebootPostUpdate      = "ServerRebootPostUpdateHasBeenIssued"
+	BIOSSettingsReasonSkipReboot                = "SkipServerRebootPostUpdateHasBeenIssued"
+	BIOSSettingsReasonRebootNeeded              = "RebootPostSettingUpdate"
+	BIOSSettingsConditionRebootPowerOff         = "RebootPowerOff"
+	BIOSSettingsReasonRebootServerPowerOff      = "PowerOffCompletedDuringReboot"
+	BIOSSettingsConditionRebootPowerOn          = "RebootPowerOn"
+	BIOSSettingsReasonRebootServerPowerOn       = "PowerOnCompletedDuringReboot"
+	BIOSSettingsConditionVerifySettings         = "VerifySettingsPostUpdate"
+	BIOSSettingsReasonVerificationCompleted     = "VerificationCompleted"
+	BIOSSettingsConditionWrongSettings          = "SettingsProvidedNotValid"
+	BIOSSettingsReasonWrongSettings             = "SettingsProvidedAreNotValid"
 )
 
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biossettings,verbs=get;list;watch;create;update;patch;delete
@@ -181,14 +183,14 @@ func (r *BiosSettingsReconciler) cleanupServerMaintenanceReferences(
 			// if the biosSettings is not being deleted, update the
 			log.V(1).Info("Deleting server maintenance", "serverMaintenance Name", serverMaintenance.Name, "state", serverMaintenance.Status.State)
 			acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
-			condition, err = r.getCondition(acc, biosSettings.Status.Conditions, serverMaintenanceDeletedCondition)
+			condition, err = r.getCondition(acc, biosSettings.Status.Conditions, BIOSServerMaintenanceConditionDeleted)
 			if err != nil {
 				return fmt.Errorf("failed to get the delete condition while clean up maintenance %v", err)
 			}
 			if err := acc.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(deleteServerMaintenanceReason),
+				conditionutils.UpdateReason(BIOSServerMaintenanceReasonDeleted),
 				conditionutils.UpdateMessage(fmt.Sprintf("Deleting %v", serverMaintenance.Name)),
 			); err != nil {
 				return fmt.Errorf("failed to update deleting serverMaintenance condition: %w", err)
@@ -345,14 +347,14 @@ func (r *BiosSettingsReconciler) handleSettingPendingState(
 	}
 	if len(pendingSettings) > 0 {
 		log.V(1).Info("Pending bios setting tasks found", "biosSettings pending tasks", pendingSettings)
-		pendingSettingStateCheckCondition, err := r.getCondition(acc, biosSettings.Status.Conditions, pendingSettingCheckCondition)
+		pendingSettingStateCheckCondition, err := r.getCondition(acc, biosSettings.Status.Conditions, BIOSPendingSettingConditionCheck)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for pending Settings state %v", err)
 		}
 		if err := acc.Update(
 			pendingSettingStateCheckCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(pendingBIOSSettingsFound),
+			conditionutils.UpdateReason(BIOSPendingSettingsReasonFound),
 			conditionutils.UpdateMessage(fmt.Sprintf("Pending Setting found, Hence can not start with bios setting update, current pending settings: %v", pendingSettings)),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update Pending BIOSVersion update condition: %w", err)
@@ -383,14 +385,14 @@ func (r *BiosSettingsReconciler) handleSettingPendingState(
 
 	if len(duplicateName) > 0 || len(duplicateSettingsNames) > 0 {
 		log.V(1).Info("Duplicate keys found", "duplicate names", duplicateName, "duplicate keys", duplicateSettingsNames)
-		duplicateCheckCondition, err := r.getCondition(acc, biosSettings.Status.Conditions, duplicateKeyCheckCondition)
+		duplicateCheckCondition, err := r.getCondition(acc, biosSettings.Status.Conditions, BIOSSettingsConditionDuplicateKey)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for pending Settings state %v", err)
 		}
 		if err := acc.Update(
 			duplicateCheckCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(duplicateKeysFoundReason),
+			conditionutils.UpdateReason(BIOSSettingsReasonFoundDuplicateKeys),
 			conditionutils.UpdateMessage(fmt.Sprintf("Found duplicate Keys in Name: %v or settings Keys %v", duplicateName, duplicateSettingsNames)),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update Pending BIOSVersion update condition: %w", err)
@@ -408,7 +410,7 @@ func (r *BiosSettingsReconciler) handleSettingPendingState(
 	// if conditions are present, skip this shortcut to be able capture all conditions states (ex: verifySetting, reboot etc)
 	if len(settingsDiff) == 0 && len(biosSettings.Status.Conditions) == 0 {
 		// move status to completed
-		verifySettingUpdate, err := r.getCondition(acc, biosSettings.Status.Conditions, verifySettingCondition)
+		verifySettingUpdate, err := r.getCondition(acc, biosSettings.Status.Conditions, BIOSSettingsConditionVerifySettings)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for Verifyed Settings condition %v", err)
 		}
@@ -416,7 +418,7 @@ func (r *BiosSettingsReconciler) handleSettingPendingState(
 		if err := acc.Update(
 			verifySettingUpdate,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(verificationCompleteReason),
+			conditionutils.UpdateReason(BIOSSettingsReasonVerificationCompleted),
 			conditionutils.UpdateMessage("Required BIOS settings has been verified on the server"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update verify biossetting condition: %w", err)
@@ -433,7 +435,7 @@ func (r *BiosSettingsReconciler) handleSettingPendingState(
 	var state = metalv1alpha1.BIOSSettingsStateInProgress
 	var condition *metav1.Condition
 	if currentBiosVersion != biosSettings.Spec.Version {
-		versionCheckCondition, err := r.getCondition(acc, biosSettings.Status.Conditions, pendingVersionUpdateCondition)
+		versionCheckCondition, err := r.getCondition(acc, biosSettings.Status.Conditions, BIOSVersionUpdateConditionPending)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for pending BIOSVersion update state %v", err)
 		}
@@ -444,7 +446,7 @@ func (r *BiosSettingsReconciler) handleSettingPendingState(
 		if err := acc.Update(
 			versionCheckCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(pendingBIOSVersionUpgradeReason),
+			conditionutils.UpdateReason(BIOSVersionUpgradeReasonPending),
 			conditionutils.UpdateMessage(fmt.Sprintf("Waiting to update biosVersion: %v, current biosVersion: %v", biosSettings.Spec.Version, currentBiosVersion)),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update Pending BIOSVersion update condition: %w", err)
@@ -514,7 +516,7 @@ func (r *BiosSettingsReconciler) handleSettingInProgressState(
 				}
 				// mark completed, and move on
 				acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
-				verifySettingUpdate, err := r.getCondition(acc, currentSettingsFlowStatus.Conditions, verifySettingCondition)
+				verifySettingUpdate, err := r.getCondition(acc, currentSettingsFlowStatus.Conditions, BIOSSettingsConditionVerifySettings)
 				if err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to get Condition for Verifyed Settings condition %v", err)
 				}
@@ -522,7 +524,7 @@ func (r *BiosSettingsReconciler) handleSettingInProgressState(
 				if err := acc.Update(
 					verifySettingUpdate,
 					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(verificationCompleteReason),
+					conditionutils.UpdateReason(BIOSSettingsReasonVerificationCompleted),
 					conditionutils.UpdateMessage("Required BIOS settings has been RE verified on the server. Hence, moving out of Pending state"),
 				); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update verify biossetting condition: %w", err)
@@ -635,7 +637,7 @@ func (r *BiosSettingsReconciler) applySettingUpdate(
 		return false, err
 	}
 	acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
-	turnOnServer, err := r.getCondition(acc, currentFlowStatus.Conditions, turnServerOnCondition)
+	turnOnServer, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingsConditionServerPowerOn)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for Initial powerOn of server %v", err)
 	}
@@ -645,7 +647,7 @@ func (r *BiosSettingsReconciler) applySettingUpdate(
 			if err := acc.Update(
 				turnOnServer,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(serverPoweredOnReason),
+				conditionutils.UpdateReason(BIOSSettingsReasonServerPoweredOn),
 				conditionutils.UpdateMessage("Server is powered On to start the biosUpdate process"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -672,10 +674,10 @@ func (r *BiosSettingsReconciler) applySettingUpdate(
 	// if the condition is present, we have checked the skip reboot condition.
 	condFound, err := acc.FindSlice(
 		currentFlowStatus.Conditions,
-		skipRebootCondition,
+		BIOSSettingssConditionRebootPostUpdate,
 		&metav1.Condition{})
 	if err != nil {
-		return false, fmt.Errorf("failed to find Condition %v. error: %v", skipRebootCondition, err)
+		return false, fmt.Errorf("failed to find Condition %v. error: %v", BIOSSettingssConditionRebootPostUpdate, err)
 	}
 	if !condFound {
 		log.V(1).Info("Verify if the current Settings needs reboot of server")
@@ -685,11 +687,28 @@ func (r *BiosSettingsReconciler) applySettingUpdate(
 		}
 		resetReq, err := bmcClient.CheckBiosAttributes(settingsDiff)
 		if err != nil {
-			log.V(1).Error(err, "could not determine if reboot needed")
+			log.V(1).Error(err, "could not validate settings and determine if reboot needed")
+			var invalidSettingsErr *bmc.InvalidBIOSSettingsError
+			if errors.As(err, &invalidSettingsErr) {
+				inValidSettings, errCond := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingsConditionWrongSettings)
+				if errCond != nil {
+					return false, fmt.Errorf("failed to get Condition for skip reboot post setting update %v", err)
+				}
+				if errCond := acc.Update(
+					inValidSettings,
+					conditionutils.UpdateStatus(corev1.ConditionTrue),
+					conditionutils.UpdateReason(BIOSSettingsReasonWrongSettings),
+					conditionutils.UpdateMessage(fmt.Sprintf("Settings provided is invalid. error: %v", err)),
+				); errCond != nil {
+					return false, fmt.Errorf("failed to update Invalid Settings condition: %w", errCond)
+				}
+				err = r.updateBiosSettingsFlowStatus(ctx, log, biosSettings, metalv1alpha1.BIOSSettingsFlowStateFailed, currentFlowStatus, inValidSettings)
+				return true, errors.Join(err, r.updateBiosSettingsStatus(ctx, log, biosSettings, metalv1alpha1.BIOSSettingsStateFailed, nil))
+			}
 			return false, err
 		}
 
-		skipReboot, err := r.getCondition(acc, currentFlowStatus.Conditions, skipRebootCondition)
+		skipReboot, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingssConditionRebootPostUpdate)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Condition for skip reboot post setting update %v", err)
 		}
@@ -700,7 +719,7 @@ func (r *BiosSettingsReconciler) applySettingUpdate(
 			if err := acc.Update(
 				skipReboot,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(skipRebootPostSettingUpdateReason),
+				conditionutils.UpdateReason(BIOSSettingsReasonSkipReboot),
 				conditionutils.UpdateMessage("Settings provided does not need server reboot"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update skip reboot condition: %w", err)
@@ -709,7 +728,7 @@ func (r *BiosSettingsReconciler) applySettingUpdate(
 			if err := acc.Update(
 				skipReboot,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(rebootPostSettingUpdateReason),
+				conditionutils.UpdateReason(BIOSSettingsReasonRebootNeeded),
 				conditionutils.UpdateMessage("Settings provided needs server reboot"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update skip reboot condition: %w", err)
@@ -720,7 +739,7 @@ func (r *BiosSettingsReconciler) applySettingUpdate(
 		return false, err
 	}
 
-	issueBiosUpdate, err := r.getCondition(acc, currentFlowStatus.Conditions, issueSettingsUpdateCondition)
+	issueBiosUpdate, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingsConditionIssuedUpdate)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for issuing BIOSSetting update to server %v", err)
 	}
@@ -729,13 +748,13 @@ func (r *BiosSettingsReconciler) applySettingUpdate(
 		return false, r.applyBiosSettingOnServer(ctx, log, bmcClient, biosSettings, currentSettings, currentFlowStatus, server, issueBiosUpdate)
 	}
 
-	skipReboot, err := r.getCondition(acc, currentFlowStatus.Conditions, skipRebootCondition)
+	skipReboot, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingssConditionRebootPostUpdate)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for reboot needed condition %v", err)
 	}
 
 	if skipReboot.Status != metav1.ConditionTrue {
-		rebootPowerOnCondition, err := r.getCondition(acc, currentFlowStatus.Conditions, rebootPowerOnCondition)
+		rebootPowerOnCondition, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingsConditionRebootPowerOn)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Condition for reboot PowerOn condition %v", err)
 		}
@@ -754,7 +773,7 @@ func (r *BiosSettingsReconciler) SetTimeOutForApplyingSettings(
 	currentFlowStatus *metalv1alpha1.BIOSSettingsFlowStatus,
 ) (bool, error) {
 	acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
-	timeoutCheck, err := r.getCondition(acc, currentFlowStatus.Conditions, timeoutStartCondition)
+	timeoutCheck, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingConditionUpdateStartTime)
 	if err != nil {
 		return false, fmt.Errorf("failed to get condition for TimeOut during setting update %v", err)
 	}
@@ -762,7 +781,7 @@ func (r *BiosSettingsReconciler) SetTimeOutForApplyingSettings(
 		if err := acc.Update(
 			timeoutCheck,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(settingsUpdateStartedReason),
+			conditionutils.UpdateReason(BIOSSettingsReasonUpdateStartTime),
 			conditionutils.UpdateMessage("Settings are being updated on Server. Timeout will occur beyond this point if settings are not applied"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update starting setting update condition: %w", err)
@@ -773,14 +792,14 @@ func (r *BiosSettingsReconciler) SetTimeOutForApplyingSettings(
 		startTime := timeoutCheck.LastTransitionTime.Time
 		if time.Now().After(startTime.Add(r.TimeoutExpiry)) {
 			log.V(1).Info("Timedout while updating the biosSettings")
-			timedOut, err := r.getCondition(acc, currentFlowStatus.Conditions, timedOutCondition)
+			timedOut, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingConditionUpdateTimedOut)
 			if err != nil {
 				return false, fmt.Errorf("failed to get Condition for Timeout of BIOSSettings update %v", err)
 			}
 			if err := acc.Update(
 				timedOut,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(timeoutOutDuringUpdateReason),
+				conditionutils.UpdateReason(BIOSSettingsReasonUpdateTimedout),
 				conditionutils.UpdateMessage(fmt.Sprintf("Timeout after: %v. startTime: %v. timedOut on: %v", r.TimeoutExpiry, startTime, time.Now().String())),
 			); err != nil {
 				return false, fmt.Errorf("failed to update timeout during settings update condition: %w", err)
@@ -802,7 +821,7 @@ func (r *BiosSettingsReconciler) VerifySettingsUpdateComplete(
 	server *metalv1alpha1.Server,
 ) (bool, error) {
 	acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
-	verifySettingUpdate, err := r.getCondition(acc, currentFlowStatus.Conditions, verifySettingCondition)
+	verifySettingUpdate, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingsConditionVerifySettings)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for Verification condition %v", err)
 	}
@@ -818,7 +837,7 @@ func (r *BiosSettingsReconciler) VerifySettingsUpdateComplete(
 			if err := acc.Update(
 				verifySettingUpdate,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(verificationCompleteReason),
+				conditionutils.UpdateReason(BIOSSettingsReasonVerificationCompleted),
 				conditionutils.UpdateMessage("Required BIOS settings has been applied and verified on the server"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update verify biossetting condition: %w", err)
@@ -848,7 +867,7 @@ func (r *BiosSettingsReconciler) rebootServer(
 	server *metalv1alpha1.Server,
 ) error {
 	acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
-	rebootPowerOffCondition, err := r.getCondition(acc, currentFlowStatus.Conditions, rebootPowerOffCondition)
+	rebootPowerOffCondition, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingsConditionRebootPowerOff)
 	if err != nil {
 		return fmt.Errorf("failed to get Condition for reboot PowerOff condition %v", err)
 	}
@@ -865,7 +884,7 @@ func (r *BiosSettingsReconciler) rebootServer(
 			if err := acc.Update(
 				rebootPowerOffCondition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(rebootPowerOffCompletedReason),
+				conditionutils.UpdateReason(BIOSSettingsReasonRebootServerPowerOff),
 				conditionutils.UpdateMessage("Server has entered power off state"),
 			); err != nil {
 				return fmt.Errorf("failed to update reboot server powerOff condition: %w", err)
@@ -877,7 +896,7 @@ func (r *BiosSettingsReconciler) rebootServer(
 		return nil
 	}
 
-	rebootPowerOnCondition, err := r.getCondition(acc, currentFlowStatus.Conditions, rebootPowerOnCondition)
+	rebootPowerOnCondition, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingsConditionRebootPowerOn)
 	if err != nil {
 		return fmt.Errorf("failed to get Condition for reboot PowerOn condition %v", err)
 	}
@@ -894,7 +913,7 @@ func (r *BiosSettingsReconciler) rebootServer(
 			if err := acc.Update(
 				rebootPowerOnCondition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(rebootPowerOnCompletedReason),
+				conditionutils.UpdateReason(BIOSSettingsReasonRebootServerPowerOn),
 				conditionutils.UpdateMessage("Server has entered power on state"),
 			); err != nil {
 				return fmt.Errorf("failed to update reboot server powerOn condition: %w", err)
@@ -928,7 +947,7 @@ func (r *BiosSettingsReconciler) applyBiosSettingOnServer(
 		if err := acc.Update(
 			issueBiosUpdate,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(issuedBIOSSettingUpdateReason),
+			conditionutils.UpdateReason(BIOSSettingReasonIssuedUpdate),
 			conditionutils.UpdateMessage("BIOS Settings issue has been Skipped on the server as no difference found"),
 		); err != nil {
 			return fmt.Errorf("failed to update issued settings update condition: %w", err)
@@ -962,7 +981,7 @@ func (r *BiosSettingsReconciler) applyBiosSettingOnServer(
 		return fmt.Errorf("failed to get pending BIOS settings: %w", err)
 	}
 
-	skipReboot, err := r.getCondition(acc, currentFlowStatus.Conditions, skipRebootCondition)
+	skipReboot, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingssConditionRebootPostUpdate)
 	if err != nil {
 		return fmt.Errorf("failed to get Condition for reboot needed condition %v", err)
 	}
@@ -981,14 +1000,14 @@ func (r *BiosSettingsReconciler) applyBiosSettingOnServer(
 	// all required settings should in pending settings.
 	if len(pendingSettingsDiff) > 0 {
 		log.V(1).Info("Unknown pending BIOS settings found", "Unknown pending settings", pendingSettingsDiff)
-		unexpectedPendingSettings, err := r.getCondition(acc, currentFlowStatus.Conditions, unknownPendingSettingCondition)
+		unexpectedPendingSettings, err := r.getCondition(acc, currentFlowStatus.Conditions, BIOSSettingsConditionUnknownPendingSettings)
 		if err != nil {
 			return fmt.Errorf("failed to get Condition for unexpected pending BIOSSetting state %v", err)
 		}
 		if err := acc.Update(
 			unexpectedPendingSettings,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(unexpectedPendingSettingsReason),
+			conditionutils.UpdateReason(BIOSSettingsReasonUnexpectedPendingSettings),
 			conditionutils.UpdateMessage(fmt.Sprintf("Found unexpected settings after issuing settings update for BIOS. unexpected settings %v", pendingSettingsDiff)),
 		); err != nil {
 			return fmt.Errorf("failed to update unexpected pending settings found condition: %w", err)
@@ -1000,7 +1019,7 @@ func (r *BiosSettingsReconciler) applyBiosSettingOnServer(
 	if err := acc.Update(
 		issueBiosUpdate,
 		conditionutils.UpdateStatus(corev1.ConditionTrue),
-		conditionutils.UpdateReason(issuedBIOSSettingUpdateReason),
+		conditionutils.UpdateReason(BIOSSettingReasonIssuedUpdate),
 		conditionutils.UpdateMessage("BIOS Settings Update has been triggered on the server"),
 	); err != nil {
 		return fmt.Errorf("failed to update issued settings update condition: %w", err)
@@ -1285,14 +1304,14 @@ func (r *BiosSettingsReconciler) requestMaintenanceOnServer(
 	log.V(1).Info("Created serverMaintenance", "serverMaintenance", serverMaintenance.Name, "serverMaintenance label", serverMaintenance.Labels, "Operation", opResult)
 
 	acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
-	createdCondition, err := r.getCondition(acc, biosSettings.Status.Conditions, serverMaintenanceCreatedCondition)
+	createdCondition, err := r.getCondition(acc, biosSettings.Status.Conditions, BIOSServerMaintenanceConditionCreated)
 	if err != nil {
 		return false, err
 	}
 	if err := acc.Update(
 		createdCondition,
 		conditionutils.UpdateStatus(corev1.ConditionTrue),
-		conditionutils.UpdateReason(createdServerMaintenanceReason),
+		conditionutils.UpdateReason(BIOSServerMaintenanceReasonCreated),
 		conditionutils.UpdateMessage(fmt.Sprintf("Created %v at %v", serverMaintenance.Name, time.Now())),
 	); err != nil {
 		return false, fmt.Errorf("failed to update creating serverMaintenance condition: %w", err)

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -134,7 +134,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 		Eventually(Object(biosSettingsV1)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", verifySettingCondition),
+					HaveField("Type", BIOSSettingsConditionVerifySettings),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -234,11 +234,71 @@ var _ = Describe("BIOSSettings Controller", func() {
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", verifySettingCondition),
+					HaveField("Type", BIOSSettingsConditionVerifySettings),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
 		)
+
+		By("Deleting the BIOSSettings")
+		Expect(k8sClient.Delete(ctx, biosSettings)).To(Succeed())
+
+		By("Ensuring that the bios ref is empty")
+		Eventually(Object(server)).Should(
+			HaveField("Spec.BIOSSettingsRef", BeNil()),
+		)
+		Eventually(Object(server)).Should(
+			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
+		)
+	})
+
+	It("should reboot server if the resetRequired field is missing in the biosRegistry", func(ctx SpecContext) {
+		// settings mocked at
+		// metal-operator/bmc/mock/server/data/Registries/BiosAttributeRegistry.v1_0_0.json
+		biosSetting := make(map[string]string)
+		biosSetting["EmbeddedSata"] = "NonRaid"
+
+		By("Creating a BIOSSetting")
+		biosSettings := &metalv1alpha1.BIOSSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-no-change",
+			},
+			Spec: metalv1alpha1.BIOSSettingsSpec{
+				BIOSSettingsTemplate: metalv1alpha1.BIOSSettingsTemplate{
+					Version: defaultMockUpServerBiosVersion,
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{
+						Settings: biosSetting,
+						Priority: 1,
+						Name:     "one",
+					}},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+				ServerRef: &v1.LocalObjectReference{Name: server.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, biosSettings)).To(Succeed())
+
+		By("Ensuring that the Server has the bios setting ref")
+		Eventually(Object(server)).Should(
+			HaveField("Spec.BIOSSettingsRef.Name", biosSettings.Name),
+		)
+
+		Eventually(Object(biosSettings)).Should(
+			HaveField("Status.FlowState", ContainElement(SatisfyAll(
+				HaveField("Conditions", ContainElement(SatisfyAll(
+					HaveField("Type", BIOSSettingssConditionRebootPostUpdate),
+					HaveField("Reason", BIOSSettingsReasonRebootNeeded),
+					HaveField("Status", metav1.ConditionFalse)),
+				)),
+				HaveField("Name", "one"),
+			))),
+		)
+
+		Eventually(Object(biosSettings)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.BIOSSettingsStateApplied),
+			HaveField("Status.LastAppliedTime.IsZero()", false),
+		))
 
 		By("Deleting the BIOSSettings")
 		Expect(k8sClient.Delete(ctx, biosSettings)).To(Succeed())
@@ -1136,6 +1196,70 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 		)
 	})
 
+	It("Should fail if settings provide in inValid", func(ctx SpecContext) {
+		By("Creating a BIOSSetting with sequence of settings")
+		biosSettings := &metalv1alpha1.BIOSSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-setting-flow-",
+			},
+			// settings mocked at
+			// metal-operator/bmc/mock/server/data/Registries/BiosAttributeRegistry.v1_0_0.json
+			Spec: metalv1alpha1.BIOSSettingsSpec{
+				BIOSSettingsTemplate: metalv1alpha1.BIOSSettingsTemplate{
+					Version: defaultMockUpServerBiosVersion,
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{
+						{
+							Priority: 100,
+							Settings: map[string]string{"PowerProfile": "UnKnownValue"},
+							Name:     "100",
+						},
+					},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+				ServerRef: &v1.LocalObjectReference{Name: server.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, biosSettings)).To(Succeed())
+
+		By("Ensuring that the BIOSSetting Object has moved to Failed")
+		Eventually(Object(biosSettings)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.BIOSSettingsStateFailed),
+		))
+
+		By("Ensuring the Condition has been saved")
+		Eventually(Object(biosSettings)).Should(
+			SatisfyAll(
+				HaveField("Status.FlowState", ContainElement(
+					SatisfyAll(
+						HaveField("Conditions", ContainElement(
+							SatisfyAll(
+								HaveField("Type", BIOSSettingsConditionWrongSettings),
+								HaveField("Reason", BIOSSettingsReasonWrongSettings),
+							),
+						)),
+						HaveField("Name", "100"),
+						HaveField("State", metalv1alpha1.BIOSSettingsFlowStateFailed),
+					),
+				)),
+			),
+		)
+
+		By("Deleting the biosSettings")
+		serverMaintenance := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      biosSettings.Name,
+			},
+		}
+		Eventually(Get(serverMaintenance)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, biosSettings)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, serverMaintenance)).To(Succeed())
+		Eventually(Object(server)).Should(
+			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
+		)
+	})
+
 	It("Should fail if duplicate keys in names or settings found", func(ctx SpecContext) {
 		By("Creating a BIOSSetting with sequence of settings")
 		biosSettings := &metalv1alpha1.BIOSSettings{
@@ -1181,7 +1305,7 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", duplicateKeyCheckCondition),
+					HaveField("Type", BIOSSettingsConditionDuplicateKey),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1230,7 +1354,7 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 		Eventually(Object(biosSettings2)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", duplicateKeyCheckCondition),
+					HaveField("Type", BIOSSettingsConditionDuplicateKey),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1355,7 +1479,7 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 				HaveField("Status.FlowState", Not(ContainElement(
 					SatisfyAll(
 						HaveField("Conditions", ContainElement(
-							HaveField("Type", issueSettingsUpdateCondition),
+							HaveField("Type", BIOSSettingsConditionIssuedUpdate),
 						)),
 						HaveField("Name", oldNames[1]),
 					),
@@ -1419,7 +1543,7 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 	By("Ensuring the wait for version upgrade condition has NOT been added")
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", Not(ContainElement(
-			HaveField("Type", pendingVersionUpdateCondition),
+			HaveField("Type", BIOSVersionUpdateConditionPending),
 		))),
 	)
 
@@ -1427,7 +1551,7 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElement(
 			SatisfyAll(
-				HaveField("Type", serverMaintenanceCreatedCondition),
+				HaveField("Type", BIOSServerMaintenanceConditionCreated),
 				HaveField("Status", metav1.ConditionTrue),
 			),
 		)),
@@ -1440,28 +1564,28 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 		flowStateMatcher := SatisfyAll(
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", timeoutStartCondition),
+					HaveField("Type", BIOSSettingConditionUpdateStartTime),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", turnServerOnCondition),
+					HaveField("Type", BIOSSettingsConditionServerPowerOn),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
 			HaveField("Conditions", ContainElement(
-				HaveField("Type", skipRebootCondition),
+				HaveField("Type", BIOSSettingssConditionRebootPostUpdate),
 			)),
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", issueSettingsUpdateCondition),
+					HaveField("Type", BIOSSettingsConditionIssuedUpdate),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", verifySettingCondition),
+					HaveField("Type", BIOSSettingsConditionVerifySettings),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1476,7 +1600,7 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElement(
 			SatisfyAll(
-				HaveField("Type", serverMaintenanceDeletedCondition),
+				HaveField("Type", BIOSServerMaintenanceConditionDeleted),
 				HaveField("Status", metav1.ConditionTrue),
 			),
 		)),
@@ -1517,7 +1641,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", pendingVersionUpdateCondition),
+					HaveField("Type", BIOSVersionUpdateConditionPending),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1526,7 +1650,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		By("Ensuring the wait for version upgrade condition has NOT been added")
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", Not(ContainElement(
-				HaveField("Type", pendingVersionUpdateCondition),
+				HaveField("Type", BIOSVersionUpdateConditionPending),
 			))),
 		)
 	}
@@ -1535,7 +1659,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElement(
 			SatisfyAll(
-				HaveField("Type", serverMaintenanceCreatedCondition),
+				HaveField("Type", BIOSServerMaintenanceConditionCreated),
 				HaveField("Status", metav1.ConditionTrue),
 			),
 		)),
@@ -1546,7 +1670,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElement(
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", timeoutStartCondition),
+					HaveField("Type", BIOSSettingConditionUpdateStartTime),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1558,7 +1682,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElement(
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", turnServerOnCondition),
+					HaveField("Type", BIOSSettingsConditionServerPowerOn),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1572,12 +1696,12 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 				HaveField("Conditions", SatisfyAll(
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", skipRebootCondition),
+							HaveField("Type", BIOSSettingssConditionRebootPostUpdate),
 							HaveField("Status", metav1.ConditionTrue),
 						),
 					),
-					Not(ContainElement(HaveField("Type", rebootPowerOffCondition))),
-					Not(ContainElement(HaveField("Type", rebootPowerOnCondition))),
+					Not(ContainElement(HaveField("Type", BIOSSettingsConditionRebootPowerOff))),
+					Not(ContainElement(HaveField("Type", BIOSSettingsConditionRebootPowerOn))),
 				)),
 			)),
 		)
@@ -1588,19 +1712,19 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 				HaveField("Conditions", SatisfyAll(
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", skipRebootCondition),
+							HaveField("Type", BIOSSettingssConditionRebootPostUpdate),
 							HaveField("Status", metav1.ConditionFalse),
 						),
 					),
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", rebootPowerOffCondition),
+							HaveField("Type", BIOSSettingsConditionRebootPowerOff),
 							HaveField("Status", metav1.ConditionTrue),
 						),
 					),
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", rebootPowerOnCondition),
+							HaveField("Type", BIOSSettingsConditionRebootPowerOn),
 							HaveField("Status", metav1.ConditionTrue),
 						),
 					),
@@ -1614,7 +1738,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElements(
 			SatisfyAll(
 				HaveField("Conditions", ContainElements(
-					HaveField("Type", issueSettingsUpdateCondition),
+					HaveField("Type", BIOSSettingsConditionIssuedUpdate),
 					HaveField("Status", metav1.ConditionTrue),
 				)),
 			),
@@ -1626,7 +1750,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElements(
 			SatisfyAll(
 				HaveField("Conditions", ContainElements(
-					HaveField("Type", verifySettingCondition),
+					HaveField("Type", BIOSSettingsConditionVerifySettings),
 					HaveField("Status", metav1.ConditionTrue),
 				)),
 			),
@@ -1636,7 +1760,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 	By("Ensuring the server maintenance has been deleted")
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElements(
-			HaveField("Type", serverMaintenanceDeletedCondition),
+			HaveField("Type", BIOSServerMaintenanceConditionDeleted),
 			HaveField("Status", metav1.ConditionTrue),
 		)),
 	)


### PR DESCRIPTION
# Proposed Changes
Fix reboot issue in Biossettings update for HPE server
move to failed state if the settings provided in invalid

Fixes #544 