### PR TITLE
Use constants for mock server addresses and port in unit tests

### DIFF
--- a/internal/cmd/move/move_test.go
+++ b/internal/cmd/move/move_test.go
@@ -31,13 +31,13 @@ var _ = Describe("metalctl move", func() {
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-common-"},
 			Spec: metalv1alpha1.EndpointSpec{
 				MACAddress: "23:11:8A:33:CF:EA",
-				IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+				IP:         metalv1alpha1.MustParseIP(MockServerIP),
 			}}
 		sourceEndpoint := &metalv1alpha1.Endpoint{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-"},
 			Spec: metalv1alpha1.EndpointSpec{
 				MACAddress: "23:11:8A:33:CF:EB",
-				IP:         metalv1alpha1.MustParseIP("127.0.0.2"),
+				IP:         metalv1alpha1.MustParseIP(MockServerIP2),
 			}}
 		Expect(clients.Source.Create(ctx, sourceCommonEndpoint)).To(Succeed())
 		Expect(clients.Source.Create(ctx, sourceEndpoint)).To(Succeed())

--- a/internal/cmd/move/suite_test.go
+++ b/internal/cmd/move/suite_test.go
@@ -27,6 +27,9 @@ const (
 	pollingInterval      = 50 * time.Millisecond
 	eventuallyTimeout    = 3 * time.Second
 	consistentlyDuration = 1 * time.Second
+	MockServerIP         = "127.0.0.1"
+	MockServerIP2        = "127.0.0.2"
+	MockServerPort       = 8000
 )
 
 var (

--- a/internal/controller/biossettingsset_controller_test.go
+++ b/internal/controller/biossettingsset_controller_test.go
@@ -4,6 +4,8 @@
 package controller
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,9 +23,9 @@ import (
 var _ = Describe("BIOSSettingsSet Controller", func() {
 	var (
 		MockServerIPAddrs = []netip.AddrPort{
-			netip.MustParseAddrPort("127.0.0.1:8000"),
-			netip.MustParseAddrPort("127.0.0.1:8001"),
-			netip.MustParseAddrPort("127.0.0.1:8002"),
+			netip.MustParseAddrPort(fmt.Sprintf("%s:%d", MockServerIP, MockServerPort)),
+			netip.MustParseAddrPort(fmt.Sprintf("%s:%d", MockServerIP, MockServerPort+1)),
+			netip.MustParseAddrPort(fmt.Sprintf("%s:%d", MockServerIP, MockServerPort+2)),
 		}
 		server01  *metalv1alpha1.Server
 		server02  *metalv1alpha1.Server

--- a/internal/controller/biosversion_controller_test.go
+++ b/internal/controller/biosversion_controller_test.go
@@ -55,9 +55,9 @@ var _ = Describe("BIOSVersion Controller", func() {
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
+						Port: MockServerPort,
 					},
-					Address: "127.0.0.1",
+					Address: MockServerIP,
 					BMCSecretRef: v1.LocalObjectReference{
 						Name: bmcSecret.Name,
 					},
@@ -446,12 +446,12 @@ var _ = Describe("BIOSVersion Controller with BMCRef BMC", func() {
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "23:11:8A:33:CF:EA",
 				},
 				Protocol: metalv1alpha1.Protocol{
 					Name: metalv1alpha1.ProtocolRedfishLocal,
-					Port: 8000,
+					Port: MockServerPort,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
 					Name: bmcSecret.Name,

--- a/internal/controller/biosversionset_controller_test.go
+++ b/internal/controller/biosversionset_controller_test.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/netip"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,9 +22,9 @@ import (
 var _ = Describe("BIOSVersionSet Controller", func() {
 	var (
 		MockServerIPAddrs = []netip.AddrPort{
-			netip.MustParseAddrPort("127.0.0.1:8000"),
-			netip.MustParseAddrPort("127.0.0.1:8001"),
-			netip.MustParseAddrPort("127.0.0.1:8002"),
+			netip.MustParseAddrPort(fmt.Sprintf("%s:%d", MockServerIP, MockServerPort)),
+			netip.MustParseAddrPort(fmt.Sprintf("%s:%d", MockServerIP, MockServerPort+1)),
+			netip.MustParseAddrPort(fmt.Sprintf("%s:%d", MockServerIP, MockServerPort+2)),
 		}
 		server01                 *metalv1alpha1.Server
 		server02                 *metalv1alpha1.Server

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -35,7 +35,7 @@ var _ = Describe("BMC Controller", func() {
 			Spec: metalv1alpha1.EndpointSpec{
 				// emulator BMC mac address
 				MACAddress: "23:11:8A:33:CF:EA",
-				IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+				IP:         metalv1alpha1.MustParseIP(MockServerIP),
 			},
 		}
 		Expect(k8sClient.Create(ctx, endpoint)).To(Succeed())
@@ -55,7 +55,7 @@ var _ = Describe("BMC Controller", func() {
 				Controller:         ptr.To(true),
 				BlockOwnerDeletion: ptr.To(true),
 			})),
-			HaveField("Status.IP", metalv1alpha1.MustParseIP("127.0.0.1")),
+			HaveField("Status.IP", metalv1alpha1.MustParseIP(MockServerIP)),
 			HaveField("Status.MACAddress", "23:11:8A:33:CF:EA"),
 			HaveField("Status.Model", "Joo Janta 200"),
 			HaveField("Status.State", metalv1alpha1.BMCStateEnabled),
@@ -122,12 +122,12 @@ var _ = Describe("BMC Controller", func() {
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "23:11:8A:33:CF:EA",
 				},
 				Protocol: metalv1alpha1.Protocol{
 					Name: metalv1alpha1.ProtocolRedfishLocal,
-					Port: 8000,
+					Port: MockServerPort,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
 					Name: bmcSecret.Name,
@@ -137,7 +137,7 @@ var _ = Describe("BMC Controller", func() {
 		Expect(k8sClient.Create(ctx, bmc)).To(Succeed())
 
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Status.IP", metalv1alpha1.MustParseIP("127.0.0.1")),
+			HaveField("Status.IP", metalv1alpha1.MustParseIP(MockServerIP)),
 			HaveField("Status.MACAddress", "23:11:8A:33:CF:EA"),
 			HaveField("Status.Model", "Joo Janta 200"),
 			HaveField("Status.State", metalv1alpha1.BMCStateEnabled),
@@ -199,12 +199,12 @@ var _ = Describe("BMC Controller", func() {
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "23:11:8A:33:CF:EA",
 				},
 				Protocol: metalv1alpha1.Protocol{
 					Name: metalv1alpha1.ProtocolRedfishLocal,
-					Port: 8000,
+					Port: MockServerPort,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
 					Name: bmcSecret.Name,
@@ -214,7 +214,7 @@ var _ = Describe("BMC Controller", func() {
 		Expect(k8sClient.Create(ctx, bmc)).To(Succeed())
 
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Status.IP", metalv1alpha1.MustParseIP("127.0.0.1")),
+			HaveField("Status.IP", metalv1alpha1.MustParseIP(MockServerIP)),
 			HaveField("Status.MACAddress", "23:11:8A:33:CF:EA"),
 			HaveField("Status.Model", "Joo Janta 200"),
 			HaveField("Status.State", metalv1alpha1.BMCStateEnabled),
@@ -277,7 +277,7 @@ var _ = Describe("BMC Validation", func() {
 			Spec: metalv1alpha1.BMCSpec{
 				EndpointRef: &v1.LocalObjectReference{Name: "foo"},
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "aa:bb:cc:dd:ee:ff",
 				},
 			},
@@ -350,7 +350,7 @@ var _ = Describe("BMC Validation", func() {
 		Eventually(Update(bmc, func() {
 			bmc.Spec.EndpointRef = nil
 			bmc.Spec.Endpoint = &metalv1alpha1.InlineEndpoint{
-				IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+				IP:         metalv1alpha1.MustParseIP(MockServerIP),
 				MACAddress: "aa:bb:cc:dd:ee:ff",
 			}
 		})).Should(Succeed())
@@ -367,7 +367,7 @@ var _ = Describe("BMC Validation", func() {
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "aa:bb:cc:dd:ee:ff",
 				},
 			},
@@ -386,7 +386,7 @@ var _ = Describe("BMC Validation", func() {
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "aa:bb:cc:dd:ee:ff",
 				},
 			},
@@ -398,7 +398,7 @@ var _ = Describe("BMC Validation", func() {
 		})).Should(Not(Succeed()))
 
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.Endpoint.IP", metalv1alpha1.MustParseIP("127.0.0.1")),
+			HaveField("Spec.Endpoint.IP", metalv1alpha1.MustParseIP(MockServerIP)),
 			HaveField("Spec.Endpoint.MACAddress", "aa:bb:cc:dd:ee:ff"),
 		))
 
@@ -414,7 +414,7 @@ var _ = Describe("BMC Validation", func() {
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "aa:bb:cc:dd:ee:ff",
 				},
 			},
@@ -459,12 +459,12 @@ var _ = Describe("BMC Reset", func() {
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "aa:bb:cc:dd:ee:ff",
 				},
 				Protocol: metalv1alpha1.Protocol{
 					Name: metalv1alpha1.ProtocolRedfishLocal,
-					Port: 8000,
+					Port: MockServerPort,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
 					Name: bmcSecret.Name,
@@ -527,12 +527,12 @@ var _ = Describe("BMC Conditions", func() {
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "aa:bb:cc:dd:ee:ff",
 				},
 				Protocol: metalv1alpha1.Protocol{
 					Name: metalv1alpha1.ProtocolRedfishLocal,
-					Port: 8000,
+					Port: MockServerPort,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
 					Name: bmcSecret.Name,

--- a/internal/controller/bmcsettings_controller_test.go
+++ b/internal/controller/bmcsettings_controller_test.go
@@ -51,12 +51,12 @@ var _ = Describe("BMCSettings Controller", func() {
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "23:11:8A:33:CF:EA",
 				},
 				Protocol: metalv1alpha1.Protocol{
 					Name: metalv1alpha1.ProtocolRedfishLocal,
-					Port: 8000,
+					Port: MockServerPort,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
 					Name: bmcSecret.Name,

--- a/internal/controller/bmcversion_controller_test.go
+++ b/internal/controller/bmcversion_controller_test.go
@@ -54,12 +54,12 @@ var _ = Describe("BMCVersion Controller", func() {
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
-					IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+					IP:         metalv1alpha1.MustParseIP(MockServerIP),
 					MACAddress: "23:11:8A:33:CF:EA",
 				},
 				Protocol: metalv1alpha1.Protocol{
 					Name: metalv1alpha1.ProtocolRedfishLocal,
-					Port: 8000,
+					Port: MockServerPort,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
 					Name: bmcSecret.Name,

--- a/internal/controller/bmcversionset_controller_test.go
+++ b/internal/controller/bmcversionset_controller_test.go
@@ -24,9 +24,9 @@ import (
 var _ = Describe("BMCVersionSet Controller", func() {
 	var (
 		MockServerIPAddrs = []netip.AddrPort{
-			netip.MustParseAddrPort("127.0.0.1:8000"),
-			netip.MustParseAddrPort("127.0.0.1:8001"),
-			netip.MustParseAddrPort("127.0.0.1:8002"),
+			netip.MustParseAddrPort(fmt.Sprintf("%s:%d", MockServerIP, MockServerPort)),
+			netip.MustParseAddrPort(fmt.Sprintf("%s:%d", MockServerIP, MockServerPort+1)),
+			netip.MustParseAddrPort(fmt.Sprintf("%s:%d", MockServerIP, MockServerPort+2)),
 		}
 		bmc01                   *metalv1alpha1.BMC
 		bmc02                   *metalv1alpha1.BMC

--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Endpoints Controller", func() {
 			},
 			Spec: metalv1alpha1.EndpointSpec{
 				MACAddress: "23:11:8A:33:CF:EA",
-				IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+				IP:         metalv1alpha1.MustParseIP(MockServerIP),
 			},
 		}
 		Expect(k8sClient.Create(ctx, endpoint)).To(Succeed())
@@ -73,7 +73,7 @@ var _ = Describe("Endpoints Controller", func() {
 			HaveField("Spec.BMCSecretRef.Name", Equal(bmc.Name)),
 			HaveField("Spec.Protocol", metalv1alpha1.Protocol{
 				Name: metalv1alpha1.ProtocolRedfishLocal,
-				Port: 8000,
+				Port: MockServerPort,
 			}),
 			HaveField("Spec.ConsoleProtocol", &metalv1alpha1.ConsoleProtocol{
 				Name: metalv1alpha1.ConsoleProtocolNameSSH,

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Server Controller", func() {
 			Spec: metalv1alpha1.EndpointSpec{
 				// emulator BMC mac address
 				MACAddress: "23:11:8A:33:CF:EA",
-				IP:         metalv1alpha1.MustParseIP("127.0.0.1"),
+				IP:         metalv1alpha1.MustParseIP(MockServerIP),
 			},
 		}
 		Expect(k8sClient.Create(ctx, endpoint)).To(Succeed())
@@ -305,9 +305,9 @@ var _ = Describe("Server Controller", func() {
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
+						Port: MockServerPort,
 					},
-					Address: "127.0.0.1",
+					Address: MockServerIP,
 					BMCSecretRef: v1.LocalObjectReference{
 						Name: bmcSecret.Name,
 					},
@@ -528,9 +528,9 @@ var _ = Describe("Server Controller", func() {
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
+						Port: MockServerPort,
 					},
-					Address: "127.0.0.1",
+					Address: MockServerIP,
 					BMCSecretRef: v1.LocalObjectReference{
 						Name: bmcSecret.Name,
 					},
@@ -611,9 +611,9 @@ var _ = Describe("Server Controller", func() {
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
+						Port: MockServerPort,
 					},
-					Address: "127.0.0.1",
+					Address: MockServerIP,
 					BMCSecretRef: v1.LocalObjectReference{
 						Name: bmcSecret.Name,
 					},
@@ -674,9 +674,9 @@ var _ = Describe("Server Controller", func() {
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
+						Port: MockServerPort,
 					},
-					Address: "127.0.0.1",
+					Address: MockServerIP,
 					BMCSecretRef: v1.LocalObjectReference{
 						Name: bmcSecret.Name,
 					},
@@ -758,9 +758,9 @@ var _ = Describe("Server Controller", func() {
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
+						Port: MockServerPort,
 					},
-					Address: "127.0.0.1",
+					Address: MockServerIP,
 					BMCSecretRef: v1.LocalObjectReference{
 						Name: bmcSecret.Name,
 					},

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -50,9 +50,9 @@ var _ = Describe("ServerClaim Controller", func() {
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
+						Port: MockServerPort,
 					},
-					Address: "127.0.0.1",
+					Address: MockServerIP,
 					BMCSecretRef: v1.LocalObjectReference{
 						Name: bmcSecret.Name,
 					},

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -44,9 +44,9 @@ var _ = Describe("ServerMaintenance Controller", func() {
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: 8000,
+						Port: MockServerPort,
 					},
-					Address: "127.0.0.1",
+					Address: MockServerIP,
 					BMCSecretRef: corev1.LocalObjectReference{
 						Name: bmcSecret.Name,
 					},


### PR DESCRIPTION
in #581 the variables `MockServerIP` and `MockServerPort` of a `_test.go` file were moved into the corresponding `suite_test.go` file for that package, this PR updates all other tests to do the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized test configuration by replacing hard-coded server addresses with reusable mock constants across multiple test suites, improving test maintainability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->