### PR TITLE
Fix BMC event subscription errors on production hardware

### DIFF
--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -1005,20 +1005,25 @@ func (r *RedfishBaseBMC) CreateEventSubscription(
 		return "", fmt.Errorf("event service is not enabled")
 	}
 	payload := &subscriptionPayload{
-		Destination:         destination,
-		EventFormatType:     eventFormatType, // event or metricreport
-		Protocol:            schemas.RedfishEventDestinationProtocol,
-		DeliveryRetryPolicy: retry,
-		Context:             "metal-operator",
+		Destination:     destination,
+		EventFormatType: eventFormatType, // event or metricreport
+		Protocol:        schemas.RedfishEventDestinationProtocol,
+		Context:         "metal-operator",
+	}
+	// Only set DeliveryRetryPolicy if the BMC supports it.
+	// HPE iLO systems don't support this property and will reject the request with 400 error.
+	// We detect support by checking if the EventService advertises retry capabilities.
+	// As a safe default, we omit this field to maximize compatibility across vendors.
+	if ev.DeliveryRetryAttempts > 0 {
+		payload.DeliveryRetryPolicy = retry
 	}
 	client := ev.GetClient()
 	// some implementations (like Dell) do not support ResourceTypes and RegistryPrefixes
 	if len(ev.ResourceTypes) == 0 {
 		payload.EventTypes = []schemas.EventType{}
-	} else {
-		payload.RegistryPrefixes = []string{""} // Filters by the prefix of the event's MessageId, which points to a Message Registry: [Base, ResourceEvent, iLOEvents]
-		payload.ResourceTypes = []string{""}    // Filters by the schema name (Resource Type) of the event's OriginOfCondition:	[Chassis, ComputerSystem, Power]
 	}
+	// Omit RegistryPrefixes and ResourceTypes to allow all events.
+	// Sending empty strings ("") causes 400 errors on BMCs that validate enum values.
 	resp, err := client.Post(ev.SubscriptionsLink, payload)
 	if err != nil {
 		return "", err

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -549,13 +549,13 @@ func (r *BMCReconciler) handleEventSubscriptions(ctx context.Context, bmcClient 
 	if r.EventURL == "" {
 		return false, nil
 	}
-	log.V(1).Info("Handling event subscriptions for BMC")
+	log.V(1).Info("Handling event subscriptions for BMC", "bmcName", bmcObj.Name, "bmcIP", bmcObj.Status.IP)
 	modified := false
 
 	if bmcObj.Status.MetricsReportSubscriptionLink == "" {
 		link, err := serverevents.SubscribeMetricsReport(ctx, r.EventURL, bmcObj.Name, bmcClient)
 		if err != nil {
-			return false, fmt.Errorf("failed to subscribe to server metrics report: %w", err)
+			return false, fmt.Errorf("failed to subscribe to server metrics report for BMC %s (%s): %w", bmcObj.Name, bmcObj.Status.IP, err)
 		}
 		bmcBase := bmcObj.DeepCopy()
 		bmcObj.Status.MetricsReportSubscriptionLink = link
@@ -563,11 +563,12 @@ func (r *BMCReconciler) handleEventSubscriptions(ctx context.Context, bmcClient 
 		if err := r.Status().Patch(ctx, bmcObj, client.MergeFrom(bmcBase)); err != nil {
 			return false, fmt.Errorf("failed to patch server status with subscription links: %w", err)
 		}
+		log.Info("Created metrics report subscription", "bmcName", bmcObj.Name, "bmcIP", bmcObj.Status.IP, "link", link)
 	}
 	if bmcObj.Status.EventsSubscriptionLink == "" {
 		link, err := serverevents.SubscribeEvents(ctx, r.EventURL, bmcObj.Name, bmcClient)
 		if err != nil {
-			return false, fmt.Errorf("failed to subscribe to server alerts: %w", err)
+			return false, fmt.Errorf("failed to subscribe to server alerts for BMC %s (%s): %w", bmcObj.Name, bmcObj.Status.IP, err)
 		}
 		bmcBase := bmcObj.DeepCopy()
 		bmcObj.Status.EventsSubscriptionLink = link
@@ -575,6 +576,7 @@ func (r *BMCReconciler) handleEventSubscriptions(ctx context.Context, bmcClient 
 		if err := r.Status().Patch(ctx, bmcObj, client.MergeFrom(bmcBase)); err != nil {
 			return false, fmt.Errorf("failed to patch server status with subscription links: %w", err)
 		}
+		log.Info("Created events subscription", "bmcName", bmcObj.Name, "bmcIP", bmcObj.Status.IP, "link", link)
 	}
 	return modified, nil
 }


### PR DESCRIPTION
Fixes three critical issues preventing event subscriptions on HPE iLO and Dell iDRAC systems:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional handling of delivery retry policy in event subscriptions.
  * Corrected event filtering behavior when no resource types are specified.

* **Improvements**
  * Enhanced error reporting for subscription failures with additional BMC context.
  * Improved logging visibility for successful event subscriptions and metrics reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->