### PR TITLE
Fix `kind` local registry

### DIFF
--- a/hack/kind-with-registry.sh
+++ b/hack/kind-with-registry.sh
@@ -39,7 +39,7 @@ EOF
 
 # add the registry config to the nodes
 REGISTRY_DIR="/etc/containerd/certs.d/localhost:${reg_port}"
-node="metal-control-plane"
+node="${KIND_CLUSTER_NAME}-control-plane"
 docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
 cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
 [host."http://${reg_name}:5000"]


### PR DESCRIPTION
# Proposed Changes

- update kind local registry as per https://kind.sigs.k8s.io/docs/user/local-registry/ for containerd v2 compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined local registry configuration to a centralized registry block for development clusters.
  * Added provisioning steps to propagate registry hosting to each node, including per-node certificate directory creation and host entry writing.
  * Improved registry network handling with guarded connectivity checks to avoid redundant attachment attempts.
  * Integrated registry provisioning before final readiness and configuration steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->