### PR TITLE
Implement BootPolicy API handling in the ServerClaim

### DIFF
--- a/api/v1alpha1/serverclaim_types.go
+++ b/api/v1alpha1/serverclaim_types.go
@@ -12,6 +12,11 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.serverRef) || has(self.serverRef)", message="serverRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.serverSelector) || has(self.serverSelector)", message="serverSelector is required once set"
 type ServerClaimSpec struct {
+	// BootPolicy specifies how the server should be configured to boot from the network.
+	// +kubebuilder:validation:Enum=None;NetworkBootOnce;NetworkBootAlways
+	// +kubebuilder:default=NetworkBootOnce
+	BootPolicy BootPolicy `json:"bootPolicy,omitempty"`
+
 	// Power specifies the desired power state of the server.
 	// +required
 	Power Power `json:"power"`
@@ -39,6 +44,18 @@ type ServerClaimSpec struct {
 	// +required
 	Image string `json:"image"`
 }
+
+// BootPolicy defines the boot behavior for a server claimed by a ServerClaim.
+type BootPolicy string
+
+const (
+	// BootPolicyNone indicates that no network boot should be configured when reconciling the server claim.
+	BootPolicyNone BootPolicy = "None"
+	// BootPolicyNetworkBootOnce configures the server to boot from the network once on the next power cycle.
+	BootPolicyNetworkBootOnce BootPolicy = "NetworkBootOnce"
+	// BootPolicyNetworkBootAlways configures the server to set PXE boot on every reconciliation.
+	BootPolicyNetworkBootAlways BootPolicy = "NetworkBootAlways"
+)
 
 // Phase defines the possible phases of a ServerClaim.
 type Phase string

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ironcore-dev/controller-utils/conditionutils"
@@ -92,6 +93,8 @@ func main() { // nolint: gocyclo
 		serverMaxConcurrentReconciles      int
 		serverClaimMaxConcurrentReconciles int
 		dnsRecordTemplatePath              string
+		firstBootConditionsRaw             string
+		firstBootConditions                []string
 	)
 
 	flag.IntVar(&serverMaxConcurrentReconciles, "server-max-concurrent-reconciles", 5,
@@ -150,6 +153,8 @@ func main() { // nolint: gocyclo
 		"Timeout for BIOS Settings Controller")
 	flag.StringVar(&dnsRecordTemplatePath, "dns-record-template-path", "",
 		"Path to the DNS record template file used for creating DNS records for Servers.")
+	flag.StringVar(&firstBootConditionsRaw, "first-boot-conditions", "IgnitionDataFetched,IPXEScriptFetched",
+		"Comma-separated list of ServerBootConfiguration condition types that indicate first boot completion.")
 
 	opts := zap.Options{
 		Development: true,
@@ -158,6 +163,8 @@ func main() { // nolint: gocyclo
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	firstBootConditions = splitAndTrimList(firstBootConditionsRaw)
 
 	if probeOSImage == "" {
 		setupLog.Error(nil, "probe OS image must be set")
@@ -368,6 +375,7 @@ func main() { // nolint: gocyclo
 		EnforcePowerOff:         enforcePowerOff,
 		MaxConcurrentReconciles: serverMaxConcurrentReconciles,
 		Conditions:              conditionutils.NewAccessor(conditionutils.AccessorOptions{}),
+		FirstBootConditions:     firstBootConditions,
 		BMCOptions: bmc.Options{
 			BasicAuth:               true,
 			PowerPollingInterval:    powerPollingInterval,
@@ -583,4 +591,21 @@ func main() { // nolint: gocyclo
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func splitAndTrimList(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		out = append(out, part)
+	}
+	return out
 }

--- a/config/crd/bases/metal.ironcore.dev_serverclaims.yaml
+++ b/config/crd/bases/metal.ironcore.dev_serverclaims.yaml
@@ -55,6 +55,15 @@ spec:
           spec:
             description: ServerClaimSpec defines the desired state of ServerClaim.
             properties:
+              bootPolicy:
+                default: NetworkBootOnce
+                description: BootPolicy specifies how the server should be configured
+                  to boot from the network.
+                enum:
+                - None
+                - NetworkBootOnce
+                - NetworkBootAlways
+                type: string
               ignitionSecretRef:
                 description: |-
                   IgnitionSecretRef is a reference to the Kubernetes Secret object that contains

--- a/dist/chart/templates/crd/metal.ironcore.dev_serverclaims.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_serverclaims.yaml
@@ -61,6 +61,15 @@ spec:
           spec:
             description: ServerClaimSpec defines the desired state of ServerClaim.
             properties:
+              bootPolicy:
+                default: NetworkBootOnce
+                description: BootPolicy specifies how the server should be configured
+                  to boot from the network.
+                enum:
+                - None
+                - NetworkBootOnce
+                - NetworkBootAlways
+                type: string
               ignitionSecretRef:
                 description: |-
                   IgnitionSecretRef is a reference to the Kubernetes Secret object that contains

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -844,6 +844,24 @@ _Appears in:_
 | `device` _string_ | Device is the device to boot from. |  |  |
 
 
+#### BootPolicy
+
+_Underlying type:_ _string_
+
+BootPolicy defines the boot behavior for a server claimed by a ServerClaim.
+
+
+
+_Appears in:_
+- [ServerClaimSpec](#serverclaimspec)
+
+| Field | Description |
+| --- | --- |
+| `None` | BootPolicyNone indicates that no network boot should be configured when reconciling the server claim.<br /> |
+| `NetworkBootOnce` | BootPolicyNetworkBootOnce configures the server to boot from the network once on the next power cycle.<br /> |
+| `NetworkBootAlways` | BootPolicyNetworkBootAlways configures the server to set PXE boot on every reconciliation.<br /> |
+
+
 #### ConsoleProtocol
 
 
@@ -1326,6 +1344,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `bootPolicy` _[BootPolicy](#bootpolicy)_ | BootPolicy specifies how the server should be configured to boot from the network. | NetworkBootOnce | Enum: [None NetworkBootOnce NetworkBootAlways] <br /> |
 | `power` _[Power](#power)_ | Power specifies the desired power state of the server. |  |  |
 | `serverRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | ServerRef is a reference to a specific server to be claimed.<br />This field is optional and can be omitted if the server is to be selected using ServerSelector. |  | Optional: \{\} <br /> |
 | `serverSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#labelselector-v1-meta)_ | ServerSelector specifies a label selector to identify the server to be claimed.<br />This field is optional and can be omitted if a specific server is referenced using ServerRef. |  | Optional: \{\} <br /> |

--- a/docs/concepts/serverclaims.md
+++ b/docs/concepts/serverclaims.md
@@ -43,6 +43,12 @@ spec:
     name: my-ignition-secret
 ```
 
+## Boot Policies
+
+- `bootPolicy: NetworkBootOnce` (default): The controller configures a one-time PXE boot when the server is restarted.
+- `bootPolicy: NetworkBootAlways`: The controller always refreshes the PXE boot configuration during reconciliation, ensuring every power cycle uses network boot.
+- `bootPolicy: None`: The controller does not configure PXE boot, preserving the existing boot configuration during power operations.
+
 ## Reconciliation Process
 
 - [`ServerBootConfiguration`](serverbootconfigurations.md):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bootPolicy to ServerClaim with options None, NetworkBootOnce (default), NetworkBootAlways.
  * Added configurable first-boot conditions flag to control initial boot behavior.

* **Documentation**
  * Updated API reference and concepts guide with boot policy details and examples.

* **Tests**
  * Added comprehensive tests covering PXE boot decision logic across policies and first-boot scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->