### PR TITLE
Fix Server UUID print column

### DIFF
--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -413,7 +413,7 @@ type Storage struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:scope=Cluster
-//+kubebuilder:printcolumn:name="UUID",type=string,JSONPath=`.spec.uuid`
+//+kubebuilder:printcolumn:name="SystemUUID",type=string,JSONPath=`.spec.systemUUID`
 //+kubebuilder:printcolumn:name="Manufacturer",type=string,JSONPath=`.status.manufacturer`
 //+kubebuilder:printcolumn:name="Model",type=string,JSONPath=`.status.model`
 //+kubebuilder:printcolumn:name="Memory",type=string,JSONPath=`.status.totalSystemMemory`

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -15,8 +15,8 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.uuid
-      name: UUID
+    - jsonPath: .spec.systemUUID
+      name: SystemUUID
       type: string
     - jsonPath: .status.manufacturer
       name: Manufacturer

--- a/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
@@ -21,8 +21,8 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.uuid
-      name: UUID
+    - jsonPath: .spec.systemUUID
+      name: SystemUUID
       type: string
     - jsonPath: .status.manufacturer
       name: Manufacturer


### PR DESCRIPTION
# Proposed Changes

- Print column needs to adjusted due to the switch to `systemUUID`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the displayed server information columns to show SystemUUID instead of UUID, ensuring the correct system identifier is presented when viewing server listings and management interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->