### PR TITLE
Set maintenance needed label on `ServerClaim`

### DIFF
--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -25,6 +25,9 @@ import (
 const (
 	// ServerMaintenanceFinalizer is the finalizer for the ServerMaintenance resource.
 	ServerMaintenanceFinalizer = "metal.ironcore.dev/servermaintenance"
+
+	// trueValue represents the string value "true" used for labels and annotations
+	trueValue = "true"
 )
 
 // ServerMaintenanceReconciler reconciles a ServerMaintenance object
@@ -137,11 +140,11 @@ func (r *ServerMaintenanceReconciler) handlePendingState(ctx context.Context, lo
 	if serverClaim.Labels == nil {
 		serverClaim.Labels = make(map[string]string)
 	}
-	serverClaim.Labels[metalv1alpha1.ServerMaintenanceNeededLabelKey] = "true"
+	serverClaim.Labels[metalv1alpha1.ServerMaintenanceNeededLabelKey] = trueValue
 	if serverClaim.Annotations == nil {
 		serverClaim.Annotations = make(map[string]string)
 	}
-	serverClaim.Annotations[metalv1alpha1.ServerMaintenanceNeededLabelKey] = "true"
+	serverClaim.Annotations[metalv1alpha1.ServerMaintenanceNeededLabelKey] = trueValue
 	if maintenance.Annotations[metalv1alpha1.ServerMaintenanceReasonAnnotationKey] != "" {
 		serverClaim.Annotations[metalv1alpha1.ServerMaintenanceReasonAnnotationKey] = maintenance.Annotations[metalv1alpha1.ServerMaintenanceReasonAnnotationKey]
 	}

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -180,8 +180,8 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Ensuring that the ServerClaim has the maintenance needed label and annotation")
 		Eventually(Object(serverClaim)).Should(SatisfyAll(
-			HaveField("ObjectMeta.Annotations", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceNeededLabelKey, "true")),
-			HaveField("ObjectMeta.Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceNeededLabelKey, "true")),
+			HaveField("ObjectMeta.Annotations", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceNeededLabelKey, trueValue)),
+			HaveField("ObjectMeta.Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceNeededLabelKey, trueValue)),
 		))
 
 		By("Checking the Server is not in maintenance")
@@ -191,16 +191,16 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Approving the maintenance")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovalKey, "true")
+			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovalKey, trueValue)
 		})).Should(Succeed())
 
 		maintenanceAnnotations := map[string]string{
-			metalv1alpha1.ServerMaintenanceNeededLabelKey:      "true",
+			metalv1alpha1.ServerMaintenanceNeededLabelKey:      trueValue,
 			metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "test-maintenance",
-			metalv1alpha1.ServerMaintenanceApprovalKey:         "true",
+			metalv1alpha1.ServerMaintenanceApprovalKey:         trueValue,
 		}
 		maintenanceLabels := map[string]string{
-			metalv1alpha1.ServerMaintenanceNeededLabelKey: "true",
+			metalv1alpha1.ServerMaintenanceNeededLabelKey: trueValue,
 		}
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Spec.ServerMaintenanceRef.Name", serverMaintenance.Name),


### PR DESCRIPTION
# Proposed Changes

- To align with CCM [flow](https://github.com/ironcore-dev/cloud-provider-metal/blob/d2937f8b0f523cd50c96b222c90914d801b8729e/pkg/cloudprovider/metal/node_controller.go#L121-L125), we will also label the `ServerClaim` with `ServerMaintenanceNeeded` label
- Later, same annotation will be removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server maintenance status is now recorded on ServerClaim objects using both labels and annotations, improving visibility and compatibility with Kubernetes tooling; status is set and removed consistently across lifecycle stages.

* **Tests**
  * Test suite updated to verify both label and annotation presence, values and removal across maintenance transitions, including pending, approval, and cleanup flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->