### PR TITLE
Improved automated chart versioning

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -44,15 +46,28 @@ jobs:
       - name: Determine chart version
         id: chart_version
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            # Use SHA for main branch
-            CHART_VERSION="0.0.0-$(echo ${{ github.sha }} | cut -c1-7)"
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             # Use tag version (strip 'v' prefix)
             CHART_VERSION="${GITHUB_REF#refs/tags/v}"
           else
-            # Use PR SHA for dry run
-            CHART_VERSION="0.0.0-$(echo ${{ github.sha }} | cut -c1-7)"
+            # Get the latest tag
+            LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "v0.0.0")
+            # Strip 'v' prefix
+            VERSION="${LATEST_TAG#v}"
+            # Remove prerelease/build metadata (everything after '-' or '+')
+            BASE_VERSION="${VERSION%%-*}"
+            BASE_VERSION="${BASE_VERSION%%+*}"
+            # Parse base version
+            MAJOR=$(echo $BASE_VERSION | cut -d. -f1)
+            MINOR=$(echo $BASE_VERSION | cut -d. -f2)
+            PATCH=$(echo $BASE_VERSION | cut -d. -f3)
+            # Increment patch version
+            NEXT_PATCH=$((PATCH + 1))
+            # Get timestamp and short SHA
+            TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+            SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+            # Format: major.minor.patch+1-timestamp-sha
+            CHART_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-${TIMESTAMP}-${SHORT_SHA}"
           fi
           echo "version=$CHART_VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION

# Proposed Changes

New commits to main result in a published chart following `<MAJOR>.<MINOR>.<NEXT_PATCH>-<TIMESTAMP>-<SHORT_SHA>`

Fixes #603 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated chart versioning: tag pushes keep the release tag; non-tag pushes now derive the next patch from the latest tag and produce a pre-release version that includes a UTC timestamp and short commit identifier.
  * CI checkout behavior adjusted to ensure full repository context for version calculation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->