### PR TITLE
Add `DNSRecord` template volume to Helm chart

### DIFF
--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -61,6 +61,11 @@ spec:
         volumeMounts:
         - mountPath: /etc/macdb/
           name: macdb
+        {{- if .Values.controllerManager.dnsRecordTemplate.enabled }}
+        - mountPath: /etc/metal-operator/dns
+          name: dns-record-template
+          readOnly: true
+        {{- end }}
         {{- if and .Values.webhook.enable .Values.certmanager.enable }}
         - name: webhook-cert
           mountPath: /tmp/k8s-webhook-server/serving-certs
@@ -87,6 +92,11 @@ spec:
       - name: macdb
         secret:
           secretName: macdb
+      {{- if .Values.controllerManager.dnsRecordTemplate.enabled }}
+      - name: dns-record-template
+        configMap:
+          name: dns-record-template
+      {{- end }}
       {{- if and .Values.webhook.enable .Values.certmanager.enable }}
       - name: webhook-cert
         secret:

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -36,6 +36,8 @@ controllerManager:
       capabilities:
         drop:
           - "ALL"
+  dnsRecordTemplate:
+    enabled: false
   podSecurityContext:
     runAsNonRoot: true
     seccompProfile:


### PR DESCRIPTION
# Proposed Changes

adds a dns template volume to helm-charts. Disabled per default