### PR TITLE
Use `ginkgo` instead of `go test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,9 @@ vet: ## Run go vet against code.
 check-gen: generate manifests docs helm fmt ## Run code generation, manifests generation, documentation generation, helm plugin setup, and formatting checks.
 
 .PHONY: test-only
-test-only: setup-envtest ## Run tests without generating manifests or code.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -p $(NPROCS) $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+test-only: setup-envtest ginkgo ## Run tests without generating manifests or code.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	$(GINKGO) --fail-fast --cover --coverprofile=cover.out --skip-package=e2e ./...
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest test-only ## Run tests.
@@ -268,6 +269,7 @@ KUBEBUILDER ?= $(LOCALBIN)/kubebuilder
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GOIMPORTS ?= $(LOCALBIN)/goimports
 METALCTL ?= $(LOCALBIN)/metalctl
+GINKGO ?= $(LOCALBIN)/ginkgo
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
@@ -281,6 +283,12 @@ GOIMPORTS_VERSION ?= v0.38.0
 CRD_REF_DOCS_VERSION ?= v0.2.0
 KUBEBUILDER_VERSION ?= v4.10.1
 ADDLICENSE_VERSION ?= v1.1.1
+GINKGO_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
+
+.PHONY: ginkgo
+ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.
+$(GINKGO): $(LOCALBIN)
+	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo,$(GINKGO_VERSION))
 
 .PHONY: addlicense
 addlicense: $(ADDLICENSE) ## Download addlicense locally if necessary.

--- a/bmc/mock/server/server.go
+++ b/bmc/mock/server/server.go
@@ -365,7 +365,7 @@ func handleSystemReset(s *MockServer, r *http.Request, urlPath string, body []by
 		s.mu.Unlock()
 		s.log.Info("System resource is locked, cannot perform reset", base)
 		go func() {
-			// unlock after waiting period incase of stuck lock
+			// unlock after waiting period in case of stuck lock
 			time.Sleep(300 * time.Millisecond)
 			delete(base, ResourceLockKey)
 		}()

--- a/internal/controller/biossettingsset_controller_test.go
+++ b/internal/controller/biossettingsset_controller_test.go
@@ -331,6 +331,7 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 		server02.ResourceVersion = ""
 		server02.Spec.BIOSSettingsRef = nil
 		Expect(k8sClient.Create(ctx, server02)).Should(Succeed())
+
 		By("Checking if the BIOSSettings have been created")
 		Eventually(Get(biosSettings02)).Should(Succeed())
 		Eventually(Get(biosSettings03)).Should(Succeed())

--- a/internal/controller/biosversionset_controller_test.go
+++ b/internal/controller/biosversionset_controller_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	v1 "k8s.io/api/core/v1"
@@ -315,7 +316,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 
 		By("Deleting the server02")
 		Expect(k8sClient.Delete(ctx, server02)).To(Succeed())
-		Eventually(Get(server02)).ShouldNot(Succeed())
+		Eventually(Get(server02)).Should(Satisfy(apierrors.IsNotFound))
 
 		By("Checking if the BIOSVersion have been deleted")
 		Eventually(Get(biosVersion02)).ShouldNot(Succeed())
@@ -333,6 +334,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 		By("creating the server02")
 		server02.ResourceVersion = ""
 		Expect(k8sClient.Create(ctx, server02)).Should(Succeed())
+
 		By("Checking if the BIOSVersion have been created")
 		Eventually(Get(biosVersion02)).Should(Succeed())
 		Eventually(Get(biosVersion03)).Should(Succeed())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -353,46 +353,23 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 func EnsureCleanState() {
 	GinkgoHelper()
 
-	Eventually(func(g Gomega) error {
-		endpoints := &metalv1alpha1.EndpointList{}
-		g.Eventually(ObjectList(endpoints)).Should(HaveField("Items", HaveLen(0)))
+	objectLists := []client.ObjectList{
+		&metalv1alpha1.EndpointList{},
+		&metalv1alpha1.BMCList{},
+		&metalv1alpha1.BMCSecretList{},
+		&metalv1alpha1.ServerClaimList{},
+		&metalv1alpha1.BMCSettingsSetList{},
+		&metalv1alpha1.BMCSettingsList{},
+		&metalv1alpha1.BMCVersionSetList{},
+		&metalv1alpha1.BMCVersionList{},
+		&metalv1alpha1.BIOSVersionList{},
+		&metalv1alpha1.BIOSSettingsSetList{},
+		&metalv1alpha1.BIOSSettingsList{},
+		&metalv1alpha1.ServerMaintenanceList{},
+		&metalv1alpha1.ServerList{},
+	}
 
-		bmcs := &metalv1alpha1.BMCList{}
-		g.Eventually(ObjectList(bmcs)).Should(HaveField("Items", HaveLen(0)))
-
-		bmcSecrets := &metalv1alpha1.BMCSecretList{}
-		g.Eventually(ObjectList(bmcSecrets)).Should(HaveField("Items", HaveLen(0)))
-
-		claims := &metalv1alpha1.ServerClaimList{}
-		g.Eventually(ObjectList(claims)).Should(HaveField("Items", HaveLen(0)))
-
-		bmcSettingsSets := &metalv1alpha1.BMCSettingsSetList{}
-		g.Eventually(ObjectList(bmcSettingsSets)).Should(HaveField("Items", HaveLen(0)))
-
-		bmcSettingsList := &metalv1alpha1.BMCSettingsList{}
-		g.Eventually(ObjectList(bmcSettingsList)).Should(HaveField("Items", HaveLen(0)))
-
-		bmcVersionSets := &metalv1alpha1.BMCVersionSetList{}
-		g.Eventually(ObjectList(bmcVersionSets)).Should(HaveField("Items", HaveLen(0)))
-
-		bmcVersions := &metalv1alpha1.BMCVersionList{}
-		g.Eventually(ObjectList(bmcVersions)).Should(HaveField("Items", HaveLen(0)))
-
-		biosVersions := &metalv1alpha1.BIOSVersionList{}
-		g.Eventually(ObjectList(biosVersions)).Should(HaveField("Items", HaveLen(0)))
-
-		biosSettingsSets := &metalv1alpha1.BIOSSettingsSetList{}
-		g.Eventually(ObjectList(biosSettingsSets)).Should(HaveField("Items", HaveLen(0)))
-
-		biosSettingsList := &metalv1alpha1.BIOSSettingsList{}
-		g.Eventually(ObjectList(biosSettingsList)).Should(HaveField("Items", HaveLen(0)))
-
-		maintenances := &metalv1alpha1.ServerMaintenanceList{}
-		g.Eventually(ObjectList(maintenances)).Should(HaveField("Items", HaveLen(0)))
-
-		servers := &metalv1alpha1.ServerList{}
-		g.Eventually(ObjectList(servers)).Should(HaveField("Items", HaveLen(0)))
-
-		return nil
-	}).Should(Succeed())
+	for _, list := range objectLists {
+		Eventually(ObjectList(list)).Should(HaveField("Items", HaveLen(0)))
+	}
 }

--- a/internal/registry/server.go
+++ b/internal/registry/server.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"sync"
 
@@ -130,39 +129,39 @@ func (s *Server) bootstateHandler(w http.ResponseWriter, r *http.Request) {
 		s.log.Info("Received unsupported HTTP method", "method", r.Method)
 		return
 	}
-	var bootstate registry.BootstatePayload
-	if err := json.NewDecoder(r.Body).Decode(&bootstate); err != nil {
+	var payload registry.BootstatePayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		s.log.Error(err, "Failed to decode bootstate payload")
 		return
 	}
-	log.Printf("Received boot state for system UUID: %s, Booted: %t\n", bootstate.SystemUUID, bootstate.Booted)
-	if !bootstate.Booted {
+	s.log.Info("Received boot state for system", "SystemUUID", payload.SystemUUID, "BootState", payload.Booted)
+	if !payload.Booted {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 	var servers metalv1alpha1.ServerList
-	if err := s.k8sClient.List(r.Context(), &servers, client.MatchingFields{"spec.systemUUID": bootstate.SystemUUID}); err != nil {
-		http.Error(w, fmt.Sprintf("Failed to list servers for system UUID %s: %v", bootstate.SystemUUID, err), http.StatusInternalServerError)
-		s.log.Error(err, "Failed to list servers for system", "systemUUID", bootstate.SystemUUID)
+	if err := s.k8sClient.List(r.Context(), &servers, client.MatchingFields{"spec.systemUUID": payload.SystemUUID}); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to list servers for system UUID %s: %v", payload.SystemUUID, err), http.StatusInternalServerError)
+		s.log.Error(err, "Failed to list servers for system", "systemUUID", payload.SystemUUID)
 		return
 	}
 	if len(servers.Items) != 1 {
-		http.Error(w, fmt.Sprintf("No servers found for system UUID %s", bootstate.SystemUUID), http.StatusNotFound)
-		s.log.Info("Found unexpected number of server of system", "systemUUID", bootstate.SystemUUID, "count", len(servers.Items))
+		http.Error(w, fmt.Sprintf("No servers found for system UUID %s", payload.SystemUUID), http.StatusNotFound)
+		s.log.Info("Found unexpected number of server of system", "systemUUID", payload.SystemUUID, "count", len(servers.Items))
 		return
 	}
 	server := servers.Items[0]
 	bootConfigRef := server.Spec.BootConfigurationRef
 	if bootConfigRef == nil {
-		http.Error(w, fmt.Sprintf("Servers for system UUID %s does not reference a ServerBootConfiguration", bootstate.SystemUUID), http.StatusNotFound)
+		http.Error(w, fmt.Sprintf("Servers for system UUID %s does not reference a ServerBootConfiguration", payload.SystemUUID), http.StatusNotFound)
 		s.log.Info("Server does not reference a ServerBootConfiguration", "server", server.Name)
 		return
 	}
 	bootConfigKey := client.ObjectKey{Namespace: bootConfigRef.Namespace, Name: bootConfigRef.Name}
 	var bootConfig metalv1alpha1.ServerBootConfiguration
 	if err := s.k8sClient.Get(r.Context(), bootConfigKey, &bootConfig); err != nil {
-		http.Error(w, fmt.Sprintf("No ServerBootConfig found for system UUID %s", bootstate.SystemUUID), http.StatusNotFound)
+		http.Error(w, fmt.Sprintf("No ServerBootConfig found for system UUID %s", payload.SystemUUID), http.StatusNotFound)
 		s.log.Error(err, "Failed to retrieve ServerBootConfiguration", "name", bootConfigKey.Name, "namespace", bootConfig.Namespace)
 		return
 	}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched test execution to Ginkgo with fail-fast and coverage reporting; added local tooling handling to ensure Ginkgo is available.
* **Tests**
  * Reordered endpoint cleanup for more reliable teardown and tolerant deletions.
  * Consolidated repetitive empty-list checks into a single aggregated loop.
  * Made deletion assertions explicitly expect not-found outcomes where appropriate.
* **Bug Fixes / Logging**
  * Improved boot-state logging to be structured and clearer.
* **Style**
  * Minor comment and formatting cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #637 