### PR TITLE
Add `ServerMaintenanceRequested` common label

### DIFF
--- a/api/v1alpha1/servermaintenance_types.go
+++ b/api/v1alpha1/servermaintenance_types.go
@@ -15,6 +15,8 @@ const (
 	ServerMaintenanceReasonAnnotationKey = "metal.ironcore.dev/maintenance-reason"
 	// ServerMaintenanceApprovalKey is a label key that is used to store the approval status for a server maintenance.
 	ServerMaintenanceApprovalKey = "metal.ironcore.dev/maintenance-approval"
+	// ServerMaintenanceRequestedLabelKey is a label key that is used to request server maintenance.
+	ServerMaintenanceRequestedLabelKey = "metal.ironcore.dev/maintenance-requested"
 )
 
 // ServerBootConfigurationTemplate defines the parameters to be used for rendering a boot configuration.


### PR DESCRIPTION
# Proposed Changes

- This label will be mostly used by other components (CCM)
- But we should define it as a common label key, so that other tools can reference it via API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added a new label key for server maintenance requests in the API, enabling enhanced labeling capabilities for maintenance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->