### PR TITLE
Add installation guide for `kustomize`

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -24,7 +24,7 @@ export default withMermaid({
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Concepts', link: '/concepts' },
-      { text: 'Usage', link: '/usage' },
+      { text: 'Quickstart', link: '/quickstart' },
       { text: 'IronCore Documentation', link: 'https://ironcore-dev.github.io' },
     ],
 
@@ -46,7 +46,14 @@ export default withMermaid({
     sidebar: [
         {
         items: [
-          { text: 'Quick Start', link: '/usage/installation' },
+          { text: "Quickstart", link: '/quickstart' },
+          { text: 'Installation',
+            collapsed: true,
+            items: [
+              { text: 'Kustomize', link: '/installation/kustomize' },
+              { text: 'Helm', link: '/installation/helm' },
+            ]
+          },
           { text: 'Architecture', link: '/architecture' },
           { text: 'API Reference', link: '/api-reference/api' },
         ]
@@ -75,7 +82,6 @@ export default withMermaid({
         text: 'Usage',
         collapsed: false,
         items: [
-          { text: 'Installation', link: '/usage/installation' },
           { text: 'metalctl', link: '/usage/metalctl' },
         ]
       },

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ hero:
   actions:
     - theme: brand
       text: Getting started
-      link: /usage/installation
+      link: /quickstart
     - theme: alt
       text: API Reference
       link: /api-reference/api

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -1,4 +1,4 @@
-# Helm Installation Guide
+# Helm Installation
 
 This guide will help you install the Metal Operator using Helm.
 

--- a/docs/installation/kustomize.md
+++ b/docs/installation/kustomize.md
@@ -1,0 +1,67 @@
+# Kustomize Installation
+
+This guide will help you install the Metal Operator using Kustomize.
+
+## Prerequisites
+
+- Kubernetes cluster (v1.30+)
+- Kustomize (v5.0.0+)
+- Docker (17.03+)
+- kubectl (v1.30+)
+
+## Install from git
+
+Install the Metal Operator directly from the GitHub repository using Kustomize.
+
+### Steps
+
+1. **Clone the Repository**
+
+   First, clone the Metal Operator repository to your local machine.
+
+   ```sh
+   git clone https://github.com/ironcore-dev/metal-operator.git
+   ```
+   
+2. **Navigate to the Project Directory**
+
+    Change into the Metal Operator directory.
+    
+    ```sh
+    cd metal-operator
+    ```
+   
+3. **Install CRDs**
+
+   Apply the Custom Resource Definitions (CRDs) to your Kubernetes cluster.
+
+   ```sh
+   make install
+   ```
+
+4. **Deploy the Metal Operator**
+
+   Use Kustomize to deploy the Metal Operator to your Kubernetes cluster.
+
+   ```sh
+   make deploy IMG=ghcr.io/ironcore-dev/metal-operator:latest
+   ```
+
+### Uninstall
+
+To uninstall the Metal Operator and remove all associated resources from your Kubernetes cluster, follow these steps:
+
+First, make sure no custom resources are using the CRDs; otherwise, the uninstall will fail.
+Next, delete the installed APIs (CRDs) and the controller.
+
+Delete the APIs(CRDs) from the cluster:
+
+```sh
+make uninstall
+```
+
+Uninstall the controller from the cluster:
+
+```sh
+make undeploy
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,18 @@
+# Quickstart Guide
+
+This guide will help you quickly get started with the Metal Operator.
+
+## Installation
+
+You can install the Metal Operator using either Helm or Kustomize. Choose the method that best fits your workflow.
+* [Kustomize Installation](/installation/kustomize)
+* [Helm Installation](/installation/helm)
+
+## Usage
+
+After installing the Metal Operator, you can start managing your bare-metal servers using Kubernetes-native APIs.
+Refer to the [API Reference](/api-reference/api) for detailed information on the available resources and how to use them.
+
+## Next Steps
+
+- Explore the [metalctl](/usage/metalctl) command-line tool for interacting with the Metal Operator API.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,0 @@
-# your mkdocs plugins go here

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,4 +1,0 @@
-# Usage Guides
-
-- [**Installation**](/usage/installation): Instructions for installing the Metal Operator in your Kubernetes cluster.
-- [**metalctl**](/usage/metalctl): Command-line tool for interacting with the Metal Operator API.


### PR DESCRIPTION
# Proposed Changes

Add an installation guide for using `kustomize` to install the `metal-operator`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Top navigation and hero link updated: "Usage" renamed to "Quickstart" and hero action now points to Quickstart.
  * New Quickstart guide added, linking to installation and usage resources.
  * Installation reorganized into its own collapsed sidebar group with Kustomize and Helm guides; new Kustomize installation guide added.
  * Usage section content removed.
  * Helm page heading simplified; minor placeholder comment removed from docs requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->