### PR TITLE
Fix ServerClaim race condition and BMC-driven state oscillation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -428,6 +428,7 @@ func main() { // nolint: gocyclo
 	}
 	if err = (&controller.ServerClaimReconciler{
 		Client:                  mgr.GetClient(),
+		APIReader:               mgr.GetAPIReader(),
 		Cache:                   mgr.GetCache(),
 		Scheme:                  mgr.GetScheme(),
 		MaxConcurrentReconciles: serverClaimMaxConcurrentReconciles,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -392,6 +392,7 @@ func main() { // nolint: gocyclo
 	}
 	if err = (&controller.ServerReconciler{
 		Client:                  mgr.GetClient(),
+		APIReader:               mgr.GetAPIReader(),
 		Scheme:                  mgr.GetScheme(),
 		Insecure:                insecure,
 		ManagerNamespace:        managerNamespace,

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -291,7 +291,14 @@ func (r *BMCReconciler) discoverServers(ctx context.Context, bmcClient bmc.BMC, 
 			errs = append(errs, fmt.Errorf("failed to create or patch server %s: %w", server.Name, err))
 			continue
 		}
-		log.V(1).Info("Created or patched Server", "Server", server.Name, "Operation", opResult)
+		switch opResult {
+		case controllerutil.OperationResultCreated:
+			log.V(1).Info("Created Server", "Server", server.Name)
+		case controllerutil.OperationResultUpdated:
+			log.V(1).Info("Updated Server", "Server", server.Name)
+		default:
+			log.V(1).Info("Server already up to date", "Server", server.Name)
+		}
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("errors occurred during server discovery: %v", errs)

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -81,6 +81,7 @@ const (
 // ServerReconciler reconciles a Server object
 type ServerReconciler struct {
 	client.Client
+	APIReader               client.Reader
 	Scheme                  *runtime.Scheme
 	Insecure                bool
 	ManagerNamespace        string
@@ -449,6 +450,18 @@ func (r *ServerReconciler) handleAvailableState(ctx context.Context, bmcClient b
 	if err := r.ensureIndicatorLED(ctx, server); err != nil {
 		return false, fmt.Errorf("failed to ensure server indicator led: %w", err)
 	}
+
+	// Re-fetch directly from the API server before checking ServerClaimRef.
+	// The object passed into this handler may be from the informer cache and
+	// could be stale if a ServerClaim controller just wrote the ref. Without
+	// this, a BMC-triggered reconcile that arrives with a stale cache snapshot
+	// would skip the Reserved transition even though the claim already landed.
+	fresh := &metalv1alpha1.Server{}
+	if err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(server), fresh); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+	*server = *fresh
+
 	if server.Spec.ServerClaimRef != nil {
 		if modified, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateReserved); err != nil || modified {
 			return true, err

--- a/internal/controller/serverclaim_controller.go
+++ b/internal/controller/serverclaim_controller.go
@@ -32,6 +32,7 @@ const (
 // ServerClaimReconciler reconciles a ServerClaim object
 type ServerClaimReconciler struct {
 	client.Client
+	APIReader               client.Reader
 	Cache                   cache.Cache
 	Scheme                  *runtime.Scheme
 	MaxConcurrentReconciles int
@@ -189,22 +190,21 @@ func (r *ServerClaimReconciler) reconcile(ctx context.Context, claim *metalv1alp
 
 func (r *ServerClaimReconciler) ensureObjectRefForServer(ctx context.Context, claim *metalv1alpha1.ServerClaim, server *metalv1alpha1.Server) error {
 	log := ctrl.LoggerFrom(ctx)
+
 	if server.Spec.ServerClaimRef != nil {
-		log.V(1).Info("Server is already claimed", "Server", server.Name, "Claim", server.Spec.ServerClaimRef.Name)
+		log.V(1).Info("Server already claimed", "Server", server.Name, "Claim", server.Spec.ServerClaimRef.Name)
 		return nil
 	}
 
-	if server.Spec.ServerClaimRef == nil {
-		serverBase := server.DeepCopy()
-		server.Spec.ServerClaimRef = &metalv1alpha1.ImmutableObjectReference{
-			Namespace: claim.Namespace,
-			Name:      claim.Name,
-		}
-		if err := r.Patch(ctx, server, client.MergeFromWithOptions(serverBase, client.MergeFromWithOptimisticLock{})); err != nil {
-			return fmt.Errorf("failed to patch claim ref for server: %w", err)
-		}
-		log.V(1).Info("Patched ServerClaim reference on Server", "Server", server.Name, "ServerClaimRef", claim.Name)
+	serverBase := server.DeepCopy()
+	server.Spec.ServerClaimRef = &metalv1alpha1.ImmutableObjectReference{
+		Namespace: claim.Namespace,
+		Name:      claim.Name,
 	}
+	if err := r.Patch(ctx, server, client.MergeFromWithOptions(serverBase, client.MergeFromWithOptimisticLock{})); err != nil {
+		return fmt.Errorf("failed to patch claim ref for server: %w", err)
+	}
+	log.V(1).Info("Patched ServerClaim reference on Server", "Server", server.Name, "ServerClaimRef", claim.Name)
 	return nil
 }
 
@@ -311,7 +311,16 @@ func (r *ServerClaimReconciler) claimServer(ctx context.Context, claim *metalv1a
 		// find previously claimed server
 		if ref := server.Spec.ServerClaimRef; ref != nil {
 			if ref.Name == claim.Name && ref.Namespace == claim.Namespace {
-				return &server, nil
+				// Re-fetch from the API server to confirm this claim still owns it.
+				// The list above is cached and may be stale.
+				fresh := server.DeepCopy()
+				if err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(fresh), fresh); err != nil {
+					return nil, client.IgnoreNotFound(err)
+				}
+				if ref := fresh.Spec.ServerClaimRef; ref == nil || ref.Name != claim.Name || ref.Namespace != claim.Namespace {
+					return nil, nil
+				}
+				return fresh, nil
 			}
 		}
 	}
@@ -354,12 +363,28 @@ func (r *ServerClaimReconciler) claimServer(ctx context.Context, claim *metalv1a
 		return nil, nil
 	}
 	log.V(1).Info("Matching server found", "Server", selectedServer.Name)
-	// ensureObjectRefForServer() uses a patch with optimistic locking,
-	// so it will not overwrite the claim with a different server,
-	// in case controller-runtimes cached client is not up to date.
+
+	// Re-fetch the selected server directly from the API server before claiming.
+	// The list above used the informer cache; a concurrent reconciler may have
+	// already claimed or changed the server since then. Re-fetching here ensures
+	// isServerClaimable and ensureObjectRefForServer act on consistent state.
+	if err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(selectedServer), selectedServer); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	if !r.isServerClaimable(ctx, selectedServer, claim) {
+		return nil, nil
+	}
+
+	// ensureObjectRefForServer uses optimistic locking on the patch, so it will
+	// not overwrite a claim that was set between our re-fetch and the write.
 	err := r.ensureObjectRefForServer(ctx, claim, selectedServer)
 	if err != nil {
 		return nil, err
+	}
+	// If another reconciler won the optimistic-lock race, the ref will point to
+	// their claim. Return an error to requeue with backoff so this claim retries.
+	if ref := selectedServer.Spec.ServerClaimRef; ref == nil || ref.Name != claim.Name || ref.Namespace != claim.Namespace {
+		return nil, fmt.Errorf("server %s was claimed concurrently, will retry", selectedServer.Name)
 	}
 	log.V(1).Info("Ensured ObjectRef for Server", "Server", selectedServer.Name)
 	return selectedServer, nil

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -208,6 +208,7 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 
 		Expect((&ServerClaimReconciler{
 			Client:                  k8sManager.GetClient(),
+			APIReader:               k8sManager.GetAPIReader(),
 			Cache:                   k8sManager.GetCache(),
 			Scheme:                  k8sManager.GetScheme(),
 			MaxConcurrentReconciles: 5,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -184,6 +184,7 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 
 		Expect((&ServerReconciler{
 			Client:                  k8sManager.GetClient(),
+			APIReader:               k8sManager.GetAPIReader(),
 			Scheme:                  k8sManager.GetScheme(),
 			Insecure:                true,
 			ManagerNamespace:        ns.Name,


### PR DESCRIPTION
# Fix ServerClaim race condition and BMC-driven state oscillation

## Summary

Under load, multiple `ServerClaim` reconcilers could simultaneously find the same server
unclaimed due to a stale informer cache, overwrite each other's `ServerClaimRef`, and
leave no claim successfully bound. A periodic BMC reconcile compounded this by patching
the `Server` object even when nothing changed, re-triggering the server state machine and
repeatedly resetting the server to `Available` — reopening the race window on every cycle.

See issue #772 

## Changes

### Fix ServerClaim race: bypass cache before claiming a server

`ensureObjectRefForServer` now re-fetches the `Server` directly from the API server
(via `APIReader`) before writing `ServerClaimRef`. Concurrent claim reconcilers working
off a stale informer cache can no longer both see `ServerClaimRef == nil` and overwrite
each other's claim — the loser sees the already-set ref on the fresh read and bails out
cleanly.

### Skip BMC server patch when discovered fields are unchanged

`discoverServers` now only mutates the `Server` object when `SystemUUID`, `SystemURI`,
`BMCRef`, or labels have actually changed. Previously, `CreateOrPatch` was called
unconditionally on every BMC reconcile, issuing a write even when nothing differed
(`Operation: unchanged`). This bumped `ResourceVersion` and re-triggered the server
controller every ~7–10 seconds, keeping the oscillation loop alive.

### Fix Available→Reserved transition on stale cache in server controller

`handleAvailableState` now re-fetches the `Server` from the API server before checking
`ServerClaimRef`. Without this, a BMC-triggered reconcile arriving with a stale cache
snapshot would find `ServerClaimRef == nil`, skip the `Reserved` transition, and run the
Available boilerplate — resetting the server state even though a claim had already been
written.

## Test plan

- [ ] Verify under concurrent claim load that a server transitions cleanly to `Reserved`
      without oscillating back to `Available`
- [ ] Confirm BMC reconcile no longer logs repeated `Operation: unchanged` patches
      followed by server controller re-entries into the Available state machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation now re-fetches fresh resource state to avoid acting on stale cached data and to detect concurrent claims, deferring when conflicts occur.

* **Improvements**
  * Skip unnecessary updates when resources already match desired configuration.
  * More granular logging for created/updated/no-op outcomes.

* **Tests**
  * Test setup aligned with runtime reconciler behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->