### PR TITLE
Enqueue multiple ServerClaims on Server changes

### DIFF
--- a/internal/controller/serverclaim_controller.go
+++ b/internal/controller/serverclaim_controller.go
@@ -441,13 +441,11 @@ func (r *ServerClaimReconciler) enqueueServerClaimByRefs() handler.EventHandler 
 				req = append(req, reconcile.Request{
 					NamespacedName: types.NamespacedName{Namespace: claim.Namespace, Name: claim.Name},
 				})
-				return req
 			}
 			if claim.Spec.ServerRef == nil {
 				req = append(req, reconcile.Request{
 					NamespacedName: types.NamespacedName{Namespace: claim.Namespace, Name: claim.Name},
 				})
-				return req
 			}
 		}
 		return req


### PR DESCRIPTION
# Proposed Changes

- Returning early causes missed reconciliations and can lead to a bound `Server`/`ServerClaim` pair to be stuck in the `Unbound` state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where server claim reconciliation requests were incomplete, potentially missing valid claim matches. The system now properly processes all applicable requests instead of stopping prematurely.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->