### PR TITLE
Simplify BIOSVersion controller and fix bugs

### DIFF
--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -46,8 +46,6 @@ const (
 	BIOSSettingsReasonUpdateTimedOut            = "BIOSSettingsTimedOutDuringUpdate"
 	BIOSSettingsConditionServerPowerOn          = "ServerPowerOnCondition"
 	BIOSSettingsReasonServerPoweredOn           = "ServerPoweredHasBeenPoweredOn"
-	BMCConditionReset                           = "BMCResetIssued"
-	BMCReasonReset                              = "BMCResetIssued"
 	BIOSSettingsConditionIssuedUpdate           = "SettingsUpdateIssued"
 	BIOSSettingReasonIssuedUpdate               = "BIOSSettingUpdateIssued"
 	BIOSSettingsConditionUnknownPendingSettings = "UnknownPendingSettingState"

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -558,6 +558,10 @@ func (r *BIOSVersionReconciler) cleanup(ctx context.Context, bmcClient bmc.BMC, 
 		return err
 	}
 
+	// Clear stale conditions from previous reconciliation cycles so they do not
+	// interfere when the resource is re-reconciled after a spec update.
+	version.Status.Conditions = nil
+
 	if currentVersion == version.Spec.Version {
 		if err := r.cleanupServerMaintenanceReferences(ctx, version); err != nil {
 			return err

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -27,17 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
-// BIOSVersionReconciler reconciles a BIOSVersion object
-type BIOSVersionReconciler struct {
-	client.Client
-	ManagerNamespace string
-	Insecure         bool
-	Scheme           *runtime.Scheme
-	BMCOptions       bmc.Options
-	ResyncInterval   time.Duration
-	Conditions       *conditionutils.Accessor
-}
-
 const (
 	BIOSVersionFinalizer = "metal.ironcore.dev/biosversion"
 
@@ -57,6 +46,17 @@ const (
 	ReasonUpgradeTaskCompleted    = "UpgradeTaskCompleted"
 )
 
+// BIOSVersionReconciler reconciles a BIOSVersion object
+type BIOSVersionReconciler struct {
+	client.Client
+	ManagerNamespace string
+	Insecure         bool
+	Scheme           *runtime.Scheme
+	BMCOptions       bmc.Options
+	ResyncInterval   time.Duration
+	Conditions       *conditionutils.Accessor
+}
+
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversions/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversions/finalizers,verbs=update
@@ -68,71 +68,71 @@ const (
 
 func (r *BIOSVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	biosVersion := &metalv1alpha1.BIOSVersion{}
-	if err := r.Get(ctx, req.NamespacedName, biosVersion); err != nil {
+	version := &metalv1alpha1.BIOSVersion{}
+	if err := r.Get(ctx, req.NamespacedName, version); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.V(1).Info("Reconciling BIOSVersion")
 
-	return r.reconcileExists(ctx, biosVersion)
+	return r.reconcileExists(ctx, version)
 }
 
-func (r *BIOSVersionReconciler) reconcileExists(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) (ctrl.Result, error) {
-	if r.shouldDelete(ctx, biosVersion) {
-		return r.delete(ctx, biosVersion)
+func (r *BIOSVersionReconciler) reconcileExists(ctx context.Context, version *metalv1alpha1.BIOSVersion) (ctrl.Result, error) {
+	if r.shouldDelete(ctx, version) {
+		return r.delete(ctx, version)
 	}
-	return r.reconcile(ctx, biosVersion)
+	return r.reconcile(ctx, version)
 }
 
-func (r *BIOSVersionReconciler) shouldDelete(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) bool {
+func (r *BIOSVersionReconciler) shouldDelete(ctx context.Context, version *metalv1alpha1.BIOSVersion) bool {
 	log := ctrl.LoggerFrom(ctx)
-	if biosVersion.DeletionTimestamp.IsZero() {
+	if version.DeletionTimestamp.IsZero() {
 		return false
 	}
 
-	if controllerutil.ContainsFinalizer(biosVersion, BIOSVersionFinalizer) &&
-		biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
-		if _, err := GetServerByName(ctx, r.Client, biosVersion.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
-			log.V(1).Info("Server not found, proceeding with deletion", "Server", biosVersion.Spec.ServerRef.Name)
+	if controllerutil.ContainsFinalizer(version, BIOSVersionFinalizer) &&
+		version.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
+		if _, err := GetServerByName(ctx, r.Client, version.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
+			log.V(1).Info("Server not found, proceeding with deletion", "Server", version.Spec.ServerRef.Name)
 			return true
 		}
-		log.V(1).Info("Postponing deletion as BIOS version update is in progress")
+		log.V(1).Info("Postponed deletion as BIOS version update is in progress")
 		return false
 	}
 
 	return true
 }
 
-func (r *BIOSVersionReconciler) delete(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) (ctrl.Result, error) {
+func (r *BIOSVersionReconciler) delete(ctx context.Context, version *metalv1alpha1.BIOSVersion) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Deleting BIOSVersion")
 	defer log.V(1).Info("Deleted BIOSVersion")
 
-	if !controllerutil.ContainsFinalizer(biosVersion, BIOSVersionFinalizer) {
+	if !controllerutil.ContainsFinalizer(version, BIOSVersionFinalizer) {
 		return ctrl.Result{}, nil
 	}
 
 	log.V(1).Info("Ensuring that the finalizer is removed")
-	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, biosVersion, BIOSVersionFinalizer); err != nil || modified {
+	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, version, BIOSVersionFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (r *BIOSVersionReconciler) cleanupServerMaintenanceReferences(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) error {
+func (r *BIOSVersionReconciler) cleanupServerMaintenanceReferences(ctx context.Context, version *metalv1alpha1.BIOSVersion) error {
 	log := ctrl.LoggerFrom(ctx)
-	if biosVersion.Spec.ServerMaintenanceRef == nil {
+	if version.Spec.ServerMaintenanceRef == nil {
 		return nil
 	}
 
-	serverMaintenance, err := r.getServerMaintenanceForRef(ctx, biosVersion.Spec.ServerMaintenanceRef)
+	serverMaintenance, err := r.getServerMaintenanceForRef(ctx, version.Spec.ServerMaintenanceRef)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get referred ServerMaintenance: %w", err)
 	}
 
 	if serverMaintenance.DeletionTimestamp.IsZero() {
-		if metav1.IsControlledBy(serverMaintenance, biosVersion) {
+		if metav1.IsControlledBy(serverMaintenance, version) {
 			log.V(1).Info("Deleting ServerMaintenance", "ServerMaintenance", client.ObjectKeyFromObject(serverMaintenance))
 			if err := r.Delete(ctx, serverMaintenance); err != nil {
 				return err
@@ -144,34 +144,34 @@ func (r *BIOSVersionReconciler) cleanupServerMaintenanceReferences(ctx context.C
 
 	// Remove the reference if the object is gone.
 	if apierrors.IsNotFound(err) || err == nil {
-		log.V(1).Info("Cleaning up ServerMaintenance ref in BIOSVersion as the object is gone")
-		if err := r.patchServerMaintenanceRef(ctx, biosVersion, nil); err != nil {
-			return fmt.Errorf("failed to clean up serverMaintenance ref in BIOSVersionReconciler status: %w", err)
+		log.V(1).Info("Cleaned up ServerMaintenance ref in BIOSVersion")
+		if err := r.patchServerMaintenanceRef(ctx, version, nil); err != nil {
+			return fmt.Errorf("failed to clean up ServerMaintenance ref in BIOSVersion: %w", err)
 		}
 	}
 	return nil
 }
 
-func (r *BIOSVersionReconciler) reconcile(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) (ctrl.Result, error) {
+func (r *BIOSVersionReconciler) reconcile(ctx context.Context, version *metalv1alpha1.BIOSVersion) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	if shouldIgnoreReconciliation(biosVersion) {
+	if shouldIgnoreReconciliation(version) {
 		log.V(1).Info("Skipped BIOSVersion reconciliation")
 		return ctrl.Result{}, nil
 	}
 
-	base := biosVersion.DeepCopy()
-	if biosVersion.Spec.ServerMaintenanceRef != nil && clearDeprecatedObjectRefFields(biosVersion.Spec.ServerMaintenanceRef) {
-		if err := r.Patch(ctx, biosVersion, client.MergeFrom(base)); err != nil {
+	base := version.DeepCopy()
+	if version.Spec.ServerMaintenanceRef != nil && clearDeprecatedObjectRefFields(version.Spec.ServerMaintenanceRef) {
+		if err := r.Patch(ctx, version, client.MergeFrom(base)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to clear deprecated ObjectReference fields on BIOSVersion: %w", err)
 		}
 		return ctrl.Result{}, nil
 	}
 
-	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, biosVersion, BIOSVersionFinalizer); err != nil || modified {
+	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, version, BIOSVersionFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}
 
-	requeue, err := r.transitionState(ctx, biosVersion)
+	requeue, err := r.transitionState(ctx, version)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -183,13 +183,13 @@ func (r *BIOSVersionReconciler) reconcile(ctx context.Context, biosVersion *meta
 	return ctrl.Result{}, nil
 }
 
-func (r *BIOSVersionReconciler) transitionState(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) (bool, error) {
+func (r *BIOSVersionReconciler) transitionState(ctx context.Context, version *metalv1alpha1.BIOSVersion) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	if biosVersion.Spec.ServerRef == nil {
+	if version.Spec.ServerRef == nil {
 		return false, fmt.Errorf("BIOSVersion does not have a ServerRef")
 	}
 
-	server, err := GetServerByName(ctx, r.Client, biosVersion.Spec.ServerRef.Name)
+	server, err := GetServerByName(ctx, r.Client, version.Spec.ServerRef.Name)
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch server: %w", err)
 	}
@@ -204,87 +204,61 @@ func (r *BIOSVersionReconciler) transitionState(ctx context.Context, biosVersion
 	}
 	defer bmcClient.Logout()
 
-	switch biosVersion.Status.State {
+	switch version.Status.State {
 	case "", metalv1alpha1.BIOSVersionStatePending:
-		return false, r.cleanup(ctx, bmcClient, biosVersion, server)
+		return false, r.cleanup(ctx, bmcClient, version, server)
 	case metalv1alpha1.BIOSVersionStateInProgress:
-		if ok, err := r.handleServerMaintenance(ctx, bmcClient, biosVersion, server); err != nil || !ok {
+		if ok, err := r.handleServerMaintenance(ctx, bmcClient, version, server); err != nil || !ok {
 			return false, err
 		}
 
-		return r.processInProgressState(ctx, bmcClient, biosVersion, server)
+		return r.processInProgressState(ctx, bmcClient, version, server)
 	case metalv1alpha1.BIOSVersionStateCompleted:
-		return false, r.cleanup(ctx, bmcClient, biosVersion, server)
+		return false, r.cleanup(ctx, bmcClient, version, server)
 	case metalv1alpha1.BIOSVersionStateFailed:
-		if shouldRetryReconciliation(biosVersion) {
-			log.V(1).Info("Retrying ...")
-			biosVersionBase := biosVersion.DeepCopy()
-			biosVersion.Status.State = metalv1alpha1.BIOSVersionStatePending
-			biosVersion.Status.Conditions = []metav1.Condition{}
-			annotations := biosVersion.GetAnnotations()
+		if shouldRetryReconciliation(version) {
+			log.V(1).Info("Retrying BIOSVersion reconciliation")
+			versionBase := version.DeepCopy()
+			version.Status.State = metalv1alpha1.BIOSVersionStatePending
+			version.Status.Conditions = []metav1.Condition{}
+			annotations := version.GetAnnotations()
 			delete(annotations, metalv1alpha1.OperationAnnotation)
-			biosVersion.SetAnnotations(annotations)
+			version.SetAnnotations(annotations)
 
-			if err := r.Status().Patch(ctx, biosVersion, client.MergeFrom(biosVersionBase)); err != nil {
+			if err := r.Status().Patch(ctx, version, client.MergeFrom(versionBase)); err != nil {
 				return true, fmt.Errorf("failed to patch BIOSVersion status for retrying: %w", err)
 			}
 			return true, nil
 		}
-		log.V(1).Info("Failed to upgrade BIOSVersion", "BIOSVersion", biosVersion, "Server", server.Name)
+		log.V(1).Info("Failed to upgrade BIOSVersion", "BIOSVersion", version.Name, "Server", server.Name)
 		return false, nil
 	}
 
-	log.V(1).Info("Unknown State found", "State", biosVersion.Status.State)
+	log.V(1).Info("Unknown state found", "state", version.Status.State)
 	return false, nil
 }
 
-func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmcClient bmc.BMC, biosVersion *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
+func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmcClient bmc.BMC, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	if biosVersion.Spec.ServerMaintenanceRef == nil {
-		if requeue, err := r.requestServerMaintenance(ctx, biosVersion, server); err != nil || requeue {
+	if version.Spec.ServerMaintenanceRef == nil {
+		if requeue, err := r.requestServerMaintenance(ctx, version, server); err != nil || requeue {
 			return false, err
 		}
 	}
 
-	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ServerMaintenanceConditionWaiting)
+	condition, err := GetCondition(r.Conditions, version.Status.Conditions, ServerMaintenanceConditionWaiting)
 	if err != nil {
 		return false, err
 	}
 
 	if server.Status.State != metalv1alpha1.ServerStateMaintenance {
-		log.V(1).Info("Server is not in maintenance. waiting...", "server State", server.Status.State, "server", server.Name)
-		if condition.Status != metav1.ConditionTrue {
-			if err := r.Conditions.Update(
-				condition,
-				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
-				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", biosVersion.Spec.ServerMaintenanceRef.Name)),
-			); err != nil {
-				return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
-			}
-			if err := r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, condition); err != nil {
-				return false, fmt.Errorf("failed to patch BIOSVersion ServerMaintenance waiting conditions: %w", err)
-			}
-		}
-		return false, nil
+		log.V(1).Info("Server not in maintenance, waiting", "serverState", server.Status.State, "server", server.Name)
+		return false, r.ensureMaintenanceWaitingCondition(ctx, version, condition)
 	}
 
-	if server.Spec.ServerMaintenanceRef == nil || server.Spec.ServerMaintenanceRef.Name != biosVersion.Spec.ServerMaintenanceRef.Name || server.Spec.ServerMaintenanceRef.Namespace != biosVersion.Spec.ServerMaintenanceRef.Namespace {
-		log.V(1).Info("Server is already in maintenance", "Server", server.Name)
-		if condition.Status != metav1.ConditionTrue {
-			if err := r.Conditions.Update(
-				condition,
-				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
-				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", biosVersion.Spec.ServerMaintenanceRef.Name)),
-			); err != nil {
-				return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
-			}
-			if err := r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, condition); err != nil {
-				return false, fmt.Errorf("failed to patch BIOSVersion ServerMaintenance waiting conditions: %w", err)
-			}
-		}
-		return false, nil
+	if server.Spec.ServerMaintenanceRef == nil || server.Spec.ServerMaintenanceRef.Name != version.Spec.ServerMaintenanceRef.Name || server.Spec.ServerMaintenanceRef.Namespace != version.Spec.ServerMaintenanceRef.Namespace {
+		log.V(1).Info("Server already in maintenance for another request", "Server", server.Name)
+		return false, r.ensureMaintenanceWaitingCondition(ctx, version, condition)
 	}
 
 	if condition.Reason != ServerMaintenanceReasonApproved {
@@ -294,262 +268,301 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 			conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
 			conditionutils.UpdateMessage("Server is now in Maintenance mode"),
 		); err != nil {
-			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
+			return false, fmt.Errorf("failed to update ServerMaintenance approved condition: %w", err)
 		}
-		if err := r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, condition); err != nil {
-			return false, fmt.Errorf("failed to patch BIOSVersion ServerMaintenance waiting conditions: %w", err)
+		if err := r.updateStatus(ctx, version, version.Status.State, version.Status.UpgradeTask, condition); err != nil {
+			return false, fmt.Errorf("failed to patch BIOSVersion ServerMaintenance approved conditions: %w", err)
 		}
 		return false, nil
 	}
 
-	if ok, err := r.handleBMCReset(ctx, bmcClient, biosVersion, server); !ok || err != nil {
+	if ok, err := r.handleBMCReset(ctx, bmcClient, version, server); !ok || err != nil {
 		return false, err
 	}
 	return true, nil
 }
 
-func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcClient bmc.BMC, biosVersion *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
-	issuedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradeIssued)
-	if err != nil {
-		return false, err
+func (r *BIOSVersionReconciler) ensureMaintenanceWaitingCondition(ctx context.Context, version *metalv1alpha1.BIOSVersion, condition *metav1.Condition) error {
+	if condition.Status == metav1.ConditionTrue {
+		return nil
+	}
+	if err := r.Conditions.Update(
+		condition,
+		conditionutils.UpdateStatus(corev1.ConditionTrue),
+		conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+		conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", version.Spec.ServerMaintenanceRef.Name)),
+	); err != nil {
+		return fmt.Errorf("failed to update ServerMaintenance waiting condition: %w", err)
+	}
+	return r.updateStatus(ctx, version, version.Status.State, version.Status.UpgradeTask, condition)
+}
+
+func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcClient bmc.BMC, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
+	type stepFunc func() (done bool, requeue bool, err error)
+	steps := []stepFunc{
+		func() (bool, bool, error) { return r.handleUpgradeIssue(ctx, bmcClient, version, server) },
+		func() (bool, bool, error) { return r.handleUpgradeCompletion(ctx, bmcClient, version, server) },
+		func() (bool, bool, error) { return r.handlePowerOff(ctx, version, server) },
+		func() (bool, bool, error) { return r.handlePowerOn(ctx, version, server) },
+		func() (bool, bool, error) { return r.handleVerification(ctx, bmcClient, version, server) },
 	}
 
-	if issuedCondition.Status != metav1.ConditionTrue {
-		log.V(1).Info("Processing BIOS version upgrade ...")
-		if server.Status.PowerState != metalv1alpha1.ServerOnPowerState {
-			log.V(1).Info("Server in powered off state. Retrying ...", "Server", server.Name)
-			return false, nil
-		}
-		// Check for pending component upgrade BEFORE issuing upgrade to avoid interrupting staged firmware
-		hasPending, err := bmcClient.CheckBMCPendingComponentUpgrade(ctx, bmc.ComponentTypeBIOS)
-		if err != nil {
-			log.V(1).Info("Failed to check pending component upgrade before BIOS upgrade, proceeding anyway", "error", err)
-		} else if hasPending {
-			log.Info("Pending component upgrade detected, deferring BIOS upgrade to avoid interruption", "Server", server.Name)
-			return true, nil
-		}
-		return false, r.upgradeBIOSVersion(ctx, bmcClient, biosVersion, server, issuedCondition)
-	}
-
-	completedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted)
-	if err != nil {
-		return false, err
-	}
-
-	if completedCondition.Status != metav1.ConditionTrue {
-		log.V(1).Info("Check BIOS version upgrade task status")
-		requeue, err := r.checkUpdateBiosUpgradeStatus(ctx, bmcClient, biosVersion, server, completedCondition)
-		var TaskFetchFailed *BMCTaskFetchFailedError
-		if errors.As(err, &TaskFetchFailed) {
-			log.V(1).Info("Failed to fetch BIOS upgrade task status from BMC.", "error", err)
-			// some vendor detele the task details once upgrade is completed.
-			// check the current version and then proceed if version is as per spec
-			currentBiosVersion, errVersionFetch := r.getBIOSVersionFromBMC(ctx, bmcClient, server)
-			if errVersionFetch != nil {
-				// need to give time if BMC is not responding, hence requeue
-				log.Error(errors.Join(err, errVersionFetch), "Failed to fetch current BIOS version from BMC after upgrade task fetch failure.")
-				return true, nil
-			}
-			if currentBiosVersion == biosVersion.Spec.Version {
-				// mark as completed, and procced with the workflow as the task might have been deleted post successful upgrade
-				log.V(1).Info("BIOS version shows upgraded successfully even though task fetch failure", "Version", currentBiosVersion)
-				if err := r.Conditions.Update(
-					completedCondition,
-					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(ReasonUpgradeTaskCompleted),
-					conditionutils.UpdateMessage("Upgrade Task is missing. BIOS version successfully upgraded to: "+biosVersion.Spec.Version),
-				); err != nil {
-					return false, fmt.Errorf("failed to update upgrade complete conditions: %w", err)
-				}
-				return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, completedCondition)
-			}
-			log.V(1).Info("BIOS version not updated yet, need to wait for task details", "Version", currentBiosVersion, "DesiredVersion", biosVersion.Spec.Version)
+	for _, step := range steps {
+		done, requeue, err := step()
+		if !done || err != nil {
 			return requeue, err
 		}
-		return requeue, err
 	}
 
-	rebootPowerOffCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradePowerOff)
-	if err != nil {
-		return false, err
-	}
-
-	if rebootPowerOffCondition.Status != metav1.ConditionTrue {
-		log.V(1).Info("Ensuring server is powered off")
-		if server.Status.PowerState != metalv1alpha1.ServerOffPowerState {
-			return false, r.ensurePowerState(ctx, biosVersion, metalv1alpha1.PowerOff)
-		}
-		log.V(1).Info("Ensured server is powered off")
-
-		if err := r.Conditions.Update(
-			rebootPowerOffCondition,
-			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ReasonRebootPowerOff),
-			conditionutils.UpdateMessage("Powered off the server"),
-		); err != nil {
-			return false, fmt.Errorf("failed to update reboot power off condition: %w", err)
-		}
-
-		return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, rebootPowerOffCondition)
-	}
-
-	rebootPowerOnCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradePowerOn)
-	if err != nil {
-		return false, err
-	}
-
-	if rebootPowerOnCondition.Status != metav1.ConditionTrue {
-		log.V(1).Info("Ensuring server is powered on")
-		if server.Status.PowerState != metalv1alpha1.ServerOnPowerState {
-			return false, r.ensurePowerState(ctx, biosVersion, metalv1alpha1.PowerOn)
-		}
-		log.V(1).Info("Ensured server is powered on")
-
-		if err := r.Conditions.Update(
-			rebootPowerOnCondition,
-			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ReasonRebootPowerOn),
-			conditionutils.UpdateMessage("Powered on the server"),
-		); err != nil {
-			return false, fmt.Errorf("failed to update reboot power on condition: %w", err)
-		}
-
-		return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, rebootPowerOnCondition)
-	}
-
-	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradeVerification)
-	if err != nil {
-		return false, err
-	}
-
-	if condition.Status != metav1.ConditionTrue {
-		log.V(1).Info("Verifying BIOS version update")
-
-		currentBiosVersion, err := r.getBIOSVersionFromBMC(ctx, bmcClient, server)
-		if err != nil {
-			return false, err
-		}
-		if currentBiosVersion != biosVersion.Spec.Version {
-			// todo: add timeout
-			log.V(1).Info("BIOS version not updated", "Version", currentBiosVersion, "DesiredVersion", biosVersion.Spec.Version)
-			if condition.Reason == "" {
-				if err := r.Conditions.Update(
-					condition,
-					conditionutils.UpdateStatus(corev1.ConditionFalse),
-					conditionutils.UpdateReason(ReasonBIOSVersionVerification),
-					conditionutils.UpdateMessage("waiting for BIOS Version update"),
-				); err != nil {
-					return false, fmt.Errorf("failed to update the verification condition: %w", err)
-				}
-			}
-			log.V(1).Info("Waiting for BIOS version to reflect the new version")
-			return true, nil
-		}
-
-		if err := r.Conditions.Update(
-			condition,
-			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ReasonBIOSVersionVerified),
-			conditionutils.UpdateMessage("BIOS Version updated"),
-		); err != nil {
-			return false, fmt.Errorf("failed to update conditions: %w", err)
-		}
-
-		return false, r.updateStatus(ctx, biosVersion, metalv1alpha1.BIOSVersionStateCompleted, biosVersion.Status.UpgradeTask, condition)
-	}
-
-	log.V(1).Info("Unknown Conditions found", "Condition", condition.Type)
+	log := ctrl.LoggerFrom(ctx)
+	log.V(1).Info("All upgrade conditions completed")
 	return false, nil
 }
 
-func (r *BIOSVersionReconciler) handleBMCReset(
-	ctx context.Context,
-	bmcClient bmc.BMC,
-	biosVersion *metalv1alpha1.BIOSVersion,
-	server *metalv1alpha1.Server,
-) (bool, error) {
+func (r *BIOSVersionReconciler) handleUpgradeIssue(ctx context.Context, bmcClient bmc.BMC, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	// reset BMC if not already done
-	resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, BMCConditionReset)
+	issuedCondition, err := GetCondition(r.Conditions, version.Status.Conditions, ConditionBIOSUpgradeIssued)
 	if err != nil {
-		return false, fmt.Errorf("failed to get condition for reset of BMC of server %v", err)
+		return false, false, err
+	}
+	if issuedCondition.Status == metav1.ConditionTrue {
+		return true, false, nil
 	}
 
-	if resetBMC.Status != metav1.ConditionTrue {
-		// once the server is powered on, reset the BMC to make sure its in stable state
-		// this avoids problems with some BMCs that hang up in subsequent operations
-		if resetBMC.Reason != BMCReasonReset {
-			if err := resetBMCOfServer(ctx, r.Client, server, bmcClient); err == nil {
-				// mark reset to be issued, wait for next reconcile
-				if err := r.Conditions.Update(
-					resetBMC,
-					conditionutils.UpdateStatus(corev1.ConditionFalse),
-					conditionutils.UpdateReason(BMCReasonReset),
-					conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
-				); err != nil {
-					return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
-				}
-				return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, nil, resetBMC)
-			} else {
-				log.Error(err, "failed to reset BMC of the server")
-				return false, err
+	log.V(1).Info("Processing BIOS version upgrade")
+	if server.Status.PowerState != metalv1alpha1.ServerOnPowerState {
+		log.V(1).Info("Server powered off, waiting for power on", "Server", server.Name)
+		return false, false, nil
+	}
+	hasPending, err := bmcClient.CheckBMCPendingComponentUpgrade(ctx, bmc.ComponentTypeBIOS)
+	if err != nil {
+		log.V(1).Info("Failed to check pending component upgrade, proceeding with BIOS upgrade", "error", err)
+	} else if hasPending {
+		log.Info("Pending component upgrade detected, deferring BIOS upgrade to avoid interruption", "Server", server.Name)
+		return false, true, nil
+	}
+	return false, false, r.upgradeBIOSVersion(ctx, bmcClient, version, server, issuedCondition)
+}
+
+func (r *BIOSVersionReconciler) handleUpgradeCompletion(ctx context.Context, bmcClient bmc.BMC, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	completedCondition, err := GetCondition(r.Conditions, version.Status.Conditions, ConditionBIOSUpgradeCompleted)
+	if err != nil {
+		return false, false, err
+	}
+	if completedCondition.Status == metav1.ConditionTrue {
+		return true, false, nil
+	}
+
+	log.V(1).Info("Checking BIOS version upgrade task status")
+	requeue, err := r.checkUpdateBiosUpgradeStatus(ctx, bmcClient, version, server, completedCondition)
+	var taskFetchFailed *BMCTaskFetchFailedError
+	if !errors.As(err, &taskFetchFailed) {
+		return false, requeue, err
+	}
+
+	// Some vendors delete task details once upgrade is completed.
+	// Check the current version and proceed if it matches spec.
+	log.V(1).Info("Failed to fetch BIOS upgrade task status from BMC", "error", err)
+	currentVersion, errVersionFetch := r.getBIOSVersionFromBMC(ctx, bmcClient, server)
+	if errVersionFetch != nil {
+		log.Error(errors.Join(err, errVersionFetch), "Failed to fetch current BIOS version from BMC after upgrade task fetch failure")
+		return false, true, nil
+	}
+	if currentVersion != version.Spec.Version {
+		log.V(1).Info("BIOS version not updated yet, need to wait for task details", "Version", currentVersion, "DesiredVersion", version.Spec.Version)
+		return false, requeue, err
+	}
+
+	log.V(1).Info("BIOS version matched spec despite task fetch failure", "Version", currentVersion)
+	if err := r.Conditions.Update(
+		completedCondition,
+		conditionutils.UpdateStatus(corev1.ConditionTrue),
+		conditionutils.UpdateReason(ReasonUpgradeTaskCompleted),
+		conditionutils.UpdateMessage("Upgrade Task is missing. BIOS version successfully upgraded to: "+version.Spec.Version),
+	); err != nil {
+		return false, false, fmt.Errorf("failed to update upgrade complete conditions: %w", err)
+	}
+	return false, false, r.updateStatus(ctx, version, version.Status.State, version.Status.UpgradeTask, completedCondition)
+}
+
+func (r *BIOSVersionReconciler) handlePowerOff(ctx context.Context, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	condition, err := GetCondition(r.Conditions, version.Status.Conditions, ConditionBIOSUpgradePowerOff)
+	if err != nil {
+		return false, false, err
+	}
+	if condition.Status == metav1.ConditionTrue {
+		return true, false, nil
+	}
+
+	log.V(1).Info("Ensuring server is powered off")
+	if server.Status.PowerState != metalv1alpha1.ServerOffPowerState {
+		return false, false, r.ensurePowerState(ctx, version, metalv1alpha1.PowerOff)
+	}
+	log.V(1).Info("Ensured server is powered off")
+
+	if err := r.Conditions.Update(
+		condition,
+		conditionutils.UpdateStatus(corev1.ConditionTrue),
+		conditionutils.UpdateReason(ReasonRebootPowerOff),
+		conditionutils.UpdateMessage("Powered off the server"),
+	); err != nil {
+		return false, false, fmt.Errorf("failed to update reboot power off condition: %w", err)
+	}
+	return false, false, r.updateStatus(ctx, version, version.Status.State, version.Status.UpgradeTask, condition)
+}
+
+func (r *BIOSVersionReconciler) handlePowerOn(ctx context.Context, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	condition, err := GetCondition(r.Conditions, version.Status.Conditions, ConditionBIOSUpgradePowerOn)
+	if err != nil {
+		return false, false, err
+	}
+	if condition.Status == metav1.ConditionTrue {
+		return true, false, nil
+	}
+
+	log.V(1).Info("Ensuring server is powered on")
+	if server.Status.PowerState != metalv1alpha1.ServerOnPowerState {
+		return false, false, r.ensurePowerState(ctx, version, metalv1alpha1.PowerOn)
+	}
+	log.V(1).Info("Ensured server is powered on")
+
+	if err := r.Conditions.Update(
+		condition,
+		conditionutils.UpdateStatus(corev1.ConditionTrue),
+		conditionutils.UpdateReason(ReasonRebootPowerOn),
+		conditionutils.UpdateMessage("Powered on the server"),
+	); err != nil {
+		return false, false, fmt.Errorf("failed to update reboot power on condition: %w", err)
+	}
+	return false, false, r.updateStatus(ctx, version, version.Status.State, version.Status.UpgradeTask, condition)
+}
+
+func (r *BIOSVersionReconciler) handleVerification(ctx context.Context, bmcClient bmc.BMC, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	condition, err := GetCondition(r.Conditions, version.Status.Conditions, ConditionBIOSUpgradeVerification)
+	if err != nil {
+		return false, false, err
+	}
+	if condition.Status == metav1.ConditionTrue {
+		return true, false, nil
+	}
+
+	log.V(1).Info("Verifying BIOS version update")
+	currentVersion, err := r.getBIOSVersionFromBMC(ctx, bmcClient, server)
+	if err != nil {
+		return false, false, err
+	}
+	if currentVersion != version.Spec.Version {
+		log.V(1).Info("BIOS version not updated", "Version", currentVersion, "DesiredVersion", version.Spec.Version)
+		if condition.Reason == "" {
+			if err := r.Conditions.Update(
+				condition,
+				conditionutils.UpdateStatus(corev1.ConditionFalse),
+				conditionutils.UpdateReason(ReasonBIOSVersionVerification),
+				conditionutils.UpdateMessage("Waiting for BIOS version update"),
+			); err != nil {
+				return false, false, fmt.Errorf("failed to update the verification condition: %w", err)
 			}
-		} else if server.Spec.BMCRef != nil {
-			// we need to wait until the BMC resource annotation is removed
-			bmcObj := &metalv1alpha1.BMC{}
-			if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.BMCRef.Name}, bmcObj); err != nil {
-				log.Error(err, "failed to get referred server's Manager")
-				return false, err
-			}
-			annotations := bmcObj.GetAnnotations()
-			if annotations != nil {
-				if op, ok := annotations[metalv1alpha1.OperationAnnotation]; ok {
-					if op == metalv1alpha1.GracefulRestartBMC {
-						log.V(1).Info("Waiting for BMC reset as annotation on BMC object is set")
-						return false, nil
-					}
-				}
-			}
+		}
+		log.V(1).Info("Waiting for BIOS version to be updated on server")
+		return false, true, nil
+	}
+
+	if err := r.Conditions.Update(
+		condition,
+		conditionutils.UpdateStatus(corev1.ConditionTrue),
+		conditionutils.UpdateReason(ReasonBIOSVersionVerified),
+		conditionutils.UpdateMessage("BIOS Version updated"),
+	); err != nil {
+		return false, false, fmt.Errorf("failed to update conditions: %w", err)
+	}
+	return false, false, r.updateStatus(ctx, version, metalv1alpha1.BIOSVersionStateCompleted, version.Status.UpgradeTask, condition)
+}
+
+func (r *BIOSVersionReconciler) handleBMCReset(ctx context.Context, bmcClient bmc.BMC, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	resetBMC, err := GetCondition(r.Conditions, version.Status.Conditions, BMCConditionReset)
+	if err != nil {
+		return false, fmt.Errorf("failed to get BMC reset condition: %w", err)
+	}
+
+	// Already completed
+	if resetBMC.Status == metav1.ConditionTrue {
+		return true, nil
+	}
+
+	// Phase 1: Issue the reset if not yet issued
+	if resetBMC.Reason != BMCReasonReset {
+		if err := resetBMCOfServer(ctx, r.Client, server, bmcClient); err != nil {
+			log.Error(err, "Failed to reset BMC of the server")
+			return false, err
 		}
 		if err := r.Conditions.Update(
 			resetBMC,
-			conditionutils.UpdateStatus(corev1.ConditionTrue),
+			conditionutils.UpdateStatus(corev1.ConditionFalse),
 			conditionutils.UpdateReason(BMCReasonReset),
-			conditionutils.UpdateMessage("BMC reset to stabilize BMC of the server is completed"),
+			conditionutils.UpdateMessage("Issued BMC reset to stabilize the BMC"),
 		); err != nil {
-			return false, fmt.Errorf("failed to update power on server condition: %w", err)
+			return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
 		}
-		return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, nil, resetBMC)
+		return false, r.updateStatus(ctx, version, version.Status.State, nil, resetBMC)
 	}
-	return true, nil
+
+	// Phase 2: Wait for reset completion (annotation removal on BMC object)
+	if server.Spec.BMCRef != nil {
+		bmcObj := &metalv1alpha1.BMC{}
+		if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.BMCRef.Name}, bmcObj); err != nil {
+			log.Error(err, "Failed to get referred server's Manager")
+			return false, err
+		}
+		if op := bmcObj.GetAnnotations()[metalv1alpha1.OperationAnnotation]; op == metalv1alpha1.GracefulRestartBMC {
+			log.V(1).Info("Waiting for BMC reset as annotation on BMC object is set")
+			return false, nil
+		}
+	}
+
+	// Phase 3: Mark reset as completed
+	if err := r.Conditions.Update(
+		resetBMC,
+		conditionutils.UpdateStatus(corev1.ConditionTrue),
+		conditionutils.UpdateReason(BMCReasonReset),
+		conditionutils.UpdateMessage("BMC reset completed"),
+	); err != nil {
+		return false, fmt.Errorf("failed to update BMC reset completed condition: %w", err)
+	}
+	return false, r.updateStatus(ctx, version, version.Status.State, nil, resetBMC)
 }
 
 func (r *BIOSVersionReconciler) getBIOSVersionFromBMC(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (string, error) {
-	currentBiosVersion, err := bmcClient.GetBiosVersion(ctx, server.Spec.SystemURI)
+	currentVersion, err := bmcClient.GetBiosVersion(ctx, server.Spec.SystemURI)
 	if err != nil {
 		return "", fmt.Errorf("failed to get BIOS version: %w", err)
 	}
 
-	return currentBiosVersion, nil
+	return currentVersion, nil
 }
 
-func (r *BIOSVersionReconciler) cleanup(ctx context.Context, bmcClient bmc.BMC, biosVersion *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) error {
+func (r *BIOSVersionReconciler) cleanup(ctx context.Context, bmcClient bmc.BMC, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) error {
 	log := ctrl.LoggerFrom(ctx)
-	currentBiosVersion, err := r.getBIOSVersionFromBMC(ctx, bmcClient, server)
+	currentVersion, err := r.getBIOSVersionFromBMC(ctx, bmcClient, server)
 	if err != nil {
 		return err
 	}
 
-	if currentBiosVersion == biosVersion.Spec.Version {
-		if err := r.cleanupServerMaintenanceReferences(ctx, biosVersion); err != nil {
+	if currentVersion == version.Spec.Version {
+		if err := r.cleanupServerMaintenanceReferences(ctx, version); err != nil {
 			return err
 		}
 
-		log.V(1).Info("Upgraded BIOS version", "Version", currentBiosVersion, "Server", server.Name)
-		return r.updateStatus(ctx, biosVersion, metalv1alpha1.BIOSVersionStateCompleted, nil, nil)
+		log.V(1).Info("Upgraded BIOS version", "Version", currentVersion, "Server", server.Name)
+		version.Status.Conditions = nil
+		return r.updateStatus(ctx, version, metalv1alpha1.BIOSVersionStateCompleted, nil, nil)
 	}
-	return r.updateStatus(ctx, biosVersion, metalv1alpha1.BIOSVersionStateInProgress, nil, nil)
+	version.Status.Conditions = nil
+	return r.updateStatus(ctx, version, metalv1alpha1.BIOSVersionStateInProgress, nil, nil)
 }
 
 func (r *BIOSVersionReconciler) getServerMaintenanceForRef(ctx context.Context, serverMaintenanceRef *metalv1alpha1.ObjectReference) (*metalv1alpha1.ServerMaintenance, error) {
@@ -565,23 +578,17 @@ func (r *BIOSVersionReconciler) getServerMaintenanceForRef(ctx context.Context, 
 	return serverMaintenance, nil
 }
 
-func (r *BIOSVersionReconciler) updateStatus(
-	ctx context.Context,
-	biosVersion *metalv1alpha1.BIOSVersion,
-	state metalv1alpha1.BIOSVersionState,
-	upgradeTask *metalv1alpha1.Task,
-	condition *metav1.Condition,
-) error {
-	if biosVersion.Status.State == state && condition == nil && upgradeTask == nil {
+func (r *BIOSVersionReconciler) updateStatus(ctx context.Context, version *metalv1alpha1.BIOSVersion, state metalv1alpha1.BIOSVersionState, upgradeTask *metalv1alpha1.Task, condition *metav1.Condition) error {
+	if version.Status.State == state && condition == nil && upgradeTask == nil {
 		return nil
 	}
 
-	biosVersionBase := biosVersion.DeepCopy()
-	biosVersion.Status.State = state
+	versionBase := version.DeepCopy()
+	version.Status.State = state
 
 	if condition != nil {
 		if err := r.Conditions.UpdateSlice(
-			&biosVersion.Status.Conditions,
+			&version.Status.Conditions,
 			condition.Type,
 			conditionutils.UpdateStatus(condition.Status),
 			conditionutils.UpdateReason(condition.Reason),
@@ -589,40 +596,38 @@ func (r *BIOSVersionReconciler) updateStatus(
 		); err != nil {
 			return fmt.Errorf("failed to patch BIOSVersion condition: %w", err)
 		}
-	} else {
-		biosVersion.Status.Conditions = []metav1.Condition{}
 	}
 
-	biosVersion.Status.UpgradeTask = upgradeTask
+	version.Status.UpgradeTask = upgradeTask
 
-	if err := r.Status().Patch(ctx, biosVersion, client.MergeFrom(biosVersionBase)); err != nil {
+	if err := r.Status().Patch(ctx, version, client.MergeFrom(versionBase)); err != nil {
 		return fmt.Errorf("failed to patch BIOSVersion status: %w", err)
 	}
 
 	return nil
 }
 
-func (r *BIOSVersionReconciler) patchServerMaintenanceRef(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion, serverMaintenance *metalv1alpha1.ServerMaintenance) error {
-	biosVersionsBase := biosVersion.DeepCopy()
+func (r *BIOSVersionReconciler) patchServerMaintenanceRef(ctx context.Context, version *metalv1alpha1.BIOSVersion, serverMaintenance *metalv1alpha1.ServerMaintenance) error {
+	versionBase := version.DeepCopy()
 
 	if serverMaintenance == nil {
-		biosVersion.Spec.ServerMaintenanceRef = nil
+		version.Spec.ServerMaintenanceRef = nil
 	} else {
-		biosVersion.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{
+		version.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{
 			Namespace: serverMaintenance.Namespace,
 			Name:      serverMaintenance.Name,
 		}
 	}
 
-	if err := r.Patch(ctx, biosVersion, client.MergeFrom(biosVersionsBase)); err != nil {
+	if err := r.Patch(ctx, version, client.MergeFrom(versionBase)); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (r *BIOSVersionReconciler) ensurePowerState(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion, powerState metalv1alpha1.Power) error {
-	serverMaintenance, err := r.getServerMaintenanceForRef(ctx, biosVersion.Spec.ServerMaintenanceRef)
+func (r *BIOSVersionReconciler) ensurePowerState(ctx context.Context, version *metalv1alpha1.BIOSVersion, powerState metalv1alpha1.Power) error {
+	serverMaintenance, err := r.getServerMaintenanceForRef(ctx, version.Spec.ServerMaintenanceRef)
 	if err != nil {
 		return err
 	}
@@ -639,19 +644,19 @@ func (r *BIOSVersionReconciler) ensurePowerState(ctx context.Context, biosVersio
 	return nil
 }
 
-func (r *BIOSVersionReconciler) requestServerMaintenance(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
+func (r *BIOSVersionReconciler) requestServerMaintenance(ctx context.Context, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	if biosVersion.Spec.ServerMaintenanceRef != nil {
-		if _, err := GetServerMaintenanceForObjectReference(ctx, r.Client, biosVersion.Spec.ServerMaintenanceRef); apierrors.IsNotFound(err) {
+	if version.Spec.ServerMaintenanceRef != nil {
+		if _, err := GetServerMaintenanceForObjectReference(ctx, r.Client, version.Spec.ServerMaintenanceRef); apierrors.IsNotFound(err) {
 			log.V(1).Info("Referenced ServerMaintenance no longer exists, clearing ref to allow re-creation")
-			if err = r.patchServerMaintenanceRef(ctx, biosVersion, nil); err != nil {
+			if err = r.patchServerMaintenanceRef(ctx, version, nil); err != nil {
 				return false, fmt.Errorf("failed to clear stale ServerMaintenance ref: %w", err)
 			}
 			return true, nil // requeue to re-create
 		} else if err != nil {
 			return false, fmt.Errorf("failed to verify ServerMaintenance existence: %w", err)
 		}
-		condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ServerMaintenanceConditionCreated)
+		condition, err := GetCondition(r.Conditions, version.Status.Conditions, ServerMaintenanceConditionCreated)
 		if err != nil {
 			return false, err
 		}
@@ -662,11 +667,11 @@ func (r *BIOSVersionReconciler) requestServerMaintenance(ctx context.Context, bi
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
 			conditionutils.UpdateReason(ServerMaintenanceReasonCreated),
-			conditionutils.UpdateMessage(fmt.Sprintf("Created/Present %v at %v", biosVersion.Spec.ServerMaintenanceRef.Name, time.Now())),
+			conditionutils.UpdateMessage(fmt.Sprintf("Created/Present %v at %v", version.Spec.ServerMaintenanceRef.Name, time.Now())),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
 		}
-		if err := r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, condition); err != nil {
+		if err := r.updateStatus(ctx, version, version.Status.State, version.Status.UpgradeTask, condition); err != nil {
 			return false, fmt.Errorf("failed to patch BIOSVersion conditions: %w", err)
 		}
 		return true, nil
@@ -675,44 +680,38 @@ func (r *BIOSVersionReconciler) requestServerMaintenance(ctx context.Context, bi
 	serverMaintenance := &metalv1alpha1.ServerMaintenance{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: r.ManagerNamespace,
-			Name:      biosVersion.Name,
+			Name:      version.Name,
 		},
 	}
 
 	opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, serverMaintenance, func() error {
-		serverMaintenance.Spec.Policy = biosVersion.Spec.ServerMaintenancePolicy
+		serverMaintenance.Spec.Policy = version.Spec.ServerMaintenancePolicy
 		serverMaintenance.Spec.ServerPower = metalv1alpha1.PowerOn
 		serverMaintenance.Spec.ServerRef = &corev1.LocalObjectReference{Name: server.Name}
 		if serverMaintenance.Status.State != metalv1alpha1.ServerMaintenanceStateInMaintenance && serverMaintenance.Status.State != "" {
 			serverMaintenance.Status.State = ""
 		}
-		return controllerutil.SetControllerReference(biosVersion, serverMaintenance, r.Client.Scheme())
+		return controllerutil.SetControllerReference(version, serverMaintenance, r.Client.Scheme())
 	})
 	if err != nil {
-		return false, fmt.Errorf("failed to create or patch serverMaintenance: %w", err)
+		return false, fmt.Errorf("failed to create or patch ServerMaintenance: %w", err)
 	}
 	log.V(1).Info("Created ServerMaintenance", "ServerMaintenance", client.ObjectKeyFromObject(serverMaintenance), "Operation", opResult)
 
-	if err = r.patchServerMaintenanceRef(ctx, biosVersion, serverMaintenance); err != nil {
-		return false, fmt.Errorf("failed to patch ServerMaintenance ref in BIOSVersion status: %w", err)
+	if err = r.patchServerMaintenanceRef(ctx, version, serverMaintenance); err != nil {
+		return false, fmt.Errorf("failed to patch ServerMaintenance ref in BIOSVersion: %w", err)
 	}
 
 	log.V(1).Info("Patched ServerMaintenance on BIOSVersion")
 	return true, nil
 }
 
-func (r *BIOSVersionReconciler) checkUpdateBiosUpgradeStatus(
-	ctx context.Context,
-	bmcClient bmc.BMC,
-	biosVersion *metalv1alpha1.BIOSVersion,
-	server *metalv1alpha1.Server,
-	completedCondition *metav1.Condition,
-) (bool, error) {
+func (r *BIOSVersionReconciler) checkUpdateBiosUpgradeStatus(ctx context.Context, bmcClient bmc.BMC, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server, completedCondition *metav1.Condition) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	taskURI := biosVersion.Status.UpgradeTask.URI
+	taskURI := version.Status.UpgradeTask.URI
 	taskCurrentStatus, err := func() (*schemas.Task, error) {
 		if taskURI == "" {
-			return nil, fmt.Errorf("invalid task URI. uri provided: '%v'", taskURI)
+			return nil, fmt.Errorf("invalid task URI: '%v'", taskURI)
 		}
 		return bmcClient.GetBiosUpgradeTask(ctx, server.Status.Manufacturer, taskURI)
 	}()
@@ -726,13 +725,13 @@ func (r *BIOSVersionReconciler) checkUpdateBiosUpgradeStatus(
 	log.V(1).Info("BIOS upgrade task current status", "TaskState", taskCurrentStatus.TaskState)
 
 	upgradeCurrentTaskStatus := &metalv1alpha1.Task{
-		URI:             biosVersion.Status.UpgradeTask.URI,
+		URI:             version.Status.UpgradeTask.URI,
 		State:           taskCurrentStatus.TaskState,
 		Status:          taskCurrentStatus.TaskStatus,
 		PercentComplete: int32(gofish.Deref(taskCurrentStatus.PercentComplete)),
 	}
 
-	// use checkpoint in case the job has stalled and we need to requeue
+	// Use checkpoint in case the job has stalled and we need to requeue
 	transition := &conditionutils.FieldsTransition{
 		IncludeStatus:  true,
 		IncludeReason:  true,
@@ -740,7 +739,7 @@ func (r *BIOSVersionReconciler) checkUpdateBiosUpgradeStatus(
 	}
 	checkpoint, err := transition.Checkpoint(r.Conditions, *completedCondition)
 	if err != nil {
-		return false, fmt.Errorf("failed to create checkpoint for Condition. %w", err)
+		return false, fmt.Errorf("failed to create checkpoint for condition: %w", err)
 	}
 
 	if taskCurrentStatus.TaskState == schemas.KilledTaskState ||
@@ -748,7 +747,7 @@ func (r *BIOSVersionReconciler) checkUpdateBiosUpgradeStatus(
 		taskCurrentStatus.TaskState == schemas.CancelledTaskState ||
 		(taskCurrentStatus.TaskStatus != schemas.OKHealth && taskCurrentStatus.TaskStatus != "") {
 		message := fmt.Sprintf(
-			"Upgrade Bios task has failed. with message %v check '%v' for details",
+			"BIOS upgrade task failed with message %v, check '%v' for details",
 			taskCurrentStatus.Messages,
 			taskURI,
 		)
@@ -761,7 +760,7 @@ func (r *BIOSVersionReconciler) checkUpdateBiosUpgradeStatus(
 			return false, fmt.Errorf("failed to update conditions: %w", err)
 		}
 
-		return false, r.updateStatus(ctx, biosVersion, metalv1alpha1.BIOSVersionStateFailed, upgradeCurrentTaskStatus, completedCondition)
+		return false, r.updateStatus(ctx, version, metalv1alpha1.BIOSVersionStateFailed, upgradeCurrentTaskStatus, completedCondition)
 	}
 
 	if taskCurrentStatus.TaskState == schemas.CompletedTaskState {
@@ -769,15 +768,15 @@ func (r *BIOSVersionReconciler) checkUpdateBiosUpgradeStatus(
 			completedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
 			conditionutils.UpdateReason(ReasonUpgradeTaskCompleted),
-			conditionutils.UpdateMessage("BIOS version successfully upgraded to: "+biosVersion.Spec.Version),
+			conditionutils.UpdateMessage("BIOS version successfully upgraded to: "+version.Spec.Version),
 		); err != nil {
 			return false, fmt.Errorf("failed to update conditions: %w", err)
 		}
 
-		return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, upgradeCurrentTaskStatus, completedCondition)
+		return false, r.updateStatus(ctx, version, version.Status.State, upgradeCurrentTaskStatus, completedCondition)
 	}
 
-	// in-progress task states
+	// In-progress task states
 	if err := r.Conditions.Update(
 		completedCondition,
 		conditionutils.UpdateStatus(corev1.ConditionFalse),
@@ -793,43 +792,37 @@ func (r *BIOSVersionReconciler) checkUpdateBiosUpgradeStatus(
 
 	ok, err := checkpoint.Transitioned(r.Conditions, *completedCondition)
 	if !ok && err == nil {
-		log.V(1).Info("BIOS upgrade task has not progressed. retrying....")
+		log.V(1).Info("BIOS upgrade task stalled, requeueing")
 		// The upgrade job has stalled or is too slow. We need to requeue with exponential backoff.
 		return true, nil
 	}
 
-	// todo: Fail the state after certain timeout
-	return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, upgradeCurrentTaskStatus, completedCondition)
+	// TODO: Fail the state after certain timeout
+	return false, r.updateStatus(ctx, version, version.Status.State, upgradeCurrentTaskStatus, completedCondition)
 }
 
-func (r *BIOSVersionReconciler) upgradeBIOSVersion(
-	ctx context.Context,
-	bmcClient bmc.BMC,
-	biosVersion *metalv1alpha1.BIOSVersion,
-	server *metalv1alpha1.Server,
-	issuedCondition *metav1.Condition,
-) error {
+func (r *BIOSVersionReconciler) upgradeBIOSVersion(ctx context.Context, bmcClient bmc.BMC, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server, issuedCondition *metav1.Condition) error {
 	log := ctrl.LoggerFrom(ctx)
 	var username, password string
-	if biosVersion.Spec.Image.SecretRef != nil {
+	if version.Spec.Image.SecretRef != nil {
 		var err error
-		password, username, err = GetImageCredentialsForSecretRef(ctx, r.Client, biosVersion.Spec.Image.SecretRef)
+		password, username, err = GetImageCredentialsForSecretRef(ctx, r.Client, version.Spec.Image.SecretRef)
 		if err != nil {
-			return fmt.Errorf("failed to get image credentials ref for: %w", err)
+			return fmt.Errorf("failed to get image credentials: %w", err)
 		}
 	}
 
 	var forceUpdate bool
-	if biosVersion.Spec.UpdatePolicy != nil && *biosVersion.Spec.UpdatePolicy == metalv1alpha1.UpdatePolicyForce {
+	if version.Spec.UpdatePolicy != nil && *version.Spec.UpdatePolicy == metalv1alpha1.UpdatePolicyForce {
 		forceUpdate = true
 	}
 
 	parameters := &schemas.UpdateServiceSimpleUpdateParameters{
 		ForceUpdate:      forceUpdate,
-		ImageURI:         biosVersion.Spec.Image.URI,
+		ImageURI:         version.Spec.Image.URI,
 		Password:         password,
 		Username:         username,
-		TransferProtocol: schemas.TransferProtocolType(biosVersion.Spec.Image.TransferProtocol),
+		TransferProtocol: schemas.TransferProtocolType(version.Spec.Image.TransferProtocol),
 	}
 
 	taskMonitor, isFatal, err := func() (string, bool, error) {
@@ -839,81 +832,70 @@ func (r *BIOSVersionReconciler) upgradeBIOSVersion(
 	upgradeCurrentTaskStatus := &metalv1alpha1.Task{URI: taskMonitor}
 
 	if isFatal {
-		log.Error(err, "failed to issue bios upgrade", "Version", biosVersion.Spec.Version, "Server", server.Name)
-		if errCond := r.Conditions.Update(
+		log.Error(err, "Failed to issue BIOS upgrade", "Version", version.Spec.Version, "Server", server.Name)
+		if err := r.Conditions.Update(
 			issuedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
 			conditionutils.UpdateReason(ReasonUpgradeIssueFailed),
 			conditionutils.UpdateMessage("Fatal error occurred. Upgrade might still go through on server."),
-		); errCond != nil {
-			log.Error(errCond, "failed to update conditions")
-			err := r.updateStatus(ctx, biosVersion, metalv1alpha1.BIOSVersionStateFailed, upgradeCurrentTaskStatus, issuedCondition)
-			return errors.Join(errCond, err)
+		); err != nil {
+			log.Error(err, "Failed to update conditions")
+			return errors.Join(err, r.updateStatus(ctx, version, metalv1alpha1.BIOSVersionStateFailed, upgradeCurrentTaskStatus, issuedCondition))
 		}
 
-		return r.updateStatus(ctx, biosVersion, metalv1alpha1.BIOSVersionStateFailed, upgradeCurrentTaskStatus, issuedCondition)
+		return r.updateStatus(ctx, version, metalv1alpha1.BIOSVersionStateFailed, upgradeCurrentTaskStatus, issuedCondition)
 	}
 	if err != nil {
-		log.Error(err, "failed to issue bios upgrade", "Version", biosVersion.Spec.Version, "Server", server.Name)
+		log.Error(err, "Failed to issue BIOS upgrade", "Version", version.Spec.Version, "Server", server.Name)
 		return err
 	}
-	if errCond := r.Conditions.Update(
+	if err := r.Conditions.Update(
 		issuedCondition,
 		conditionutils.UpdateStatus(corev1.ConditionTrue),
 		conditionutils.UpdateReason(ReasonUpgradeIssued),
-		conditionutils.UpdateMessage(fmt.Sprintf("Task to upgrade has been created %v", taskMonitor)),
-	); errCond != nil {
-		log.Error(errCond, "failed to update conditions")
-		if errCond := r.Conditions.Update(
-			issuedCondition,
-			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ReasonUpgradeIssued),
-			conditionutils.UpdateMessage(fmt.Sprintf("Task to upgrade has been created %v", taskMonitor)),
-		); errCond != nil {
-			log.Error(errCond, "failed to update conditions")
-			err := r.updateStatus(ctx, biosVersion, metalv1alpha1.BIOSVersionStateFailed, upgradeCurrentTaskStatus, issuedCondition)
-			return errors.Join(errCond, err)
-		}
+		conditionutils.UpdateMessage(fmt.Sprintf("Upgrade task created: %v", taskMonitor)),
+	); err != nil {
+		return fmt.Errorf("failed to update issued condition after successful upgrade: %w", err)
 	}
 
-	return r.updateStatus(ctx, biosVersion, biosVersion.Status.State, upgradeCurrentTaskStatus, issuedCondition)
+	return r.updateStatus(ctx, version, version.Status.State, upgradeCurrentTaskStatus, issuedCondition)
 }
 
 func (r *BIOSVersionReconciler) enqueueBiosVersionByServerRefs(ctx context.Context, obj client.Object) []ctrl.Request {
 	log := ctrl.LoggerFrom(ctx)
-	host := obj.(*metalv1alpha1.Server)
+	server := obj.(*metalv1alpha1.Server)
 
-	// don't requeue if host in wrong state
-	if host.Status.State == metalv1alpha1.ServerStateDiscovery ||
-		host.Status.State == metalv1alpha1.ServerStateError ||
-		host.Status.State == metalv1alpha1.ServerStateInitial {
+	// Skip servers in states that don't require requeue
+	if server.Status.State == metalv1alpha1.ServerStateDiscovery ||
+		server.Status.State == metalv1alpha1.ServerStateError ||
+		server.Status.State == metalv1alpha1.ServerStateInitial {
 		return nil
 	}
 
-	// don't requeue if host does not have Maintenance
-	if host.Spec.ServerMaintenanceRef == nil {
+	// Skip servers without maintenance
+	if server.Spec.ServerMaintenanceRef == nil {
 		return nil
 	}
 
 	biosVersionList := &metalv1alpha1.BIOSVersionList{}
 	if err := r.List(ctx, biosVersionList); err != nil {
-		log.Error(err, "failed to list biosVersionList")
+		log.Error(err, "Failed to list BIOSVersions")
 		return nil
 	}
 
-	for _, biosVersion := range biosVersionList.Items {
-		if biosVersion.Spec.ServerRef.Name == host.Name {
-			// states where we do not need to requeue for host changes
-			if biosVersion.Spec.ServerMaintenanceRef == nil ||
-				biosVersion.Status.State == metalv1alpha1.BIOSVersionStateCompleted ||
-				biosVersion.Status.State == metalv1alpha1.BIOSVersionStateFailed {
+	for _, version := range biosVersionList.Items {
+		if version.Spec.ServerRef.Name == server.Name {
+			// Skip completed or failed BIOSVersions
+			if version.Spec.ServerMaintenanceRef == nil ||
+				version.Status.State == metalv1alpha1.BIOSVersionStateCompleted ||
+				version.Status.State == metalv1alpha1.BIOSVersionStateFailed {
 				return nil
 			}
-			if biosVersion.Spec.ServerMaintenanceRef.Name != host.Spec.ServerMaintenanceRef.Name {
+			if version.Spec.ServerMaintenanceRef.Name != server.Spec.ServerMaintenanceRef.Name {
 				return nil
 			}
 			return []ctrl.Request{{
-				NamespacedName: types.NamespacedName{Namespace: biosVersion.Namespace, Name: biosVersion.Name},
+				NamespacedName: types.NamespacedName{Namespace: version.Namespace, Name: version.Name},
 			}}
 		}
 	}
@@ -929,7 +911,7 @@ func (r *BIOSVersionReconciler) enqueueBiosSettingsByBMC(ctx context.Context, ob
 		server := object.(*metalv1alpha1.Server)
 		return server.Spec.BMCRef != nil && server.Spec.BMCRef.Name == bmcObj.Name, nil
 	}); err != nil {
-		log.Error(err, "failed to list Server created by this BMC resources", "BMC", bmcObj.Name)
+		log.Error(err, "Failed to list Servers for BMC", "BMC", bmcObj.Name)
 		return nil
 	}
 
@@ -940,30 +922,30 @@ func (r *BIOSVersionReconciler) enqueueBiosSettingsByBMC(ctx context.Context, ob
 
 	biosVersionList := &metalv1alpha1.BIOSVersionList{}
 	if err := clientutils.ListAndFilter(ctx, r.Client, biosVersionList, func(object client.Object) (bool, error) {
-		biosVersion := object.(*metalv1alpha1.BIOSVersion)
-		if _, exists := serverMap[biosVersion.Spec.ServerRef.Name]; !exists {
+		version := object.(*metalv1alpha1.BIOSVersion)
+		if _, exists := serverMap[version.Spec.ServerRef.Name]; !exists {
 			return false, nil
 		}
 		return true, nil
 	}); err != nil {
-		log.Error(err, "failed to list Server created by this BMC resources", "BMC", bmcObj.Name)
+		log.Error(err, "Failed to list BIOSVersions for BMC", "BMC", bmcObj.Name)
 		return nil
 	}
 
 	reqs := make([]ctrl.Request, 0)
-	for _, biosVersion := range biosVersionList.Items {
-		if biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
-			resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, BMCConditionReset)
+	for _, version := range biosVersionList.Items {
+		if version.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
+			resetBMC, err := GetCondition(r.Conditions, version.Status.Conditions, BMCConditionReset)
 			if err != nil {
-				log.Error(err, "failed to get reset BMC condition")
+				log.Error(err, "Failed to get BMC reset condition")
 				continue
 			}
 			if resetBMC.Status == metav1.ConditionTrue {
 				continue
 			}
-			// enqueue only if the BMC reset is requested for this BMC
+			// Enqueue only if the BMC reset was requested
 			if resetBMC.Reason == BMCReasonReset {
-				reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: biosVersion.Namespace, Name: biosVersion.Name}})
+				reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: version.Namespace, Name: version.Name}})
 			}
 		}
 	}

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -220,11 +220,18 @@ func (r *BIOSVersionReconciler) transitionState(ctx context.Context, version *me
 		if shouldRetryReconciliation(version) {
 			log.V(1).Info("Retrying BIOSVersion reconciliation")
 			versionBase := version.DeepCopy()
-			version.Status.State = metalv1alpha1.BIOSVersionStatePending
-			version.Status.Conditions = []metav1.Condition{}
+
 			annotations := version.GetAnnotations()
 			delete(annotations, metalv1alpha1.OperationAnnotation)
 			version.SetAnnotations(annotations)
+
+			if err := r.Patch(ctx, version, client.MergeFrom(versionBase)); err != nil {
+				return true, fmt.Errorf("failed to patch BIOSVersion metadata for retrying: %w", err)
+			}
+
+			versionBase = version.DeepCopy()
+			version.Status.State = metalv1alpha1.BIOSVersionStatePending
+			version.Status.Conditions = []metav1.Condition{}
 
 			if err := r.Status().Patch(ctx, version, client.MergeFrom(versionBase)); err != nil {
 				return true, fmt.Errorf("failed to patch BIOSVersion status for retrying: %w", err)

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/schemas"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -240,10 +241,8 @@ func (r *BIOSVersionReconciler) transitionState(ctx context.Context, version *me
 
 func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmcClient bmc.BMC, version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	if version.Spec.ServerMaintenanceRef == nil {
-		if requeue, err := r.requestServerMaintenance(ctx, version, server); err != nil || requeue {
-			return false, err
-		}
+	if requeue, err := r.requestServerMaintenance(ctx, version, server); err != nil || requeue {
+		return false, err
 	}
 
 	condition, err := GetCondition(r.Conditions, version.Status.Conditions, ServerMaintenanceConditionWaiting)
@@ -558,10 +557,8 @@ func (r *BIOSVersionReconciler) cleanup(ctx context.Context, bmcClient bmc.BMC, 
 		}
 
 		log.V(1).Info("Upgraded BIOS version", "Version", currentVersion, "Server", server.Name)
-		version.Status.Conditions = nil
 		return r.updateStatus(ctx, version, metalv1alpha1.BIOSVersionStateCompleted, nil, nil)
 	}
-	version.Status.Conditions = nil
 	return r.updateStatus(ctx, version, metalv1alpha1.BIOSVersionStateInProgress, nil, nil)
 }
 
@@ -579,11 +576,8 @@ func (r *BIOSVersionReconciler) getServerMaintenanceForRef(ctx context.Context, 
 }
 
 func (r *BIOSVersionReconciler) updateStatus(ctx context.Context, version *metalv1alpha1.BIOSVersion, state metalv1alpha1.BIOSVersionState, upgradeTask *metalv1alpha1.Task, condition *metav1.Condition) error {
-	if version.Status.State == state && condition == nil && upgradeTask == nil {
-		return nil
-	}
-
 	versionBase := version.DeepCopy()
+
 	version.Status.State = state
 
 	if condition != nil {
@@ -599,6 +593,10 @@ func (r *BIOSVersionReconciler) updateStatus(ctx context.Context, version *metal
 	}
 
 	version.Status.UpgradeTask = upgradeTask
+
+	if equality.Semantic.DeepEqual(version.Status, versionBase.Status) {
+		return nil
+	}
 
 	if err := r.Status().Patch(ctx, version, client.MergeFrom(versionBase)); err != nil {
 		return fmt.Errorf("failed to patch BIOSVersion status: %w", err)
@@ -806,7 +804,7 @@ func (r *BIOSVersionReconciler) upgradeBIOSVersion(ctx context.Context, bmcClien
 	var username, password string
 	if version.Spec.Image.SecretRef != nil {
 		var err error
-		password, username, err = GetImageCredentialsForSecretRef(ctx, r.Client, version.Spec.Image.SecretRef)
+		username, password, err = GetImageCredentialsForSecretRef(ctx, r.Client, version.Spec.Image.SecretRef)
 		if err != nil {
 			return fmt.Errorf("failed to get image credentials: %w", err)
 		}

--- a/internal/controller/biosversion_controller_test.go
+++ b/internal/controller/biosversion_controller_test.go
@@ -4,7 +4,6 @@
 package controller
 
 import (
-	"github.com/ironcore-dev/controller-utils/conditionutils"
 	"github.com/ironcore-dev/controller-utils/metautils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/ironcore-dev/metal-operator/bmc"
@@ -34,7 +33,6 @@ var _ = Describe("BIOSVersion Controller", func() {
 		By("Creating a BMCSecret")
 		bmcSecret = &metalv1alpha1.BMCSecret{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    ns.Name,
 				GenerateName: "test-",
 			},
 			Data: map[string][]byte{
@@ -47,7 +45,6 @@ var _ = Describe("BIOSVersion Controller", func() {
 		By("Creating a Server")
 		server = &metalv1alpha1.Server{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    ns.Name,
 				GenerateName: "test-maintenance-",
 			},
 			Spec: metalv1alpha1.ServerSpec{
@@ -82,14 +79,13 @@ var _ = Describe("BIOSVersion Controller", func() {
 	})
 
 	It("Should successfully mark completed if no BIOS version change", func(ctx SpecContext) {
-		By("Ensuring that the server has Available state")
+		By("Ensuring that the Server has Available state")
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 		)
 		By("Creating a BIOSVersion")
-		biosVersion := &metalv1alpha1.BIOSVersion{
+		version := &metalv1alpha1.BIOSVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    ns.Name,
 				GenerateName: "test-",
 			},
 			Spec: metalv1alpha1.BIOSVersionSpec{
@@ -101,15 +97,15 @@ var _ = Describe("BIOSVersion Controller", func() {
 				ServerRef: &v1.LocalObjectReference{Name: server.Name},
 			},
 		}
-		Expect(k8sClient.Create(ctx, biosVersion)).To(Succeed())
+		Expect(k8sClient.Create(ctx, version)).To(Succeed())
 
-		By("Ensuring that BIOS upgrade has completed")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the BIOS upgrade has completed")
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateCompleted),
 		)
 
-		By("Ensuring that BIOS upgrade Conditions has not created")
-		Consistently(Object(biosVersion)).Should(
+		By("Ensuring that BIOS upgrade conditions have not been created")
+		Consistently(Object(version)).Should(
 			HaveField("Status.Conditions", BeNil()),
 		)
 
@@ -118,11 +114,11 @@ var _ = Describe("BIOSVersion Controller", func() {
 		Consistently(ObjectList(&serverMaintenanceList)).Should(HaveField("Items", BeEmpty()))
 
 		By("Deleting the BIOSVersion")
-		Expect(k8sClient.Delete(ctx, biosVersion)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, version)).To(Succeed())
 
-		By("Ensuring that the BiosVersion has been removed")
-		Eventually(Get(biosVersion)).Should(Satisfy(apierrors.IsNotFound))
-		Consistently(Get(biosVersion)).Should(Satisfy(apierrors.IsNotFound))
+		By("Ensuring that the BIOSVersion has been removed")
+		Eventually(Get(version)).Should(Satisfy(apierrors.IsNotFound))
+		Consistently(Get(version)).Should(Satisfy(apierrors.IsNotFound))
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
 		)
@@ -133,16 +129,13 @@ var _ = Describe("BIOSVersion Controller", func() {
 		// metal-operator/bmc/redfish_local.go mockedBIOS*
 		// note: ImageURI need to have the version string.
 
-		acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
-
-		By("Ensuring that the server has Available state")
+		By("Ensuring that the Server has Available state")
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 		)
 		By("Creating a BIOSVersion")
-		biosVersion := &metalv1alpha1.BIOSVersion{
+		version := &metalv1alpha1.BIOSVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    ns.Name,
 				GenerateName: "test-",
 			},
 			Spec: metalv1alpha1.BIOSVersionSpec{
@@ -154,10 +147,10 @@ var _ = Describe("BIOSVersion Controller", func() {
 				ServerRef: &v1.LocalObjectReference{Name: server.Name},
 			},
 		}
-		Expect(k8sClient.Create(ctx, biosVersion)).To(Succeed())
+		Expect(k8sClient.Create(ctx, version)).To(Succeed())
 
-		By("Ensuring that the biosVersion has entered Inprogress state")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the BIOSVersion has entered InProgress state")
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateInProgress),
 		)
 
@@ -168,20 +161,20 @@ var _ = Describe("BIOSVersion Controller", func() {
 		serverMaintenance := &metalv1alpha1.ServerMaintenance{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
-				Name:      biosVersion.Name,
+				Name:      version.Name,
 			},
 		}
 		Eventually(Get(serverMaintenance)).Should(Succeed())
 
-		By("Ensuring that the Maintenance resource has been referenced by biosVersion")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the Maintenance resource has been referenced by the BIOSVersion")
+		Eventually(Object(version)).Should(
 			HaveField("Spec.ServerMaintenanceRef", &metalv1alpha1.ObjectReference{
 				Namespace: serverMaintenance.Namespace,
 				Name:      serverMaintenance.Name,
 			}),
 		)
 
-		By("Ensuring that Server in Maintenance state")
+		By("Ensuring that the Server is in Maintenance state")
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerStateMaintenance),
 			HaveField("Spec.ServerMaintenanceRef", &metalv1alpha1.ObjectReference{
@@ -192,33 +185,33 @@ var _ = Describe("BIOSVersion Controller", func() {
 
 		By("Ensuring that both BMCVersion and BIOSVersion report consistent InProgress state while waiting on maintenance")
 		// This test verifies that both version CRDs use the same state enum value when waiting on maintenance
-		Eventually(Object(biosVersion)).Should(
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateInProgress),
 		)
 
-		ensureBiosVersionConditionTransition(acc, biosVersion, server)
+		ensureBiosVersionConditionTransition(version, server)
 
 		By("Ensuring that BIOS upgrade has completed")
-		Eventually(Object(biosVersion)).Should(
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateCompleted),
 		)
 
-		By("Ensuring that BIOSVersion has removed Maintenance")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the BIOSVersion has removed Maintenance")
+		Eventually(Object(version)).Should(
 			HaveField("Spec.ServerMaintenanceRef", BeNil()),
 		)
-		Consistently(Object(biosVersion)).Should(
+		Consistently(Object(version)).Should(
 			HaveField("Spec.ServerMaintenanceRef", BeNil()),
 		)
 
 		Consistently(ObjectList(&serverMaintenanceList)).Should(HaveField("Items", BeEmpty()))
 
 		By("Deleting the BIOSVersion")
-		Expect(k8sClient.Delete(ctx, biosVersion)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, version)).To(Succeed())
 
-		By("Ensuring that the BiosVersion has been removed")
-		Eventually(Get(biosVersion)).Should(Satisfy(apierrors.IsNotFound))
-		Consistently(Get(biosVersion)).Should(Satisfy(apierrors.IsNotFound))
+		By("Ensuring that the BIOSVersion has been removed")
+		Eventually(Get(version)).Should(Satisfy(apierrors.IsNotFound))
+		Consistently(Get(version)).Should(Satisfy(apierrors.IsNotFound))
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
 		)
@@ -229,7 +222,6 @@ var _ = Describe("BIOSVersion Controller", func() {
 		// metal-operator/bmc/redfish_local.go mockedBIOS*
 		// note: ImageURI need to have the version string.
 
-		acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
 		By("Creating an Ignition secret")
 		ignitionSecret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -261,9 +253,8 @@ var _ = Describe("BIOSVersion Controller", func() {
 		)
 
 		By("Creating a BIOSVersion")
-		biosVersion := &metalv1alpha1.BIOSVersion{
+		version := &metalv1alpha1.BIOSVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    ns.Name,
 				GenerateName: "test-",
 			},
 			Spec: metalv1alpha1.BIOSVersionSpec{
@@ -275,10 +266,10 @@ var _ = Describe("BIOSVersion Controller", func() {
 				ServerRef: &v1.LocalObjectReference{Name: server.Name},
 			},
 		}
-		Expect(k8sClient.Create(ctx, biosVersion)).To(Succeed())
+		Expect(k8sClient.Create(ctx, version)).To(Succeed())
 
-		By("Ensuring that the biosVersion has entered Inprogress state")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the BIOSVersion has entered InProgress state")
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateInProgress),
 		)
 
@@ -289,21 +280,21 @@ var _ = Describe("BIOSVersion Controller", func() {
 		serverMaintenance := &metalv1alpha1.ServerMaintenance{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
-				Name:      biosVersion.Name,
+				Name:      version.Name,
 			},
 		}
 		Eventually(Get(serverMaintenance)).Should(Succeed())
 
-		By("Ensuring that the Maintenance resource has been referenced by biosVersion")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the Maintenance resource has been referenced by the BIOSVersion")
+		Eventually(Object(version)).Should(
 			HaveField("Spec.ServerMaintenanceRef", &metalv1alpha1.ObjectReference{
 				Namespace: serverMaintenance.Namespace,
 				Name:      serverMaintenance.Name,
 			}),
 		)
 
-		By("Ensuring that the biosVersion has Inprogress state and waiting")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the BIOSVersion has InProgress state and is waiting")
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateInProgress),
 		)
 
@@ -313,7 +304,7 @@ var _ = Describe("BIOSVersion Controller", func() {
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovalKey, trueValue)
 		})).Should(Succeed())
 
-		By("Ensuring that Server in Maintenance state")
+		By("Ensuring that the Server is in Maintenance state")
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerStateMaintenance),
 			HaveField("Spec.ServerMaintenanceRef", &metalv1alpha1.ObjectReference{
@@ -322,29 +313,29 @@ var _ = Describe("BIOSVersion Controller", func() {
 			}),
 		))
 
-		ensureBiosVersionConditionTransition(acc, biosVersion, server)
+		ensureBiosVersionConditionTransition(version, server)
 
 		By("Ensuring that BIOS upgrade has completed")
-		Eventually(Object(biosVersion)).Should(
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateCompleted),
 		)
 
-		By("Ensuring that BIOSVersion has removed Maintenance")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the BIOSVersion has removed Maintenance")
+		Eventually(Object(version)).Should(
 			HaveField("Spec.ServerMaintenanceRef", BeNil()),
 		)
-		Consistently(Object(biosVersion)).Should(
+		Consistently(Object(version)).Should(
 			HaveField("Spec.ServerMaintenanceRef", BeNil()),
 		)
 
 		Consistently(ObjectList(&serverMaintenanceList)).Should(HaveField("Items", BeEmpty()))
 
 		By("Deleting the BIOSVersion")
-		Expect(k8sClient.Delete(ctx, biosVersion)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, version)).To(Succeed())
 
-		By("Ensuring that the BiosVersion has been removed")
-		Eventually(Get(biosVersion)).Should(Satisfy(apierrors.IsNotFound))
-		Consistently(Get(biosVersion)).Should(Satisfy(apierrors.IsNotFound))
+		By("Ensuring that the BIOSVersion has been removed")
+		Eventually(Get(version)).Should(Satisfy(apierrors.IsNotFound))
+		Consistently(Get(version)).Should(Satisfy(apierrors.IsNotFound))
 
 		// cleanup
 		Expect(k8sClient.Delete(ctx, serverClaim)).To(Succeed())
@@ -356,9 +347,8 @@ var _ = Describe("BIOSVersion Controller", func() {
 
 	It("Should allow retry using annotation", func(ctx SpecContext) {
 		By("Creating a BIOSVersion")
-		biosVersion := &metalv1alpha1.BIOSVersion{
+		version := &metalv1alpha1.BIOSVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    ns.Name,
 				GenerateName: "test-",
 			},
 			Spec: metalv1alpha1.BIOSVersionSpec{
@@ -370,29 +360,29 @@ var _ = Describe("BIOSVersion Controller", func() {
 				ServerRef: &v1.LocalObjectReference{Name: server.Name},
 			},
 		}
-		Expect(k8sClient.Create(ctx, biosVersion)).To(Succeed())
+		Expect(k8sClient.Create(ctx, version)).To(Succeed())
 
 		By("Moving to Failed state")
-		Eventually(UpdateStatus(biosVersion, func() {
-			biosVersion.Status.State = metalv1alpha1.BIOSVersionStateFailed
+		Eventually(UpdateStatus(version, func() {
+			version.Status.State = metalv1alpha1.BIOSVersionStateFailed
 		})).Should(Succeed())
 
-		Eventually(Update(biosVersion, func() {
-			biosVersion.Annotations = map[string]string{
+		Eventually(Update(version, func() {
+			version.Annotations = map[string]string{
 				metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetryFailed,
 			}
 		})).Should(Succeed())
 
-		Eventually(Object(biosVersion)).Should(
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateInProgress),
 		)
 
-		Eventually(Object(biosVersion)).Should(
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateCompleted),
 		)
 
 		// cleanup
-		Expect(k8sClient.Delete(ctx, biosVersion)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, version)).To(Succeed())
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
 		)
@@ -408,10 +398,10 @@ var _ = Describe("BIOSVersion Controller with BMCRef BMC", func() {
 		bmcSecret *metalv1alpha1.BMCSecret
 	)
 	const upgradeServerBiosVersion = "P80 v1.45 (12/06/2017)"
+
 	BeforeEach(func(ctx SpecContext) {
 		bmcSecret = &metalv1alpha1.BMCSecret{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    ns.Name,
 				GenerateName: "test-bmc-secret-",
 			},
 			Data: map[string][]byte{
@@ -423,7 +413,6 @@ var _ = Describe("BIOSVersion Controller with BMCRef BMC", func() {
 		bmcObj = &metalv1alpha1.BMC{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-bmc-",
-				Namespace:    ns.Name,
 			},
 			Spec: metalv1alpha1.BMCSpec{
 				Endpoint: &metalv1alpha1.InlineEndpoint{
@@ -464,21 +453,18 @@ var _ = Describe("BIOSVersion Controller with BMCRef BMC", func() {
 
 		EnsureCleanState()
 	})
-	It("should successfully Start and monitor Upgrade task to completion", func(ctx SpecContext) {
+	It("Should successfully start and monitor upgrade task to completion", func(ctx SpecContext) {
 		// mocked at
 		// metal-operator/bmc/redfish_local.go mockedBIOS*
 		// note: ImageURI need to have the version string.
 
-		acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
-
-		By("Ensuring that the server has Available state")
+		By("Ensuring that the Server has Available state")
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 		)
 		By("Creating a BIOSVersion")
-		biosVersion := &metalv1alpha1.BIOSVersion{
+		version := &metalv1alpha1.BIOSVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    ns.Name,
 				GenerateName: "test-",
 			},
 			Spec: metalv1alpha1.BIOSVersionSpec{
@@ -490,10 +476,10 @@ var _ = Describe("BIOSVersion Controller with BMCRef BMC", func() {
 				ServerRef: &v1.LocalObjectReference{Name: server.Name},
 			},
 		}
-		Expect(k8sClient.Create(ctx, biosVersion)).To(Succeed())
+		Expect(k8sClient.Create(ctx, version)).To(Succeed())
 
-		By("Ensuring that the biosVersion has entered Inprogress state")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the BIOSVersion has entered InProgress state")
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateInProgress),
 		)
 
@@ -504,20 +490,20 @@ var _ = Describe("BIOSVersion Controller with BMCRef BMC", func() {
 		serverMaintenance := &metalv1alpha1.ServerMaintenance{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
-				Name:      biosVersion.Name,
+				Name:      version.Name,
 			},
 		}
 		Eventually(Get(serverMaintenance)).Should(Succeed())
 
-		By("Ensuring that the Maintenance resource has been referenced by biosVersion")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the Maintenance resource has been referenced by the BIOSVersion")
+		Eventually(Object(version)).Should(
 			HaveField("Spec.ServerMaintenanceRef", &metalv1alpha1.ObjectReference{
 				Namespace: serverMaintenance.Namespace,
 				Name:      serverMaintenance.Name,
 			}),
 		)
 
-		By("Ensuring that Server in Maintenance state")
+		By("Ensuring that the Server is in Maintenance state")
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerStateMaintenance),
 			HaveField("Spec.ServerMaintenanceRef", &metalv1alpha1.ObjectReference{
@@ -526,121 +512,83 @@ var _ = Describe("BIOSVersion Controller with BMCRef BMC", func() {
 			}),
 		))
 
-		ensureBiosVersionConditionTransition(acc, biosVersion, server)
+		ensureBiosVersionConditionTransition(version, server)
 
 		By("Ensuring that BIOS upgrade has completed")
-		Eventually(Object(biosVersion)).Should(
+		Eventually(Object(version)).Should(
 			HaveField("Status.State", metalv1alpha1.BIOSVersionStateCompleted),
 		)
 
-		By("Ensuring that BIOSVersion has removed Maintenance")
-		Eventually(Object(biosVersion)).Should(
+		By("Ensuring that the BIOSVersion has removed Maintenance")
+		Eventually(Object(version)).Should(
 			HaveField("Spec.ServerMaintenanceRef", BeNil()),
 		)
-		Consistently(Object(biosVersion)).Should(
+		Consistently(Object(version)).Should(
 			HaveField("Spec.ServerMaintenanceRef", BeNil()),
 		)
 
 		Consistently(ObjectList(&serverMaintenanceList)).Should(HaveField("Items", BeEmpty()))
 
 		By("Deleting the BIOSVersion")
-		Expect(k8sClient.Delete(ctx, biosVersion)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, version)).To(Succeed())
 
-		By("Ensuring that the BiosVersion has been removed")
-		Eventually(Get(biosVersion)).Should(Satisfy(apierrors.IsNotFound))
-		Consistently(Get(biosVersion)).Should(Satisfy(apierrors.IsNotFound))
+		By("Ensuring that the BIOSVersion has been removed")
+		Eventually(Get(version)).Should(Satisfy(apierrors.IsNotFound))
+		Consistently(Get(version)).Should(Satisfy(apierrors.IsNotFound))
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
 		)
 	})
 })
 
-func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVersion *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) {
-	GinkgoHelper()
-	By("Ensuring that BIOS Conditions have reached expected state 'biosVersionUpgradeIssued'")
-	condIssue := &metav1.Condition{}
-	Eventually(
-		func(g Gomega) int {
-			g.Expect(Get(biosVersion)()).To(Succeed())
-			return len(biosVersion.Status.Conditions)
-		}).Should(BeNumerically(">=", 1))
-	Eventually(
-		func(g Gomega) bool {
-			g.Expect(Get(biosVersion)()).To(Succeed())
-			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeIssued, condIssue)).To(BeTrue())
-			return condIssue.Status == metav1.ConditionTrue
-		}).Should(BeTrue())
+// conditionMatcher returns a matcher that checks for a specific condition type with ConditionTrue status.
+func conditionMatcher(conditionType string) OmegaMatcher {
+	return ContainElement(SatisfyAll(
+		HaveField("Type", conditionType),
+		HaveField("Status", Equal(metav1.ConditionTrue)),
+	))
+}
 
-	By("Ensuring that BIOSVersion has updated the taskStatus with taskURI")
+// ensureBiosVersionConditionTransition drives the BIOS upgrade through its condition waterfall.
+// envtest has no server maintenance controller, so power state transitions must be forced manually.
+func ensureBiosVersionConditionTransition(version *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) {
+	GinkgoHelper()
+
+	By("Waiting for the upgrade task to be tracked")
 	Eventually(func(g Gomega) {
-		g.Expect(Get(biosVersion)()).To(Succeed())
-		g.Expect(biosVersion.Status.UpgradeTask).NotTo(BeNil())
-		g.Expect(biosVersion.Status.UpgradeTask.URI).To(Equal(bmc.DummyMockTaskForUpgrade))
+		g.Expect(Get(version)()).To(Succeed())
+		g.Expect(version.Status.UpgradeTask).NotTo(BeNil())
+		g.Expect(version.Status.UpgradeTask.URI).To(Equal(bmc.DummyMockTaskForUpgrade))
 	}).Should(Succeed())
 
-	By("Ensuring that BIOS Conditions have reached expected state 'biosVersionUpgradeCompleted'")
-	condComplete := &metav1.Condition{}
-	Eventually(
-		func(g Gomega) int {
-			g.Expect(Get(biosVersion)()).To(Succeed())
-			return len(biosVersion.Status.Conditions)
-		}).Should(BeNumerically(">=", 2))
-	Eventually(
-		func(g Gomega) bool {
-			g.Expect(Get(biosVersion)()).To(Succeed())
-			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted, condComplete)).To(BeTrue())
-			return condComplete.Status == metav1.ConditionTrue
-		}).Should(BeTrue())
+	By("Waiting for the upgrade task to complete")
+	Eventually(Object(version)).Should(
+		HaveField("Status.Conditions", conditionMatcher(ConditionBIOSUpgradeCompleted)),
+	)
 
-	// waiting for serverMaintenance and server to eventually update the power state is making it flaky.
-	// force turn on the server already for testing
-	By("update the server state to PoweredOff state")
+	// envtest has no maintenance controller — force power state transitions manually.
+	By("Forcing server power off for reboot")
 	Eventually(UpdateStatus(server, func() {
 		server.Status.PowerState = metalv1alpha1.ServerOffPowerState
 	})).Should(Succeed())
 
-	By("Ensuring that BIOS Conditions have reached expected state 'biosVersionUpgradeRebootServerPoweroff'")
-	rebootStart := &metav1.Condition{}
-	Eventually(
-		func(g Gomega) int {
-			g.Expect(Get(biosVersion)()).To(Succeed())
-			return len(biosVersion.Status.Conditions)
-		}).Should(BeNumerically(">=", 3))
-	Eventually(
-		func(g Gomega) bool {
-			g.Expect(Get(biosVersion)()).To(Succeed())
-			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted, rebootStart)).To(BeTrue())
-			return rebootStart.Status == metav1.ConditionTrue
-		}).Should(BeTrue())
+	By("Waiting for the power off condition")
+	Eventually(Object(version)).Should(
+		HaveField("Status.Conditions", conditionMatcher(ConditionBIOSUpgradePowerOff)),
+	)
 
-	// waiting for serverMaintenance and server to eventually update the power state is making it flaky.
-	// force turn on the server already for testing
-	By("update the server state to PoweredOn state")
+	By("Forcing server power on for reboot")
 	Eventually(UpdateStatus(server, func() {
 		server.Status.PowerState = metalv1alpha1.ServerOnPowerState
 	})).Should(Succeed())
 
-	By("Ensuring that BIOS Conditions have reached expected state 'biosVersionUpgradeRebootServerPowerOn'")
-	rebootComplete := &metav1.Condition{}
-	Eventually(func(g Gomega) int {
-		g.Expect(Get(biosVersion)()).To(Succeed())
-		return len(biosVersion.Status.Conditions)
-	}).Should(BeNumerically(">=", 4))
-	Eventually(func(g Gomega) bool {
-		g.Expect(Get(biosVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted, rebootComplete)).To(BeTrue())
-		return rebootComplete.Status == metav1.ConditionTrue
-	}).Should(BeTrue())
+	By("Waiting for the power on condition")
+	Eventually(Object(version)).Should(
+		HaveField("Status.Conditions", conditionMatcher(ConditionBIOSUpgradePowerOn)),
+	)
 
-	By("Ensuring that BIOS Conditions have reached expected state 'biosVersionUpgradeVerificationCondition'")
-	verificationComplete := &metav1.Condition{}
-	Eventually(func(g Gomega) int {
-		g.Expect(Get(biosVersion)()).To(Succeed())
-		return len(biosVersion.Status.Conditions)
-	}).Should(BeNumerically(">=", 5))
-	Eventually(func(g Gomega) bool {
-		g.Expect(Get(biosVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeVerification, verificationComplete)).To(BeTrue())
-		return verificationComplete.Status == metav1.ConditionTrue
-	}).Should(BeTrue())
+	By("Waiting for verification to complete")
+	Eventually(Object(version)).Should(
+		HaveField("Status.Conditions", conditionMatcher(ConditionBIOSUpgradeVerification)),
+	)
 }

--- a/internal/controller/biosversion_controller_test.go
+++ b/internal/controller/biosversion_controller_test.go
@@ -217,6 +217,68 @@ var _ = Describe("BIOSVersion Controller", func() {
 		)
 	})
 
+	It("Should preserve conditions during upgrade and through completion", func(ctx SpecContext) {
+		By("Ensuring that the Server has Available state")
+		Eventually(Object(server)).Should(
+			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
+		)
+
+		By("Creating a BIOSVersion that requires an upgrade")
+		version := &metalv1alpha1.BIOSVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+			Spec: metalv1alpha1.BIOSVersionSpec{
+				BIOSVersionTemplate: metalv1alpha1.BIOSVersionTemplate{
+					Version:                 upgradeServerBiosVersion,
+					Image:                   metalv1alpha1.ImageSpec{URI: upgradeServerBiosVersion},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+				ServerRef: &v1.LocalObjectReference{Name: server.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, version)).To(Succeed())
+
+		By("Ensuring that the BIOSVersion has entered InProgress state")
+		Eventually(Object(version)).Should(
+			HaveField("Status.State", metalv1alpha1.BIOSVersionStateInProgress),
+		)
+
+		By("Ensuring that the Maintenance resource has been created")
+		var serverMaintenanceList metalv1alpha1.ServerMaintenanceList
+		Eventually(ObjectList(&serverMaintenanceList)).Should(HaveField("Items", Not(BeEmpty())))
+
+		serverMaintenance := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      version.Name,
+			},
+		}
+		Eventually(Get(serverMaintenance)).Should(Succeed())
+
+		By("Ensuring that the Server is in Maintenance state")
+		Eventually(Object(server)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.ServerStateMaintenance),
+			HaveField("Spec.ServerMaintenanceRef", &metalv1alpha1.ObjectReference{
+				Namespace: serverMaintenance.Namespace,
+				Name:      serverMaintenance.Name,
+			}),
+		))
+
+		By("Driving through condition transitions")
+		ensureBiosVersionConditionTransition(version, server)
+
+		By("Verifying that conditions are preserved when state transitions to Completed")
+		Eventually(Object(version)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.BIOSVersionStateCompleted),
+			HaveField("Status.Conditions", Not(BeEmpty())),
+		))
+
+		By("Deleting the BIOSVersion")
+		Expect(k8sClient.Delete(ctx, version)).To(Succeed())
+		Eventually(Get(version)).Should(Satisfy(apierrors.IsNotFound))
+	})
+
 	It("Should upgrade servers BIOS when in reserved state", func(ctx SpecContext) {
 		// mocked at
 		// metal-operator/bmc/redfish_local.go mockedBIOS*
@@ -560,6 +622,11 @@ func ensureBiosVersionConditionTransition(version *metalv1alpha1.BIOSVersion, se
 		g.Expect(version.Status.UpgradeTask).NotTo(BeNil())
 		g.Expect(version.Status.UpgradeTask.URI).To(Equal(bmc.DummyMockTaskForUpgrade))
 	}).Should(Succeed())
+
+	By("Waiting for the upgrade issued condition")
+	Eventually(Object(version)).Should(
+		HaveField("Status.Conditions", conditionMatcher(ConditionBIOSUpgradeIssued)),
+	)
 
 	By("Waiting for the upgrade task to complete")
 	Eventually(Object(version)).Should(

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -37,6 +37,9 @@ const (
 	ServerMaintenanceConditionWaiting = "ServerMaintenanceWaiting"
 	ServerMaintenanceReasonWaiting    = "ServerMaintenanceWaitingOnApproval"
 	ServerMaintenanceReasonApproved   = "ServerMaintenanceApproval"
+
+	BMCConditionReset = "BMCResetIssued"
+	BMCReasonReset    = "BMCResetIssued"
 )
 
 type BMCTaskFetchFailedError struct {


### PR DESCRIPTION
# Proposed Changes

Simplify BIOSVersion controller and fix bugs

- Fix destructive updateStatus() that silently wiped all conditions when called with nil condition
- Fix copy-paste bug with nested identical retry in upgradeBIOSVersion()
- Extract processInProgressState() waterfall into 5 focused step handlers
- Deduplicate handleServerMaintenance() via ensureMaintenanceWaitingCondition()
- Flatten handleBMCReset() from 4 levels of nesting to early returns
- Move shared BMCConditionReset/BMCReasonReset constants to helper.go
- Rename biosVersion variables to version, collapse multi-line signatures
- Fix log messages for K8s style conventions (past tense, capitalization, grammar, consistent key naming)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked BIOS upgrade reconciliation into ordered phase handlers (issue, completion, power off/on, verification) and a phase-based BMC reset flow, improving reliability of upgrade progression and maintenance handling.
  * Status conditions are preserved across transitions to retain condition history.

* **Tests**
  * Updated test suites and assertions to match renamed variables and the new condition-handling flow, with added coverage for upgrade condition preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->