### PR TITLE
Document how to connect a remote BMC in the Tilt dev environment

### DIFF
--- a/docs/development/dev_setup.md
+++ b/docs/development/dev_setup.md
@@ -144,7 +144,7 @@ spec:
 
 #### 2. Create a BMCSecret with credentials
 
-Apply a `BMCSecret` with base64-encoded credentials for the BMC:
+Create a `BMCSecret` file with credentials for the BMC:
 
 ```yaml
 apiVersion: metal.ironcore.dev/v1alpha1
@@ -156,16 +156,23 @@ data:
   password: <base64-encoded-password>
 ```
 
+> **Note:** The `username` and `password` values must be base64-encoded. You can encode them with `echo -n '<value>' | base64`.
+
+Save this as `bmcsecret-<node-name>.yaml`, but do not apply it yet.
+
 #### 3. Enable HTTPS for the BMC connection
 
-The manager defaults to `--insecure=true`, which uses plain HTTP. This is fine for the default mock server but may not work for real servers. Make sure to adapt this to the target if necessary. E.g. for a real BMC that uses HTTPS on port 443, set `--insecure=false` in the `Tiltfile`:
+The `--insecure` flag is deprecated. Use `--protocol` and `--skip-cert-validation` instead.
+
+For a real BMC that uses HTTPS on port 443, configure the manager to use secure HTTPS with certificate validation enabled in the `Tiltfile`:
 
 ```python
 settings = {
     "new_args": {
         "metal": [
             # ...
-            "--insecure=false",
+      "--protocol=https",
+      "--skip-cert-validation=false",
         ],
     }
 }
@@ -180,20 +187,6 @@ make tilt-up
 ```
 
 Once the manager is running, apply the `BMCSecret` to the local Kind cluster (it is not part of the kustomize config and must be applied manually):
-
-A `BMCSecret` looks like:
-
-```yaml
-apiVersion: metal.ironcore.dev/v1alpha1
-kind: BMCSecret
-metadata:
-  name: <node-name>
-data:
-  username: <base64-encoded-username>
-  password: <base64-encoded-password>
-```
-
-> **Note:** The `username` and `password` values must be base64-encoded. You can encode them with `echo -n '<value>' | base64`.
 
 ```shell
 # Run against the local Kind cluster

--- a/docs/development/dev_setup.md
+++ b/docs/development/dev_setup.md
@@ -71,3 +71,141 @@ The local development environment can be deleted via
 ```shell
 make kind-delete
 ```
+
+### Connecting a Remote BMC in the Tilt Environment
+
+By default, Tilt runs against a local Redfish mock server. To point the environment at real hardware instead, apply the following changes.
+
+#### Prerequisites: Claim the server on its origin cluster
+
+Before pointing your local environment at a real BMC, ensure the server is not being reconciled by another metal-operator instance. On the cluster that originally owns the server, create a `ServerMaintenance` to claim it and power it off:
+
+```yaml
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: ServerMaintenance
+metadata:
+  name: <maintenance-name>
+  namespace: default
+  annotations:
+    metal.ironcore.dev/maintenance-reason: "<maintenance-name>"
+spec:
+  policy: Enforced
+  serverRef:
+    name: <server-name>
+  serverPower: "Off"
+```
+
+```shell
+# Run against the remote cluster
+kubectl apply -f servermaintenance-<node-name>.yaml
+```
+
+To release the server back when done:
+
+```shell
+# Run against the remote cluster
+kubectl delete -f servermaintenance-<node-name>.yaml
+```
+
+> **Note:** All `kubectl` commands from this point on target the **local** Kind cluster.
+
+#### 1. Replace the mockup endpoint with a real BMC resource
+
+Edit `config/redfish-mockup/redfish_mockup_endpoint.yaml` to define a `BMC` resource targeting the real hardware:
+
+```yaml
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: BMC
+metadata:
+  name: <node-name>
+spec:
+  bmcSecretRef:
+    name: <node-name>
+  hostname: <bmc-hostname>
+  consoleProtocol:
+    name: SSH
+    port: 22
+  access:
+    ip: <bmc-ip>
+  protocol:
+    name: Redfish
+    port: 443
+    scheme: https
+```
+
+#### 2. Create a BMCSecret with credentials
+
+Apply a `BMCSecret` with base64-encoded credentials for the BMC:
+
+```yaml
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: BMCSecret
+metadata:
+  name: <node-name>
+data:
+  username: <base64-encoded-username>
+  password: <base64-encoded-password>
+```
+
+#### 3. Enable HTTPS for the BMC connection
+
+The manager defaults to `--insecure=true`, which uses plain HTTP. For a real BMC on port 443, set `--insecure=false` in the `Tiltfile` to use HTTPS instead:
+
+```python
+settings = {
+    "new_args": {
+        "metal": [
+            # ...
+            "--insecure=false",
+        ],
+    }
+}
+```
+
+#### 4. Claim the server with a ServerMaintenance
+
+Once the `Server` resource has been discovered and is `Available`, create a `ServerMaintenance` to claim it for local development. This prevents the server from being allocated by other consumers and powers it off:
+
+```yaml
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: ServerMaintenance
+metadata:
+  name: <maintenance-name>
+  namespace: default
+  annotations:
+    metal.ironcore.dev/maintenance-reason: "<maintenance-name>"
+spec:
+  policy: Enforced
+  serverRef:
+    name: <server-name>
+  serverPower: "Off"
+```
+
+Apply and delete it with:
+
+```shell
+kubectl apply -f servermaintenance-<node-name>.yaml
+kubectl delete -f servermaintenance-<node-name>.yaml
+```
+
+#### Optional: Use the debug manager image
+
+To get a shell-accessible manager image with `curl` and `ca-certificates` (useful for diagnosing BMC connectivity), switch the Tilt build target to `manager-debug`:
+
+In `Tiltfile`:
+```python
+docker_build('controller', '.', target = 'manager-debug')
+```
+
+And add the corresponding stage to `Dockerfile`:
+```dockerfile
+FROM debian:testing-slim AS manager-debug
+LABEL source_repository="https://github.com/ironcore-dev/metal-operator"
+WORKDIR /
+COPY --from=manager-builder /workspace/manager .
+COPY config/manager/ignition-template.yaml /etc/metal-operator/ignition-template.yaml
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["/manager"]
+```

--- a/docs/development/dev_setup.md
+++ b/docs/development/dev_setup.md
@@ -21,7 +21,7 @@ graph TD
 
 ### Run the local test suite
 
-The local test suite can be run via 
+The local test suite can be run via
 
 ```shell
 make test
@@ -53,6 +53,7 @@ make tilt-up
 ```
 
 This `Makefile` directive will:
+
 - create a local Kind cluster with local registry
 - install cert-manager
 - install [boot-operator](https://github.com/ironcore-dev/boot-operator) to reconcile the `ServerBootConfiguration` CRD
@@ -76,9 +77,17 @@ make kind-delete
 
 By default, Tilt runs against a local Redfish mock server. To point the environment at real hardware instead, apply the following changes.
 
-#### Prerequisites: Claim the server on its origin cluster
+#### Prerequisites: Ensure the BMC is not actively managed
 
-Before pointing your local environment at a real BMC, ensure the server is not being reconciled by another metal-operator instance. On the cluster that originally owns the server, create a `ServerMaintenance` to claim it and power it off:
+Before connecting a real BMC to your local Tilt environment, make sure it is not actively reconciled by another `metal-operator` instance to avoid conflicts. Some common ways to achieve this:
+
+- **ServerMaintenance**: Create a `ServerMaintenance` resource on the production cluster to claim the server and optionally power it off.
+- **Exclude from automation**: Remove the server from the production `metal-operator`'s scope, for example via label selectors or namespace isolation, so it is no longer reconciled.
+- **Decommission temporarily**: If the server is not in active use, you can power it off or disconnect it from the production cluster before testing.
+
+> **Note:** Refer to your production cluster's runbooks for the appropriate procedure.
+
+If you use the `ServerMaintenance` approach, apply a manifest like this on the cluster that currently owns the server:
 
 ```yaml
 apiVersion: metal.ironcore.dev/v1alpha1
@@ -87,12 +96,12 @@ metadata:
   name: <maintenance-name>
   namespace: default
   annotations:
-    metal.ironcore.dev/maintenance-reason: "<maintenance-name>"
+    metal.ironcore.dev/maintenance-reason: '<maintenance-name>'
 spec:
   policy: Enforced
   serverRef:
     name: <server-name>
-  serverPower: "Off"
+  serverPower: 'Off'
 ```
 
 ```shell
@@ -149,7 +158,7 @@ data:
 
 #### 3. Enable HTTPS for the BMC connection
 
-The manager defaults to `--insecure=true`, which uses plain HTTP. For a real BMC on port 443, set `--insecure=false` in the `Tiltfile` to use HTTPS instead:
+The manager defaults to `--insecure=true`, which uses plain HTTP. This is fine for the default mock server but may not work for real servers. Make sure to adapt this to the target if necessary. E.g. for a real BMC that uses HTTPS on port 443, set `--insecure=false` in the `Tiltfile`:
 
 ```python
 settings = {
@@ -162,30 +171,52 @@ settings = {
 }
 ```
 
-#### 4. Claim the server with a ServerMaintenance
+#### 4. Start Tilt and verify
 
-Once the `Server` resource has been discovered and is `Available`, create a `ServerMaintenance` to claim it for local development. This prevents the server from being allocated by other consumers and powers it off:
+Start the environment:
+
+```shell
+make tilt-up
+```
+
+Once the manager is running, apply the `BMCSecret` to the local Kind cluster (it is not part of the kustomize config and must be applied manually):
+
+A `BMCSecret` looks like:
 
 ```yaml
 apiVersion: metal.ironcore.dev/v1alpha1
-kind: ServerMaintenance
+kind: BMCSecret
 metadata:
-  name: <maintenance-name>
-  namespace: default
-  annotations:
-    metal.ironcore.dev/maintenance-reason: "<maintenance-name>"
-spec:
-  policy: Enforced
-  serverRef:
-    name: <server-name>
-  serverPower: "Off"
+  name: <node-name>
+data:
+  username: <base64-encoded-username>
+  password: <base64-encoded-password>
 ```
 
-Apply and delete it with:
+> **Note:** The `username` and `password` values must be base64-encoded. You can encode them with `echo -n '<value>' | base64`.
 
 ```shell
-kubectl apply -f servermaintenance-<node-name>.yaml
-kubectl delete -f servermaintenance-<node-name>.yaml
+# Run against the local Kind cluster
+kubectl apply -f bmcsecret-<node-name>.yaml
+```
+
+The metal-operator will pick up the `BMC` resource, connect to the remote hardware, and create a matching `Server` resource. Watch the resources come up:
+
+```shell
+kubectl get bmc -w
+kubectl get server -w
+```
+
+You can monitor the manager logs to verify the connection succeeds:
+
+```shell
+kubectl logs -n metal-operator-system deployment/metal-operator-controller-manager -c manager -f
+```
+
+To tear down the environment:
+
+```shell
+make kind-delete
 ```
 
 #### Optional: Use the debug manager image
@@ -193,11 +224,13 @@ kubectl delete -f servermaintenance-<node-name>.yaml
 To get a shell-accessible manager image with `curl` and `ca-certificates` (useful for diagnosing BMC connectivity), switch the Tilt build target to `manager-debug`:
 
 In `Tiltfile`:
+
 ```python
-docker_build('controller', '.', target = 'manager-debug')
+docker_build('controller', '../..', dockerfile='./Dockerfile', only=['ironcore-dev/metal-operator', 'gofish'], target = 'manager-debug')
 ```
 
 And add the corresponding stage to `Dockerfile`:
+
 ```dockerfile
 FROM debian:testing-slim AS manager-debug
 LABEL source_repository="https://github.com/ironcore-dev/metal-operator"


### PR DESCRIPTION
# Proposed Changes

- adds documentation to connect a remote bmc to the local development cluster

# Fixes

- no issue for this, it's a general enhancement of the docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Connecting a Remote BMC in the Tilt environment" walkthrough to swap the default Redfish mock server for real hardware, prepare and apply base64-encoded BMC credentials to a local Kind cluster, and verify BMC/Server resources and controller logs.
  * Added guidance for HTTPS BMCs and an optional debug build including curl and CA certificates.
  * Minor formatting and whitespace fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->