### PR TITLE
Set UEFI boot mode override explicitly on Supermicro servers

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -19,9 +19,10 @@ import (
 type Manufacturer string
 
 const (
-	ManufacturerDell   Manufacturer = "Dell Inc."
-	ManufacturerLenovo Manufacturer = "Lenovo"
-	ManufacturerHPE    Manufacturer = "HPE"
+	ManufacturerDell       Manufacturer = "Dell Inc."
+	ManufacturerLenovo     Manufacturer = "Lenovo"
+	ManufacturerHPE        Manufacturer = "HPE"
+	ManufacturerSupermicro Manufacturer = "Supermicro"
 )
 
 // BMC defines an interface for interacting with a Baseboard Management Controller.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined PXE boot decision logic to avoid incorrect UEFI mode application.
  * Added a Supermicro-specific override to ensure UEFI boot is set when required.
  * Introduced recognition for Supermicro systems so the compatibility tweak applies correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This is just a mitigation PR. A proper solution needs to be done here: https://github.com/ironcore-dev/metal-operator/issues/608 

Fixes #606 
