### PR TITLE
Manage systems with empty `systemUUIDs`

### DIFF
--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -83,7 +83,8 @@ type ServerSpec struct {
 	UUID string `json:"uuid,omitempty"`
 
 	// SystemUUID is the unique identifier for the server.
-	// +required
+	// If not provided, it will be derived from the serial
+	// +optional
 	SystemUUID string `json:"systemUUID"`
 
 	// SystemURI is the unique URI for the server resource in REDFISH API.

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -848,7 +848,9 @@ func (r *RedfishBMC) getSystemFromUri(ctx context.Context, systemURI string) (*s
 		}); err != nil {
 		return nil, fmt.Errorf("failed to wait for for server systems to be ready: %w", err)
 	}
-	if system.UUID != "" {
+	// System is considered ready even if UUID is empty - allow graceful handling of systems
+	// that don't expose System.UUID in their Redfish payload
+	if system != nil {
 		return system, nil
 	}
 	return nil, fmt.Errorf("no system found for %v", systemURI)

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -292,15 +292,15 @@ spec:
                   REDFISH API.
                 type: string
               systemUUID:
-                description: SystemUUID is the unique identifier for the server.
+                description: |-
+                  SystemUUID is the unique identifier for the server.
+                  If not provided, it will be derived from the serial
                 type: string
               uuid:
                 description: |-
                   UUID is the unique identifier for the server.
                   Deprecated in favor of systemUUID.
                 type: string
-            required:
-            - systemUUID
             type: object
           status:
             description: ServerStatus defines the observed state of Server.

--- a/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
@@ -298,15 +298,15 @@ spec:
                   REDFISH API.
                 type: string
               systemUUID:
-                description: SystemUUID is the unique identifier for the server.
+                description: |-
+                  SystemUUID is the unique identifier for the server.
+                  If not provided, it will be derived from the serial
                 type: string
               uuid:
                 description: |-
                   UUID is the unique identifier for the server.
                   Deprecated in favor of systemUUID.
                 type: string
-            required:
-            - systemUUID
             type: object
           status:
             description: ServerStatus defines the observed state of Server.

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1557,7 +1557,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `uuid` _string_ | UUID is the unique identifier for the server.<br />Deprecated in favor of systemUUID. |  |  |
-| `systemUUID` _string_ | SystemUUID is the unique identifier for the server. |  |  |
+| `systemUUID` _string_ | SystemUUID is the unique identifier for the server.<br />If not provided, it will be derived from the serial |  |  |
 | `systemURI` _string_ | SystemURI is the unique URI for the server resource in REDFISH API. |  |  |
 | `power` _[Power](#power)_ | Power specifies the desired power state of the server. |  |  |
 | `indicatorLED` _[IndicatorLED](#indicatorled)_ | IndicatorLED specifies the desired state of the server's indicator LED. |  |  |

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -977,7 +977,7 @@ var _ = Describe("generatePseudoUUID", func() {
 		}
 	})
 
-	It("Should generate deterministic UUIDs", func() {
+	It("Should generate UUIDs that are deterministic", func() {
 		serial := "TEST-SERIAL-12345"
 		uuid1 := generatePseudoUUID(serial)
 		uuid2 := generatePseudoUUID(serial)
@@ -986,7 +986,7 @@ var _ = Describe("generatePseudoUUID", func() {
 			"Same serial should always produce same UUID")
 	})
 
-	It("Should generate unique UUIDs for different inputs", func() {
+	It("Should generate UUIDs that are unique for different inputs", func() {
 		serials := []string{"SN001", "SN002", "SN003", "SN004", "SN005"}
 		uuids := make(map[string]bool)
 
@@ -1000,7 +1000,7 @@ var _ = Describe("generatePseudoUUID", func() {
 		Expect(uuids).To(HaveLen(len(serials)))
 	})
 
-	It("Should handle varying lengths and complexity", func() {
+	It("Should generate UUIDs that handle serials of varying length and complexity", func() {
 		testCases := []string{
 			"X",          // minimal
 			"SHORT",      // short


### PR DESCRIPTION
# Proposed Changes

allow systems that do not report a system uuid, generate deterministic uuid from the serial

# Fixes 

- #612 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System UUID is now optional; if absent it will be deterministically derived from the system serial to provide a stable identifier.

* **Bug Fixes**
  * Readiness checks treat systems without an exposed UUID as available.
  * Improved URI resolution with clearer errors for multi-system scenarios.

* **Documentation**
  * API and CRD docs updated to document UUID derivation.

* **Tests**
  * Added comprehensive tests validating deterministic UUID generation and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->