### PR TITLE
Use Header.Get("ETag") instead of accessing Header map directly

### DIFF
--- a/bmc/oem/dell.go
+++ b/bmc/oem/dell.go
@@ -109,23 +109,23 @@ func (d *DellIdracManager) GetObjFromUri(
 	ctx context.Context,
 	uri string,
 	respObj any,
-) ([]string, error) {
+) (string, error) {
 	resp, err := d.BMC.GetClient().Get(uri)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	defer resp.Body.Close() // nolint: errcheck
 
 	rawBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	err = json.Unmarshal(rawBody, &respObj)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return resp.Header["Etag"], nil
+	return resp.Header.Get("ETag"), nil
 }
 
 func (d *DellIdracManager) getCurrentBMCSettingAttribute(ctx context.Context) ([]DellAttributes, error) {
@@ -149,9 +149,7 @@ func (d *DellIdracManager) getCurrentBMCSettingAttribute(ctx context.Context) ([
 		if err != nil {
 			errs = append(errs, err)
 		}
-		if eTag != nil {
-			BMCDellAttribute.Etag = eTag[0]
-		}
+		BMCDellAttribute.Etag = eTag
 		BMCDellAttributes = append(BMCDellAttributes, *BMCDellAttribute)
 	}
 	if len(errs) > 0 {
@@ -317,13 +315,13 @@ func (d *DellIdracManager) UpdateBMCAttributesApplyAt(
 		// for each sub type, apply the settings
 		for settingPath, payload := range payloads {
 			// fetch the etag required for settingPath
-			etag, err := func() ([]string, error) {
+			etag, err := func() (string, error) {
 				resp, err := d.BMC.GetClient().Get(settingPath)
 				if err != nil {
-					return nil, err
+					return "", err
 				}
 				defer resp.Body.Close() // nolint: errcheck
-				return resp.Header["Etag"], nil
+				return resp.Header.Get("ETag"), nil
 			}()
 
 			if err != nil {
@@ -336,8 +334,8 @@ func (d *DellIdracManager) UpdateBMCAttributesApplyAt(
 				data["@Redfish.SettingsApplyTime"] = map[string]string{"ApplyTime": string(applyTime)}
 			}
 			var header = make(map[string]string)
-			if etag != nil {
-				header["If-Match"] = etag[0]
+			if etag != "" {
+				header["If-Match"] = etag
 			}
 
 			err = func() error {

--- a/bmc/oem/hpe.go
+++ b/bmc/oem/hpe.go
@@ -105,23 +105,23 @@ func (h *HPEILOManager) GetObjFromUri(
 	ctx context.Context,
 	uri string,
 	respObj any,
-) ([]string, error) {
+) (string, error) {
 	resp, err := h.BMC.GetClient().Get(uri)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	defer resp.Body.Close() // nolint: errcheck
 
 	rawBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	err = json.Unmarshal(rawBody, &respObj)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return resp.Header["Etag"], nil
+	return resp.Header.Get("ETag"), nil
 }
 
 func (h *HPEILOManager) GetOEMBMCSettingAttribute(

--- a/bmc/oem/lenovo.go
+++ b/bmc/oem/lenovo.go
@@ -135,23 +135,23 @@ func (l *LenovoXCCManager) GetObjFromUri(
 	ctx context.Context,
 	uri string,
 	respObj any,
-) ([]string, error) {
+) (string, error) {
 	resp, err := l.BMC.GetClient().Get(uri)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	defer resp.Body.Close() // nolint: errcheck
 
 	rawBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	err = json.Unmarshal(rawBody, &respObj)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return resp.Header["Etag"], nil
+	return resp.Header.Get("ETag"), nil
 }
 
 func (l *LenovoXCCManager) GetOEMBMCSettingAttribute(

--- a/bmc/oem/oem.go
+++ b/bmc/oem/oem.go
@@ -24,7 +24,7 @@ type ManagerInterface interface {
 	CheckBMCAttributes(ctx context.Context, attributes redfish.SettingsAttributes) (bool, error)
 
 	// GetObjFromUri retrieves an object from a given URI and populates the response object.
-	GetObjFromUri(ctx context.Context, uri string, respObj any) ([]string, error)
+	GetObjFromUri(ctx context.Context, uri string, respObj any) (string, error)
 
 	// UpdateBMCAttributesApplyAt updates BMC attributes and applies them at the specified time.
 	UpdateBMCAttributesApplyAt(ctx context.Context, attrs redfish.SettingsAttributes, applyTime common.ApplyTime) error

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -140,7 +140,7 @@ func (r *RedfishBMC) PowerOff(ctx context.Context, systemURI string) error {
 		return fmt.Errorf("failed to get systems: %w", err)
 	}
 	if err := system.Reset(redfish.GracefulShutdownResetType); err != nil {
-		return fmt.Errorf("failed to reset system to power on state: %w", err)
+		return fmt.Errorf("failed to reset system to power off state: %w", err)
 	}
 	return nil
 }
@@ -152,7 +152,7 @@ func (r *RedfishBMC) ForcePowerOff(ctx context.Context, systemURI string) error 
 		return fmt.Errorf("failed to get systems: %w", err)
 	}
 	if err := system.Reset(redfish.ForceOffResetType); err != nil {
-		return fmt.Errorf("failed to reset system to power on state: %w", err)
+		return fmt.Errorf("failed to reset system to force power off state: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #

Instead of accessing the header ETag directly, use the official way to retrieve header values: `Header.Get("ETag").`

Fixes some logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error messages for power off operations to accurately reflect the target state.

* **Refactor**
  * Improved internal consistency across multiple BMC implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->