### PR TITLE
Collaps concepts section in docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -60,7 +60,7 @@ export default withMermaid({
       },
       {
         text: 'Concepts',
-        collapsed: false,
+        collapsed: true,
         items: [
           { text: 'Endpoints', link: '/concepts/endpoints' },
           { text: 'BMCs', link: '/concepts/bmcs' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation sidebar to collapse the Concepts section by default, providing a more compact initial view of the navigation menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->