### PR TITLE
Fix percentage display in BMC/BIOS update conditions

### DIFF
--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -758,9 +758,9 @@ func (r *BIOSVersionReconciler) checkUpdateBiosUpgradeStatus(
 		conditionutils.UpdateStatus(corev1.ConditionFalse),
 		conditionutils.UpdateReason(taskCurrentStatus.TaskState),
 		conditionutils.UpdateMessage(
-			fmt.Sprintf("BIOS upgrade in state: %v: PercentageCompleted %v",
+			fmt.Sprintf("BIOS upgrade in state: %v: PercentageCompleted %d",
 				taskCurrentStatus.TaskState,
-				taskCurrentStatus.PercentComplete),
+				upgradeCurrentTaskStatus.PercentComplete),
 		),
 	); err != nil {
 		return false, fmt.Errorf("failed to update conditions: %w", err)

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -970,9 +970,9 @@ func (r *BMCVersionReconciler) checkBMCUpgradeStatus(
 		conditionutils.UpdateStatus(corev1.ConditionFalse),
 		conditionutils.UpdateReason(taskCurrentStatus.TaskState),
 		conditionutils.UpdateMessage(
-			fmt.Sprintf("BMC upgrade in state: %v: PercentageCompleted %v",
+			fmt.Sprintf("BMC upgrade in state: %v: PercentageCompleted %d",
 				taskCurrentStatus.TaskState,
-				taskCurrentStatus.PercentComplete),
+				upgradeCurrentTaskStatus.PercentComplete),
 		),
 	); err != nil {
 		log.Error(err, "failed to update the conditions status. retrying... ")


### PR DESCRIPTION
right now this happens:

```
lastTransitionTime: "2026-02-26T12:07:29Z"
    message: 'BIOS upgrade in state: Running: PercentageCompleted 0x1621457b8640'
    reason: Running
    status: "False"
    type: BIOSUpgradeCompleted
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the percentage completion display for BIOS and BMC firmware upgrades. The progress percentage shown during in-progress upgrades now reflects the accurate completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->