### PR TITLE
Fix handling of `BootSourceOverrideMode` for older Redfish

### DIFF
--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -195,7 +195,8 @@ func (r *RedfishBMC) SetPXEBootOnce(ctx context.Context, systemURI string) error
 	}
 	var setBoot redfish.Boot
 	// TODO: cover setting BootSourceOverrideMode with BIOS settings profile
-	if system.Boot.BootSourceOverrideMode != redfish.UEFIBootSourceOverrideMode {
+	// Fix for older BMCs that don't report BootSourceOverrideMode
+	if system.Boot.BootSourceOverrideMode != "" && system.Boot.BootSourceOverrideMode != redfish.UEFIBootSourceOverrideMode {
 		setBoot = pxeBootWithSettingUEFIBootMode
 	} else {
 		setBoot = pxeBootWithoutSettingUEFIBootMode

--- a/bmc/redfish_kube.go
+++ b/bmc/redfish_kube.go
@@ -376,7 +376,8 @@ func (r *RedfishKubeBMC) SetPXEBootOnce(ctx context.Context, systemURI string) e
 	}
 	var setBoot redfish.Boot
 	// TODO: cover setting BootSourceOverrideMode with BIOS settings profile
-	if system.Boot.BootSourceOverrideMode != redfish.UEFIBootSourceOverrideMode {
+	// Fix for older BMCs that don't report BootSourceOverrideMode
+	if system.Boot.BootSourceOverrideMode != "" && system.Boot.BootSourceOverrideMode != redfish.UEFIBootSourceOverrideMode {
 		setBoot = pxeBootWithSettingUEFIBootMode
 	} else {
 		setBoot = pxeBootWithoutSettingUEFIBootMode

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -821,9 +821,14 @@ func (r *ServerReconciler) extractServerDetailsFromRegistry(ctx context.Context,
 			CarrierStatus: s.CarrierStatus,
 		}
 
-		// Process all IP addresses from the single IPAddresses slice
+		// Process all IP addresses from IPAddresses slice, with fallback to singular IPAddress
 		var allIPs []metalv1alpha1.IP
-		for _, ipAddr := range s.IPAddresses {
+		ipAddrs := s.IPAddresses
+		// Fallback: if IPAddresses is empty, use the deprecated singular IPAddress field
+		if len(ipAddrs) == 0 && s.IPAddress != "" {
+			ipAddrs = []string{s.IPAddress}
+		}
+		for _, ipAddr := range ipAddrs {
 			if ipAddr != "" {
 				// Parse and validate the IP address
 				ip, err := metalv1alpha1.ParseIP(ipAddr)


### PR DESCRIPTION
* `system.Boot.BootSourceOverrideMode` is sometimes blank in gen 10 Supermicro Redfish, which crashes the operator.
* Process all IP addresses from IPAddresses slice, with fallback to singular IPAddress