### PR TITLE
Support dynamic settings in BMCSettings CRD spec

### DIFF
--- a/bmc/mockup.go
+++ b/bmc/mockup.go
@@ -30,19 +30,11 @@ type RedfishMockUps struct {
 }
 
 func (r *RedfishMockUps) InitializeDefaults() {
-	r.BIOSSettingAttr = map[string]map[string]any{
-		"abc":       {"type": "string", "reboot": false, "value": "bar"},
-		"fooreboot": {"type": "integer", "reboot": true, "value": 123},
-	}
-	r.BMCSettingAttr = map[string]map[string]any{
-		"abc":       {"type": schemas.StringAttributeType, "reboot": false, "value": "bar"},
-		"fooreboot": {"type": schemas.IntegerAttributeType, "reboot": true, "value": 123},
-	}
-	r.PendingBIOSSetting = map[string]map[string]any{}
-	r.BIOSVersion = ""
-	r.BIOSUpgradingVersion = ""
+	r.ResetBIOSSettings()
+	r.ResetBMCSettings()
+	r.ResetBIOSVersionUpdate()
+	r.ResetBMCVersionUpdate()
 
-	r.BIOSUpgradeTaskIndex = 0
 	r.BIOSUpgradeTaskStatus = []schemas.Task{
 		{
 			TaskState:       schemas.NewTaskState,
@@ -74,12 +66,6 @@ func (r *RedfishMockUps) InitializeDefaults() {
 		},
 	}
 
-	r.PendingBMCSetting = map[string]map[string]any{}
-
-	r.BMCVersion = ""
-	r.BMCUpgradingVersion = ""
-
-	r.BMCUpgradeTaskIndex = 0
 	r.BMCUpgradeTaskStatus = []schemas.Task{
 		{
 			TaskState:       schemas.NewTaskState,
@@ -174,6 +160,7 @@ func (r *RedfishMockUps) ResetBMCSettings() {
 	r.BMCSettingAttr = map[string]map[string]any{
 		"abc":       {"type": schemas.StringAttributeType, "reboot": false, "value": "bar"},
 		"fooreboot": {"type": schemas.IntegerAttributeType, "reboot": true, "value": 123},
+		"123":       {"type": schemas.StringAttributeType, "reboot": false, "value": "foo"},
 	}
 	r.PendingBMCSetting = map[string]map[string]any{}
 }

--- a/config/samples/metal_v1alpha1_bmcsettings.yaml
+++ b/config/samples/metal_v1alpha1_bmcsettings.yaml
@@ -11,4 +11,7 @@ spec:
   version: 1.45.455b66-rev4
   settings:
       abc: "3"
+      # fqdn: `{{ RegexInsertOrReplace .labels.name "-" "r" }}` ->  endpoint-sample CRD will be used to get the value of "name" key from its labels (metadata) and replace using regex pattern "-" with "r"
+      # license: `{{ GetSecretFrom "my-secret" "my-namespace" "key" }}` -> it will get the value of "key" from the secret "my-secret" in "my-namespace"
+      # data: `{{ GetConfigData "my-config" "my-namespace" "key" }}` -> it will get the value of "key" from the configmap "my-config" in "my-namespace"
   serverMaintenancePolicy: Enforced

--- a/internal/bmcutils/bmcutils.go
+++ b/internal/bmcutils/bmcutils.go
@@ -115,16 +115,15 @@ func GetBMCClientForServer(ctx context.Context, c client.Client, server *metalv1
 		b := &metalv1alpha1.BMC{}
 		bmcName := server.Spec.BMCRef.Name
 		if err := c.Get(ctx, client.ObjectKey{Name: bmcName}, b); err != nil {
-			return nil, fmt.Errorf("failed to get BMC: %w", err)
+			return nil, err
 		}
-
 		return GetBMCClientFromBMC(ctx, c, b, insecure, options)
 	}
 
 	if server.Spec.BMC != nil {
 		bmcSecret := &metalv1alpha1.BMCSecret{}
 		if err := c.Get(ctx, client.ObjectKey{Name: server.Spec.BMC.BMCSecretRef.Name}, bmcSecret); err != nil {
-			return nil, fmt.Errorf("failed to get BMC secret: %w", err)
+			return nil, err
 		}
 
 		protocolScheme := GetProtocolScheme(server.Spec.BMC.Protocol.Scheme, insecure)

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -114,6 +114,10 @@ func (r *BIOSSettingsReconciler) shouldDelete(ctx context.Context, settings *met
 
 	if controllerutil.ContainsFinalizer(settings, BIOSSettingsFinalizer) &&
 		settings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress {
+		if _, err := GetServerByName(ctx, r.Client, settings.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
+			log.V(1).Info("Server not found, proceeding with deletion", "Server", settings.Spec.ServerRef.Name)
+			return true
+		}
 		log.V(1).Info("Postponing delete as BIOSSettings update is in progress")
 		return false
 	}
@@ -274,6 +278,11 @@ func (r *BIOSSettingsReconciler) reconcile(ctx context.Context, settings *metalv
 		if errors.As(err, &bmcutils.BMCUnAvailableError{}) {
 			log.V(1).Info("BMC is not available", "BMC", server.Spec.BMCRef.Name, "Server", server.Name, "Message", err.Error())
 			return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
+		}
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("BMC/BMCSecret not found", "BMC", server.Spec.BMCRef.Name, "Server", server.Name, "error", err)
+			// if BMC is not found, then it means the server is not ready for BIOS Settings upgrade, hence requeue until BMC is available
+			return ctrl.Result{}, r.updateStatus(ctx, settings, metalv1alpha1.BIOSSettingsStateFailed, nil)
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get BMC client for server: %w", err)
 	}

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -92,6 +92,10 @@ func (r *BIOSVersionReconciler) shouldDelete(ctx context.Context, biosVersion *m
 
 	if controllerutil.ContainsFinalizer(biosVersion, BIOSVersionFinalizer) &&
 		biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
+		if _, err := GetServerByName(ctx, r.Client, biosVersion.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
+			log.V(1).Info("Server not found, proceeding with deletion", "Server", biosVersion.Spec.ServerRef.Name)
+			return true
+		}
 		log.V(1).Info("Postponing deletion as BIOS version update is in progress")
 		return false
 	}
@@ -188,6 +192,17 @@ func (r *BIOSVersionReconciler) transitionState(ctx context.Context, biosVersion
 			log.V(1).Info("BMC is not available, skipping", "BMC", server.Spec.BMCRef.Name, "Server", server.Name, "error", err)
 			return true, nil
 		}
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("BMC/BMCSecret not found", "BMC", server.Spec.BMCRef.Name, "Server", server.Name, "error", err)
+			// if BMC is not found, then it means the server is not ready for BIOS upgrade, hence requeue until BMC is available
+			var condition *metav1.Condition
+			if len(biosVersion.Status.Conditions) != 0 {
+				condition = &biosVersion.Status.Conditions[len(biosVersion.Status.Conditions)-1]
+			} else {
+				condition = nil
+			}
+			return false, r.updateStatus(ctx, biosVersion, metalv1alpha1.BIOSVersionStateFailed, biosVersion.Status.UpgradeTask, condition)
+		}
 		return false, fmt.Errorf("failed to get BMC client for server %s: %w", server.Name, err)
 	}
 	defer bmcClient.Logout()
@@ -196,72 +211,9 @@ func (r *BIOSVersionReconciler) transitionState(ctx context.Context, biosVersion
 	case "", metalv1alpha1.BIOSVersionStatePending:
 		return false, r.cleanup(ctx, bmcClient, biosVersion, server)
 	case metalv1alpha1.BIOSVersionStateInProgress:
-		if biosVersion.Spec.ServerMaintenanceRef == nil {
-			if requeue, err := r.requestServerMaintenance(ctx, biosVersion, server); err != nil || requeue {
-				return false, err
-			}
-		}
-
-		condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ServerMaintenanceConditionWaiting)
-		if err != nil {
+		if ok, err := r.handleServerMaintenance(ctx, bmcClient, biosVersion, server); err != nil || !ok {
 			return false, err
 		}
-
-		if server.Status.State != metalv1alpha1.ServerStateMaintenance {
-			log.V(1).Info("Server is not in maintenance. waiting...", "server State", server.Status.State, "server", server.Name)
-			if condition.Status != metav1.ConditionTrue {
-				if err := r.Conditions.Update(
-					condition,
-					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
-					conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", biosVersion.Spec.ServerMaintenanceRef.Name)),
-				); err != nil {
-					return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
-				}
-				if err := r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, condition); err != nil {
-					return false, fmt.Errorf("failed to patch BIOSVersion ServerMaintenance waiting conditions: %w", err)
-				}
-			}
-			return false, nil
-		}
-
-		if server.Spec.ServerMaintenanceRef == nil || server.Spec.ServerMaintenanceRef.UID != biosVersion.Spec.ServerMaintenanceRef.UID {
-			log.V(1).Info("Server is already in maintenance", "Server", server.Name)
-			if condition.Status != metav1.ConditionTrue {
-				if err := r.Conditions.Update(
-					condition,
-					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
-					conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", biosVersion.Spec.ServerMaintenanceRef.Name)),
-				); err != nil {
-					return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
-				}
-				if err := r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, condition); err != nil {
-					return false, fmt.Errorf("failed to patch BIOSVersion ServerMaintenance waiting conditions: %w", err)
-				}
-			}
-			return false, nil
-		}
-
-		if condition.Reason != ServerMaintenanceReasonApproved {
-			if err := r.Conditions.Update(
-				condition,
-				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
-				conditionutils.UpdateMessage("Server is now in Maintenance mode"),
-			); err != nil {
-				return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
-			}
-			if err := r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, condition); err != nil {
-				return false, fmt.Errorf("failed to patch BIOSVersion ServerMaintenance waiting conditions: %w", err)
-			}
-			return false, nil
-		}
-
-		if ok, err := r.handleBMCReset(ctx, bmcClient, biosVersion, server); !ok || err != nil {
-			return false, err
-		}
-
 		return r.processInProgressState(ctx, bmcClient, biosVersion, server)
 	case metalv1alpha1.BIOSVersionStateCompleted:
 		return false, r.cleanup(ctx, bmcClient, biosVersion, server)
@@ -286,6 +238,76 @@ func (r *BIOSVersionReconciler) transitionState(ctx context.Context, biosVersion
 
 	log.V(1).Info("Unknown State found", "State", biosVersion.Status.State)
 	return false, nil
+}
+
+func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmcClient bmc.BMC, biosVersion *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	if biosVersion.Spec.ServerMaintenanceRef == nil {
+		if requeue, err := r.requestServerMaintenance(ctx, biosVersion, server); err != nil || requeue {
+			return false, err
+		}
+	}
+
+	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ServerMaintenanceConditionWaiting)
+	if err != nil {
+		return false, err
+	}
+
+	if server.Status.State != metalv1alpha1.ServerStateMaintenance {
+		log.V(1).Info("Server is not in maintenance. waiting...", "server State", server.Status.State, "server", server.Name)
+		if condition.Status != metav1.ConditionTrue {
+			if err := r.Conditions.Update(
+				condition,
+				conditionutils.UpdateStatus(corev1.ConditionTrue),
+				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", biosVersion.Spec.ServerMaintenanceRef.Name)),
+			); err != nil {
+				return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
+			}
+			if err := r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, condition); err != nil {
+				return false, fmt.Errorf("failed to patch BIOSVersion ServerMaintenance waiting conditions: %w", err)
+			}
+		}
+		return false, nil
+	}
+
+	if server.Spec.ServerMaintenanceRef == nil || server.Spec.ServerMaintenanceRef.UID != biosVersion.Spec.ServerMaintenanceRef.UID {
+		log.V(1).Info("Server is already in maintenance", "Server", server.Name)
+		if condition.Status != metav1.ConditionTrue {
+			if err := r.Conditions.Update(
+				condition,
+				conditionutils.UpdateStatus(corev1.ConditionTrue),
+				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", biosVersion.Spec.ServerMaintenanceRef.Name)),
+			); err != nil {
+				return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
+			}
+			if err := r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, condition); err != nil {
+				return false, fmt.Errorf("failed to patch BIOSVersion ServerMaintenance waiting conditions: %w", err)
+			}
+		}
+		return false, nil
+	}
+
+	if condition.Reason != ServerMaintenanceReasonApproved {
+		if err := r.Conditions.Update(
+			condition,
+			conditionutils.UpdateStatus(corev1.ConditionFalse),
+			conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
+			conditionutils.UpdateMessage("Server is now in Maintenance mode"),
+		); err != nil {
+			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
+		}
+		if err := r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, condition); err != nil {
+			return false, fmt.Errorf("failed to patch BIOSVersion ServerMaintenance waiting conditions: %w", err)
+		}
+		return false, nil
+	}
+
+	if ok, err := r.handleBMCReset(ctx, bmcClient, biosVersion, server); !ok || err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcClient bmc.BMC, biosVersion *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -106,6 +106,10 @@ func (r *BMCSettingsReconciler) shouldDelete(
 	if controllerutil.ContainsFinalizer(bmcSetting, BMCSettingFinalizer) &&
 		bmcSetting.Status.State == metalv1alpha1.BMCSettingsStateInProgress {
 		log := ctrl.LoggerFrom(ctx)
+		if _, err := r.getBMC(ctx, bmcSetting); apierrors.IsNotFound(err) {
+			log.V(1).Info("BMC not found, proceeding with deletion", "BMC", bmcSetting.Spec.BMCRef.Name)
+			return true
+		}
 		log.V(1).Info("postponing delete as Settings update is in progress")
 		return false
 	}
@@ -237,7 +241,7 @@ func (r *BMCSettingsReconciler) reconcile(
 	// if referred BMC contains reference to different BMCSettings object - stop reconciliation
 	BMC, err := r.getBMC(ctx, bmcSetting)
 	if err != nil {
-		log.V(1).Info("Referred server object could not be fetched")
+		log.V(1).Info("Referred BMC object could not be fetched")
 		return ctrl.Result{}, err
 	}
 	// patch BMC with BMCSettings reference
@@ -685,7 +689,16 @@ func (r *BMCSettingsReconciler) getBMCSettingsDifference(
 	bmcClient bmc.BMC,
 ) (diff schemas.SettingsAttributes, err error) {
 	log := ctrl.LoggerFrom(ctx)
-	currentSettings, err := bmcClient.GetBMCAttributeValues(ctx, BMC.Spec.BMCUUID, bmcSetting.Spec.SettingsMap)
+	// convert go Template to strings
+	convertedSettings := make(map[string]string)
+	for key, value := range bmcSetting.Spec.SettingsMap {
+		tmpl, err := ConvertTemplate(ctx, r.Client, map[string]any{"labels": BMC.GetLabels()}, value)
+		if err != nil {
+			return diff, fmt.Errorf("failed to process template for key %s: %w", key, err)
+		}
+		convertedSettings[key] = tmpl
+	}
+	currentSettings, err := bmcClient.GetBMCAttributeValues(ctx, BMC.Spec.BMCUUID, convertedSettings)
 	if err != nil {
 		return diff, fmt.Errorf("failed to get BMC settings: %w", err)
 	}
@@ -694,7 +707,7 @@ func (r *BMCSettingsReconciler) getBMCSettingsDifference(
 
 	diff = schemas.SettingsAttributes{}
 	var errs []error
-	for key, value := range bmcSetting.Spec.SettingsMap {
+	for key, value := range convertedSettings {
 		res, ok := currentSettings[key]
 		if ok {
 			switch data := res.(type) {

--- a/internal/controller/bmcsettings_controller_test.go
+++ b/internal/controller/bmcsettings_controller_test.go
@@ -50,6 +50,7 @@ var _ = Describe("BMCSettings Controller", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-bmc-",
 				Namespace:    ns.Name,
+				Labels:       map[string]string{"name": "test-bmc"},
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
@@ -628,6 +629,89 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		Expect(k8sClient.Delete(ctx, bmcSettings2)).To(Succeed())
 		Eventually(Get(bmcSettings2)).Should(Satisfy(apierrors.IsNotFound))
+		Eventually(Object(server)).Should(
+			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
+		)
+	})
+
+	It("Should update the setting if BMCSettings Spec are in go template format", func(ctx SpecContext) {
+		bmcSetting := make(map[string]string)
+		bmcSetting["abc"] = "{{ RegexInsertOrReplace .labels.name \"-\" \"-r\" }}"
+		bmcSetting["123"] = fmt.Sprintf("{{ GetSecretFrom .labels.name \"%v\" \"test-key\" }}", ns.Name)
+
+		By("update the server state to Available state")
+		Eventually(UpdateStatus(server, func() {
+			server.Status.State = metalv1alpha1.ServerStateAvailable
+			server.Status.PowerState = metalv1alpha1.ServerOffPowerState
+		})).Should(Succeed())
+
+		By("Creating an secret")
+		someSecret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      bmc.Labels["name"],
+			},
+			StringData: map[string]string{
+				"test-key": "bar",
+			},
+		}
+		Expect(k8sClient.Create(ctx, someSecret)).To(Succeed())
+
+		By("Creating a BMCSetting")
+		bmcSettings := &metalv1alpha1.BMCSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-bmc-change",
+			},
+			Spec: metalv1alpha1.BMCSettingsSpec{
+				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
+				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
+					Version:                 "1.45.455b66-rev4",
+					SettingsMap:             bmcSetting,
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				}},
+		}
+		Expect(k8sClient.Create(ctx, bmcSettings)).To(Succeed())
+
+		By("Ensuring that the BMC has the BMCSettings ref")
+		Eventually(Object(bmc)).Should(SatisfyAll(
+			HaveField("Spec.BMCSettingRef", &v1.LocalObjectReference{Name: bmcSettings.Name}),
+		))
+
+		By("Ensuring that the BMCSettings has reached next state")
+		Eventually(Object(bmcSettings)).Should(SatisfyAny(
+			HaveField("Status.State", metalv1alpha1.BMCSettingsStateInProgress),
+			HaveField("Status.State", metalv1alpha1.BMCSettingsStateApplied),
+		))
+		Eventually(Object(bmcSettings)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.BMCSettingsStateApplied),
+		))
+
+		By("Ensuring that the Maintenance resource has been deleted")
+		var serverMaintenanceList metalv1alpha1.ServerMaintenanceList
+		Eventually(ObjectList(&serverMaintenanceList)).Should(HaveField("Items", BeEmpty()))
+		Consistently(ObjectList(&serverMaintenanceList)).Should(HaveField("Items", BeEmpty()))
+		Consistently(Object(bmcSettings)).Should(SatisfyAll(
+			HaveField("Spec.ServerMaintenanceRefs", BeNil()),
+		))
+
+		// check if the setting has been rendered correctly by the go template function
+		Expect(bmcPkg.UnitTestMockUps.BMCSettingAttr["abc"]).Should(
+			HaveKeyWithValue("value", "test-rbmc"),
+		)
+		Expect(bmcPkg.UnitTestMockUps.BMCSettingAttr["123"]).Should(
+			HaveKeyWithValue("value", "bar"),
+		)
+
+		By("Deleting the BMCSettings")
+		Expect(k8sClient.Delete(ctx, bmcSettings)).To(Succeed())
+
+		By("Ensuring that the BMCSettings ref is empty on BMC")
+		Eventually(Object(bmc)).Should(SatisfyAll(
+			HaveField("Spec.BMCSettingRef", BeNil()),
+		))
+
+		// cleanup
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
 		)

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -89,6 +89,10 @@ func (r *BMCVersionReconciler) shouldDelete(ctx context.Context, bmcVersion *met
 
 	if controllerutil.ContainsFinalizer(bmcVersion, bmcVersionFinalizer) &&
 		bmcVersion.Status.State == metalv1alpha1.BMCVersionStateInProgress {
+		if _, err := r.getBMCFromBMCVersion(ctx, bmcVersion); apierrors.IsNotFound(err) {
+			log.V(1).Info("BMC not found, proceeding with deletion", "BMC", bmcVersion.Spec.BMCRef.Name)
+			return true
+		}
 		log.V(1).Info("Postponing deletion as BMC version update is in progress")
 		return false
 	}

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"errors"
@@ -11,7 +12,10 @@ import (
 	"maps"
 	"math/big"
 	"reflect"
+	"regexp"
 	"slices"
+	"strings"
+	"text/template"
 
 	"github.com/ironcore-dev/controller-utils/conditionutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
@@ -406,4 +410,102 @@ func labelChangeOrAnyFieldChangeInObject(e event.UpdateEvent, oldFields, newFiel
 	}
 
 	return false
+}
+
+func RegexInsertOrReplace(s, pattern, repl string) string {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return s // or handle error as needed
+	}
+
+	return re.ReplaceAllString(s, repl)
+}
+
+func ConvertTemplate(ctx context.Context, c client.Client, data map[string]any, tmplStr string) (string, error) {
+	// Data to pass to the template
+	// data = map[string]interface{}{
+	// 	"labels": obj.GetLabels(),
+	// }
+	log := ctrl.LoggerFrom(ctx)
+	tmpl := template.New("BMCTemplate").Funcs(template.FuncMap{
+		"RegexInsertOrReplace": RegexInsertOrReplace,
+		"GetSecretFrom": func(name, ns, key string) string {
+			return fmt.Sprintf("secret__RefObj__:::%s:::%s:::%s", name, ns, key)
+		},
+		"GetConfigData": func(name, ns, key string) string {
+			return fmt.Sprintf("config__RefObj__:::%s:::%s:::%s", name, ns, key)
+		},
+	})
+
+	if !IsGoTemplateFormat(tmpl, tmplStr) {
+		return tmplStr, nil
+	}
+
+	tmpl, err := tmpl.Parse(tmplStr)
+	if err != nil {
+		log.V(1).Info("Template parsing error:", "Error", err)
+		return "", err
+	}
+
+	output := &bytes.Buffer{}
+	err = tmpl.Execute(output, data)
+	if err != nil {
+		log.V(1).Info("Template execute error", "Error", err)
+		return "", err
+	}
+
+	re := regexp.MustCompile(`.*__RefObj__:::(.+?):::(.+?):::(.+)`)
+
+	// check for se
+	result := re.ReplaceAllStringFunc(output.String(), func(marker string) string {
+		matches := re.FindStringSubmatch(marker)
+		if len(matches) > 3 {
+			if strings.HasPrefix(marker, "secret__RefObj__") {
+				log.V(1).Info("String is a Go template secret fetch format", "data", matches)
+				s, err := GetSecretsData(ctx, c, matches[1], matches[2], matches[3])
+				if err == nil {
+					return s
+				}
+				log.V(1).Info("Error fetching secret data for Go template", "Error", err)
+			} else if strings.HasPrefix(marker, "config__RefObj__") {
+				log.V(1).Info("String is a Go template config fetch format", "data", matches)
+				s, err := GetConfigData(ctx, c, matches[1], matches[2], matches[3])
+				if err == nil {
+					return s
+				}
+			}
+			return marker // fallback to original if no match
+		}
+		return marker // fallback to original if error
+	})
+
+	log.V(1).Info("String is a Go template format", "String", result)
+	return result, nil
+}
+
+func IsGoTemplateFormat(tmpl *template.Template, s string) bool {
+	_, err := tmpl.Parse(s)
+	return err == nil
+}
+
+func GetSecretsData(ctx context.Context, c client.Client, name, ns, key string) (string, error) {
+	secret := &corev1.Secret{}
+	err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: ns}, secret)
+
+	secretData, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("key not found in secret: %v", secret)
+	}
+	return string(secretData), err
+}
+
+func GetConfigData(ctx context.Context, c client.Client, name, ns, key string) (string, error) {
+	secret := &corev1.ConfigMap{}
+	err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: ns}, secret)
+
+	configData, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("key not found in config map: %v", secret.Data)
+	}
+	return configData, err
 }

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -133,6 +133,16 @@ func (r *ServerReconciler) shouldDelete(ctx context.Context, server *metalv1alph
 
 	if controllerutil.ContainsFinalizer(server, ServerFinalizer) &&
 		server.Status.State == metalv1alpha1.ServerStateMaintenance {
+		if server.Spec.BMCRef != nil {
+			b := &metalv1alpha1.BMC{}
+			bmcName := server.Spec.BMCRef.Name
+			if err := r.Get(ctx, client.ObjectKey{Name: bmcName}, b); err != nil {
+				if apierrors.IsNotFound(err) {
+					log.V(1).Info("BMC not found, proceeding with deletion", "BMC", bmcName, "Server", server.Name)
+					return true
+				}
+			}
+		}
 		log.V(1).Info("Postponing delete as server is in Maintenance state")
 		return false
 	}
@@ -198,6 +208,11 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 		if errors.As(err, &bmcutils.BMCUnAvailableError{}) {
 			log.V(1).Info("BMC is not available, skipping", "BMC", server.Spec.BMCRef.Name, "Server", server.Name, "error", err)
 			return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
+		}
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("BMC/BMCSecret not found", "BMC", server.Spec.BMCRef.Name, "Server", server.Name, "error", err)
+			// if BMC is not found, error until BMC is available
+			return ctrl.Result{}, fmt.Errorf("BMC Resource not Found. %w", err)
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get BMC client for server: %w", err)
 	}


### PR DESCRIPTION
# Proposed Changes
Support dynamic settings in BMC 

Fixes #740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added template support for dynamic BMC settings values, enabling regex-based substitutions and retrieval of values from secrets and configuration maps.

* **Bug Fixes**
  * Improved error handling and resource cleanup when referenced resources (Server, BMC) are missing or not found.
  * Enhanced deletion logic to properly clean up orphaned resources in progress states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->