### PR TITLE
Allow PR based image publishing via `publish-image` label

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -70,7 +70,9 @@ jobs:
         version: latest
         endpoint: builders # self-hosted
     - name: Login to GHCR
-      if: github.event_name != 'pull_request'
+      if: |
+        github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'publish-image')
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -82,7 +84,7 @@ jobs:
       with:
         context: .
         platforms: linux/amd64,linux/arm64
-        push: ${{ github.event_name != 'pull_request' }}
+        push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'publish-image') }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         target: ${{ matrix.image.target }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image publishing workflow: pull requests labeled with "publish-image" can now trigger container registry login and image pushes. This enables selected PRs to publish images automatically, giving maintainers finer control over when and which changes produce published Docker images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->