### PR TITLE
Fix certificate dns names for webhook and metrics services

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,43 +15,43 @@ namePrefix: metal-operator-
 #    someName: someValue
 
 resources:
-- ../crd
-- ../rbac
-- ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-# - ../prometheus
-# [METRICS] Expose the controller manager metrics service.
-- metrics_service.yaml
+  - ../crd
+  - ../rbac
+  - ../manager
+  # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+  # crd/kustomization.yaml
+  - ../webhook
+  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+  - ../certmanager
+  # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+  # - ../prometheus
+  # [METRICS] Expose the controller manager metrics service.
+  - metrics_service.yaml
 
 patches:
-# [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
-# More info: https://book.kubebuilder.io/reference/metrics
-- path: manager_metrics_patch.yaml
-  target:
-    kind: Deployment
+  # [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
+  # More info: https://book.kubebuilder.io/reference/metrics
+  - path: manager_metrics_patch.yaml
+    target:
+      kind: Deployment
 
-# Uncomment the patches line if you enable Metrics and CertManager
-# [METRICS-WITH-CERTS] To enable metrics protected with certManager, uncomment the following line.
-# This patch will protect the metrics with certManager self-signed certs.
-- path: cert_metrics_manager_patch.yaml
-  target:
-   kind: Deployment
+  # Uncomment the patches line if you enable Metrics and CertManager
+  # [METRICS-WITH-CERTS] To enable metrics protected with certManager, uncomment the following line.
+  # This patch will protect the metrics with certManager self-signed certs.
+  - path: cert_metrics_manager_patch.yaml
+    target:
+      kind: Deployment
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-- path: manager_webhook_patch.yaml
-  target:
-   kind: Deployment
+  # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+  # crd/kustomization.yaml
+  - path: manager_webhook_patch.yaml
+    target:
+      kind: Deployment
 
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
-# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
-# 'CERTMANAGER' needs to be enabled to use ca injection
-- path: webhookcainjection_patch.yaml
+  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+  # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+  # 'CERTMANAGER' needs to be enabled to use ca injection
+  - path: webhookcainjection_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
@@ -68,7 +68,7 @@ replacements:
         fieldPaths:
           - .metadata.annotations.[cert-manager.io/inject-ca-from]
         options:
-          delimiter: '/'
+          delimiter: "/"
           index: 0
           create: true
       - select:
@@ -76,7 +76,7 @@ replacements:
         fieldPaths:
           - .metadata.annotations.[cert-manager.io/inject-ca-from]
         options:
-          delimiter: '/'
+          delimiter: "/"
           index: 0
           create: true
       - select:
@@ -84,7 +84,7 @@ replacements:
         fieldPaths:
           - .metadata.annotations.[cert-manager.io/inject-ca-from]
         options:
-          delimiter: '/'
+          delimiter: "/"
           index: 0
           create: true
   - source:
@@ -99,7 +99,7 @@ replacements:
         fieldPaths:
           - .metadata.annotations.[cert-manager.io/inject-ca-from]
         options:
-          delimiter: '/'
+          delimiter: "/"
           index: 1
           create: true
       - select:
@@ -107,7 +107,7 @@ replacements:
         fieldPaths:
           - .metadata.annotations.[cert-manager.io/inject-ca-from]
         options:
-          delimiter: '/'
+          delimiter: "/"
           index: 1
           create: true
       - select:
@@ -115,40 +115,82 @@ replacements:
         fieldPaths:
           - .metadata.annotations.[cert-manager.io/inject-ca-from]
         options:
-          delimiter: '/'
+          delimiter: "/"
           index: 1
           create: true
-  - source: # Add cert-manager annotation to the webhook Service
-      kind: Service
-      version: v1
-      name: webhook-service
-      fieldPath: .metadata.name # namespace of the service
-    targets:
-      - select:
-          kind: Certificate
-          group: cert-manager.io
-          version: v1
-        fieldPaths:
-          - .spec.dnsNames.0
-          - .spec.dnsNames.1
-        options:
-          delimiter: '.'
-          index: 0
-          create: true
+  # [WEBHOOK-CERT] Replace SERVICE_NAME in webhook certificate dnsNames
   - source:
       kind: Service
       version: v1
       name: webhook-service
-      fieldPath: .metadata.namespace # namespace of the service
+      fieldPath: .metadata.name
     targets:
       - select:
           kind: Certificate
           group: cert-manager.io
           version: v1
+          name: serving-cert
         fieldPaths:
           - .spec.dnsNames.0
           - .spec.dnsNames.1
         options:
-          delimiter: '.'
+          delimiter: "."
+          index: 0
+          create: true
+  # [WEBHOOK-CERT] Replace SERVICE_NAMESPACE in webhook certificate dnsNames
+  - source:
+      kind: Service
+      version: v1
+      name: webhook-service
+      fieldPath: .metadata.namespace
+    targets:
+      - select:
+          kind: Certificate
+          group: cert-manager.io
+          version: v1
+          name: serving-cert
+        fieldPaths:
+          - .spec.dnsNames.0
+          - .spec.dnsNames.1
+        options:
+          delimiter: "."
+          index: 1
+          create: true
+  # [METRICS-CERT] Replace SERVICE_NAME in metrics certificate dnsNames
+  - source:
+      kind: Service
+      version: v1
+      name: controller-manager-metrics-service
+      fieldPath: .metadata.name
+    targets:
+      - select:
+          kind: Certificate
+          group: cert-manager.io
+          version: v1
+          name: metrics-certs
+        fieldPaths:
+          - .spec.dnsNames.0
+          - .spec.dnsNames.1
+        options:
+          delimiter: "."
+          index: 0
+          create: true
+  # [METRICS-CERT] Replace SERVICE_NAMESPACE in metrics certificate dnsNames
+  - source:
+      kind: Service
+      version: v1
+      name: controller-manager-metrics-service
+      fieldPath: .metadata.namespace
+    targets:
+      - select:
+          kind: Certificate
+          group: cert-manager.io
+          version: v1
+          name: metrics-certs
+        fieldPaths:
+          - .spec.dnsNames.0
+          - .spec.dnsNames.1
+        options:
+          delimiter: "."
           index: 1
           create: true


### PR DESCRIPTION
# Proposed Changes

Different dns names for different certificates

Fixes #664 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled webhook support for resource validation and mutation
  * Activated certificate management integration
  * Enabled metrics service for cluster monitoring
  * Configured automatic CA injection for security components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->