### PR TITLE
Controller for BMC Dynamic settings

### DIFF
--- a/api/v1alpha1/bmcsettingsset_types.go
+++ b/api/v1alpha1/bmcsettingsset_types.go
@@ -33,7 +33,7 @@ type DynamicSetting struct {
 	// +optional
 	ValueFrom *DynamicSettingSource `json:"valueFrom,omitempty"`
 
-	// Format defines a composite Go template with variable references like {{.name}}.
+	// Format defines a composite Go template with variable references like '{{.name}}'.
 	// +optional
 	Format string `json:"format,omitempty"`
 

--- a/api/v1alpha1/bmcsettingsset_types.go
+++ b/api/v1alpha1/bmcsettingsset_types.go
@@ -33,7 +33,7 @@ type DynamicSetting struct {
 	// +optional
 	ValueFrom *DynamicSettingSource `json:"valueFrom,omitempty"`
 
-	// Format defines a composite Go template with variable references like '{{.name}}'.
+	// Format defines a composite Go template with variable references like `{{.name}}`.
 	// +optional
 	Format string `json:"format,omitempty"`
 

--- a/api/v1alpha1/bmcsettingsset_types.go
+++ b/api/v1alpha1/bmcsettingsset_types.go
@@ -33,7 +33,7 @@ type DynamicSetting struct {
 	// +optional
 	ValueFrom *DynamicSettingSource `json:"valueFrom,omitempty"`
 
-	// Format defines a composite setting format with placeholders like $(name).
+	// Format defines a composite Go template with variable references like {{.name}}.
 	// +optional
 	Format string `json:"format,omitempty"`
 

--- a/bmc/mockup.go
+++ b/bmc/mockup.go
@@ -36,6 +36,7 @@ func (r *RedfishMockUps) InitializeDefaults() {
 	}
 	r.BMCSettingAttr = map[string]map[string]any{
 		"abc":       {"type": schemas.StringAttributeType, "reboot": false, "value": "bar"},
+		"composite": {"type": schemas.StringAttributeType, "reboot": false, "value": ""},
 		"fooreboot": {"type": schemas.IntegerAttributeType, "reboot": true, "value": 123},
 	}
 	r.PendingBIOSSetting = map[string]map[string]any{}
@@ -173,6 +174,7 @@ func (r *RedfishMockUps) ResetPendingBMCSetting() {
 func (r *RedfishMockUps) ResetBMCSettings() {
 	r.BMCSettingAttr = map[string]map[string]any{
 		"abc":       {"type": schemas.StringAttributeType, "reboot": false, "value": "bar"},
+		"composite": {"type": schemas.StringAttributeType, "reboot": false, "value": ""},
 		"fooreboot": {"type": schemas.IntegerAttributeType, "reboot": true, "value": 123},
 	}
 	r.PendingBMCSetting = map[string]map[string]any{}

--- a/config/crd/bases/metal.ironcore.dev_bmcsettingssets.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcsettingssets.yaml
@@ -138,7 +138,7 @@ spec:
                   properties:
                     format:
                       description: Format defines a composite Go template with variable
-                        references like '{{.name}}'.
+                        references like `{{.name}}`.
                       type: string
                     key:
                       description: Key is the BMC setting key to set.

--- a/config/crd/bases/metal.ironcore.dev_bmcsettingssets.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcsettingssets.yaml
@@ -137,8 +137,8 @@ spec:
                 items:
                   properties:
                     format:
-                      description: Format defines a composite setting format with
-                        placeholders like $(name).
+                      description: Format defines a composite Go template with variable
+                        references like {{.name}}.
                       type: string
                     key:
                       description: Key is the BMC setting key to set.

--- a/config/crd/bases/metal.ironcore.dev_bmcsettingssets.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcsettingssets.yaml
@@ -138,7 +138,7 @@ spec:
                   properties:
                     format:
                       description: Format defines a composite Go template with variable
-                        references like {{.name}}.
+                        references like '{{.name}}'.
                       type: string
                     key:
                       description: Key is the BMC setting key to set.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcsettingssets.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcsettingssets.yaml
@@ -144,7 +144,7 @@ spec:
                   properties:
                     format:
                       description: Format defines a composite Go template with variable
-                        references like '{{.name}}'.
+                        references like `{{.name}}`.
                       type: string
                     key:
                       description: Key is the BMC setting key to set.

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcsettingssets.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcsettingssets.yaml
@@ -143,8 +143,8 @@ spec:
                 items:
                   properties:
                     format:
-                      description: Format defines a composite setting format with
-                        placeholders like $(name).
+                      description: Format defines a composite Go template with variable
+                        references like {{.name}}.
                       type: string
                     key:
                       description: Key is the BMC setting key to set.

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcsettingssets.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcsettingssets.yaml
@@ -144,7 +144,7 @@ spec:
                   properties:
                     format:
                       description: Format defines a composite Go template with variable
-                        references like {{.name}}.
+                        references like '{{.name}}'.
                       type: string
                     key:
                       description: Key is the BMC setting key to set.

--- a/dist/chart/templates/rbac/role.yaml
+++ b/dist/chart/templates/rbac/role.yaml
@@ -10,6 +10,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -957,7 +957,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `key` _string_ | Key is the BMC setting key to set. |  | MinLength: 1 <br /> |
 | `valueFrom` _[DynamicSettingSource](#dynamicsettingsource)_ | ValueFrom defines a simple single source for the setting value. |  |  |
-| `format` _string_ | Format defines a composite Go template with variable references like \{\{.name\}\}. |  |  |
+| `format` _string_ | Format defines a composite Go template with variable references like '\{\{.name\}\}'. |  |  |
 | `variables` _object (keys:string, values:[DynamicSettingSource](#dynamicsettingsource))_ | Variables maps format placeholder names to their sources. |  |  |
 
 

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -957,7 +957,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `key` _string_ | Key is the BMC setting key to set. |  | MinLength: 1 <br /> |
 | `valueFrom` _[DynamicSettingSource](#dynamicsettingsource)_ | ValueFrom defines a simple single source for the setting value. |  |  |
-| `format` _string_ | Format defines a composite Go template with variable references like '\{\{.name\}\}'. |  |  |
+| `format` _string_ | Format defines a composite Go template with variable references like `\{\{.name\}\}`. |  |  |
 | `variables` _object (keys:string, values:[DynamicSettingSource](#dynamicsettingsource))_ | Variables maps format placeholder names to their sources. |  |  |
 
 

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -957,7 +957,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `key` _string_ | Key is the BMC setting key to set. |  | MinLength: 1 <br /> |
 | `valueFrom` _[DynamicSettingSource](#dynamicsettingsource)_ | ValueFrom defines a simple single source for the setting value. |  |  |
-| `format` _string_ | Format defines a composite setting format with placeholders like $(name). |  |  |
+| `format` _string_ | Format defines a composite Go template with variable references like \{\{.name\}\}. |  |  |
 | `variables` _object (keys:string, values:[DynamicSettingSource](#dynamicsettingsource))_ | Variables maps format placeholder names to their sources. |  |  |
 
 

--- a/internal/controller/bmcsettingsset_controller.go
+++ b/internal/controller/bmcsettingsset_controller.go
@@ -4,9 +4,11 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"text/template"
 	"time"
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
@@ -41,6 +43,8 @@ const BMCSettingsSetFinalizer = "metal.ironcore.dev/bmcsettingsset"
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servermaintenances,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 func (r *BMCSettingsSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	bmcSettingsSet := &metalv1alpha1.BMCSettingsSet{}
@@ -286,7 +290,11 @@ func (r *BMCSettingsSetReconciler) createMissingBMCSettings(
 
 			// create/patch new Settings
 			opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, newBMCSettings, func() error {
-				newBMCSettings.Spec.BMCSettingsTemplate = *bmcSettingsSet.Spec.BMCSettingsTemplate.DeepCopy()
+				effectiveTemplate, err := r.buildEffectiveTemplate(ctx, bmcSettingsSet, &bmc)
+				if err != nil {
+					return fmt.Errorf("failed to build effective settings for BMC %s: %w", bmc.Name, err)
+				}
+				newBMCSettings.Spec.BMCSettingsTemplate = *effectiveTemplate
 				newBMCSettings.Spec.BMCRef = &corev1.LocalObjectReference{Name: bmc.Name}
 				return controllerutil.SetControllerReference(bmcSettingsSet, newBMCSettings, r.Client.Scheme())
 			})
@@ -348,8 +356,21 @@ func (r *BMCSettingsSetReconciler) patchBMCSettingsFromTemplate(
 			continue
 		}
 
+		bmc := &metalv1alpha1.BMC{}
+		if err := r.Get(ctx, client.ObjectKey{Name: bmcSettings.Spec.BMCRef.Name}, bmc); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to get BMC %s for BMCSettings %s: %w", bmcSettings.Spec.BMCRef.Name, bmcSettings.Name, err))
+			continue
+		}
+
 		opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, &bmcSettings, func() error {
-			bmcSettings.Spec.BMCSettingsTemplate = *bmcSettingsSet.Spec.BMCSettingsTemplate.DeepCopy()
+			effectiveTemplate, err := r.buildEffectiveTemplate(ctx, bmcSettingsSet, bmc)
+			if err != nil {
+				return fmt.Errorf("failed to build effective settings for BMC %s: %w", bmc.Name, err)
+			}
+			bmcSettings.Spec.BMCSettingsTemplate = *effectiveTemplate
 			return nil
 		})
 		if err != nil {
@@ -360,6 +381,99 @@ func (r *BMCSettingsSetReconciler) patchBMCSettingsFromTemplate(
 		}
 	}
 	return pendingPatchingSettings, errors.Join(errs...)
+}
+
+func (r *BMCSettingsSetReconciler) buildEffectiveTemplate(
+	ctx context.Context,
+	bmcSettingsSet *metalv1alpha1.BMCSettingsSet,
+	bmc *metalv1alpha1.BMC,
+) (*metalv1alpha1.BMCSettingsTemplate, error) {
+	effectiveTemplate := bmcSettingsSet.Spec.BMCSettingsTemplate.DeepCopy()
+	if effectiveTemplate.SettingsMap == nil {
+		effectiveTemplate.SettingsMap = map[string]string{}
+	}
+
+	for _, dynamicSetting := range bmcSettingsSet.Spec.DynamicSettings {
+		value, err := r.resolveDynamicSettingValue(ctx, bmc, &dynamicSetting)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve dynamic setting %q: %w", dynamicSetting.Key, err)
+		}
+		// Dynamic values intentionally override static settings for the same key.
+		effectiveTemplate.SettingsMap[dynamicSetting.Key] = value
+	}
+
+	return effectiveTemplate, nil
+}
+
+func (r *BMCSettingsSetReconciler) resolveDynamicSettingValue(
+	ctx context.Context,
+	bmc *metalv1alpha1.BMC,
+	setting *metalv1alpha1.DynamicSetting,
+) (string, error) {
+	if setting.ValueFrom != nil {
+		return r.resolveDynamicSettingSource(ctx, bmc, setting.ValueFrom)
+	}
+
+	data := make(map[string]string, len(setting.Variables))
+	for name, source := range setting.Variables {
+		value, err := r.resolveDynamicSettingSource(ctx, bmc, &source)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve variable %q: %w", name, err)
+		}
+		data[name] = value
+	}
+
+	tmpl, err := template.New("format").Option("missingkey=error").Parse(setting.Format)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse format template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute format template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func (r *BMCSettingsSetReconciler) resolveDynamicSettingSource(
+	ctx context.Context,
+	bmc *metalv1alpha1.BMC,
+	source *metalv1alpha1.DynamicSettingSource,
+) (string, error) {
+	if source.BMCLabel != "" {
+		if value, ok := bmc.Labels[source.BMCLabel]; ok {
+			return value, nil
+		}
+		return "", fmt.Errorf("bmc label %q not found on BMC %s", source.BMCLabel, bmc.Name)
+	}
+
+	if source.ConfigMapKeyRef != nil {
+		selector := source.ConfigMapKeyRef
+		configMap := &corev1.ConfigMap{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: selector.Namespace, Name: selector.Name}, configMap); err != nil {
+			return "", fmt.Errorf("failed to get ConfigMap %s/%s: %w", selector.Namespace, selector.Name, err)
+		}
+		if value, ok := configMap.Data[selector.Key]; ok {
+			return value, nil
+		}
+		if value, ok := configMap.BinaryData[selector.Key]; ok {
+			return string(value), nil
+		}
+		return "", fmt.Errorf("key %q not found in ConfigMap %s/%s", selector.Key, selector.Namespace, selector.Name)
+	}
+
+	if source.SecretKeyRef != nil {
+		selector := source.SecretKeyRef
+		secret := &corev1.Secret{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: selector.Namespace, Name: selector.Name}, secret); err != nil {
+			return "", fmt.Errorf("failed to get Secret %s/%s: %w", selector.Namespace, selector.Name, err)
+		}
+		if value, ok := secret.Data[selector.Key]; ok {
+			return string(value), nil
+		}
+		return "", fmt.Errorf("key %q not found in Secret %s/%s", selector.Key, selector.Namespace, selector.Name)
+	}
+
+	return "", errors.New("dynamic setting source is empty")
 }
 
 func (r *BMCSettingsSetReconciler) enqueueByBMC(
@@ -410,6 +524,75 @@ func (r *BMCSettingsSetReconciler) enqueueByBMC(
 	return reqs
 }
 
+func (r *BMCSettingsSetReconciler) enqueueByConfigMap(
+	ctx context.Context,
+	obj client.Object,
+) []ctrl.Request {
+	configMap := obj.(*corev1.ConfigMap)
+	return r.enqueueByDynamicSource(ctx, configMap.Namespace, configMap.Name, true)
+}
+
+func (r *BMCSettingsSetReconciler) enqueueBySecret(
+	ctx context.Context,
+	obj client.Object,
+) []ctrl.Request {
+	secret := obj.(*corev1.Secret)
+	return r.enqueueByDynamicSource(ctx, secret.Namespace, secret.Name, false)
+}
+
+func (r *BMCSettingsSetReconciler) enqueueByDynamicSource(
+	ctx context.Context,
+	namespace string,
+	name string,
+	isConfigMap bool,
+) []ctrl.Request {
+	log := ctrl.LoggerFrom(ctx)
+	bmcSettingsSetList := &metalv1alpha1.BMCSettingsSetList{}
+	if err := r.List(ctx, bmcSettingsSetList); err != nil {
+		log.Error(err, "Failed to list BMCSettingsSet")
+		return nil
+	}
+
+	var reqs []ctrl.Request
+	for _, bmcSettingsSet := range bmcSettingsSetList.Items {
+		if referencesDynamicSource(&bmcSettingsSet, namespace, name, isConfigMap) {
+			reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKey{Name: bmcSettingsSet.Name, Namespace: bmcSettingsSet.Namespace}})
+		}
+	}
+	return reqs
+}
+
+func referencesDynamicSource(
+	bmcSettingsSet *metalv1alpha1.BMCSettingsSet,
+	namespace string,
+	name string,
+	isConfigMap bool,
+) bool {
+	for _, setting := range bmcSettingsSet.Spec.DynamicSettings {
+		if setting.ValueFrom != nil && sourceMatchesDynamicRef(setting.ValueFrom, namespace, name, isConfigMap) {
+			return true
+		}
+		for _, source := range setting.Variables {
+			if sourceMatchesDynamicRef(&source, namespace, name, isConfigMap) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sourceMatchesDynamicRef(
+	source *metalv1alpha1.DynamicSettingSource,
+	namespace string,
+	name string,
+	isConfigMap bool,
+) bool {
+	if isConfigMap {
+		return source.ConfigMapKeyRef != nil && source.ConfigMapKeyRef.Namespace == namespace && source.ConfigMapKeyRef.Name == name
+	}
+	return source.SecretKeyRef != nil && source.SecretKeyRef.Namespace == namespace && source.SecretKeyRef.Name == name
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *BMCSettingsSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -426,6 +609,14 @@ func (r *BMCSettingsSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return labelChangeOrAnyFieldChangeInObject(e, []any{oldBMC.Spec.BMCSettingRef}, []any{newBMC.Spec.BMCSettingRef})
 				},
 			})).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueByConfigMap),
+		).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueBySecret),
+		).
 		Named("bmcsettingsset").
 		Complete(r)
 }

--- a/internal/controller/bmcsettingsset_controller.go
+++ b/internal/controller/bmcsettingsset_controller.go
@@ -439,10 +439,12 @@ func (r *BMCSettingsSetReconciler) resolveDynamicSettingSource(
 	bmc *metalv1alpha1.BMC,
 	source *metalv1alpha1.DynamicSettingSource,
 ) (string, error) {
+	log := ctrl.LoggerFrom(ctx)
 	if source.BMCLabel != "" {
 		if value, ok := bmc.Labels[source.BMCLabel]; ok {
 			return value, nil
 		}
+		log.Error(fmt.Errorf("bmc label %q not found on BMC %s", source.BMCLabel, bmc.Name), "BMC label not found")
 		return "", fmt.Errorf("bmc label %q not found on BMC %s", source.BMCLabel, bmc.Name)
 	}
 
@@ -450,7 +452,8 @@ func (r *BMCSettingsSetReconciler) resolveDynamicSettingSource(
 		selector := source.ConfigMapKeyRef
 		configMap := &corev1.ConfigMap{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: selector.Namespace, Name: selector.Name}, configMap); err != nil {
-			return "", fmt.Errorf("failed to get ConfigMap %s/%s: %w", selector.Namespace, selector.Name, err)
+			log.Error(err, "Failed to get ConfigMap", "ConfigMap", fmt.Sprintf("%s/%s", selector.Namespace, selector.Name))
+			return "", err
 		}
 		if value, ok := configMap.Data[selector.Key]; ok {
 			return value, nil
@@ -465,7 +468,8 @@ func (r *BMCSettingsSetReconciler) resolveDynamicSettingSource(
 		selector := source.SecretKeyRef
 		secret := &corev1.Secret{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: selector.Namespace, Name: selector.Name}, secret); err != nil {
-			return "", fmt.Errorf("failed to get Secret %s/%s: %w", selector.Namespace, selector.Name, err)
+			log.Error(err, "Failed to get Secret", "Secret", fmt.Sprintf("%s/%s", selector.Namespace, selector.Name))
+			return "", err
 		}
 		if value, ok := secret.Data[selector.Key]; ok {
 			return string(value), nil

--- a/internal/controller/bmcsettingsset_controller_test.go
+++ b/internal/controller/bmcsettingsset_controller_test.go
@@ -670,5 +670,155 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 			Expect(k8sClient.Delete(ctx, bmcSettings01_02)).To(Succeed())
 			Eventually(Get(bmcSettings01_02)).Should(Satisfy(apierrors.IsNotFound))
 		})
+
+		It("Should merge dynamic settings and override static settings", func(ctx SpecContext) {
+			By("Creating dynamic setting sources")
+			dynamicConfigMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "dynamic-settings-cm",
+				},
+				Data: map[string]string{
+					"suffix": "cm",
+				},
+			}
+			Expect(k8sClient.Create(ctx, dynamicConfigMap)).To(Succeed())
+
+			dynamicSecret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      "dynamic-settings-secret",
+				},
+				Data: map[string][]byte{
+					"token": []byte("secret"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, dynamicSecret)).To(Succeed())
+
+			By("Creating a BMCSettingsSet with static and dynamic settings")
+			bmcSettingsSet := &metalv1alpha1.BMCSettingsSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    ns.Name,
+					GenerateName: "test-bmcsettingsset-dynamic-",
+				},
+				Spec: metalv1alpha1.BMCSettingsSetSpec{
+					BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
+						Version:                 "1.45.455b66-rev4",
+						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+						SettingsMap: map[string]string{
+							"abc": "static-value",
+						},
+					},
+					DynamicSettings: []metalv1alpha1.DynamicSetting{
+						{
+							Key: "abc",
+							ValueFrom: &metalv1alpha1.DynamicSettingSource{
+								BMCLabel: "metal.ironcore.dev/Model",
+							},
+						},
+						{
+							Key:    "composite",
+							Format: "{{.model}}-{{.token}}-{{.suffix}}",
+							Variables: map[string]metalv1alpha1.DynamicSettingSource{
+								"model": {
+									BMCLabel: "metal.ironcore.dev/Model",
+								},
+								"token": {
+									SecretKeyRef: &metalv1alpha1.NamespacedKeySelector{
+										Namespace: ns.Name,
+										Name:      dynamicSecret.Name,
+										Key:       "token",
+									},
+								},
+								"suffix": {
+									ConfigMapKeyRef: &metalv1alpha1.NamespacedKeySelector{
+										Namespace: ns.Name,
+										Name:      dynamicConfigMap.Name,
+										Key:       "suffix",
+									},
+								},
+							},
+						},
+					},
+					BMCSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"metal.ironcore.dev/Manufacturer": "foo",
+							"metal.ironcore.dev/Model":        "bar",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, bmcSettingsSet)).To(Succeed())
+
+			By("Verifying dynamic values are resolved and override static values")
+			bmcSettings01 := &metalv1alpha1.BMCSettings{ObjectMeta: metav1.ObjectMeta{Name: bmcSettingsSet.Name + "-" + bmc01.Name}}
+			Eventually(Get(bmcSettings01)).Should(Succeed())
+			Eventually(Object(bmcSettings01)).Should(SatisfyAll(
+				HaveField("Spec.SettingsMap", HaveKeyWithValue("abc", "bar")),
+				HaveField("Spec.SettingsMap", HaveKeyWithValue("composite", "bar-secret-cm")),
+			))
+
+			By("Waiting for BMCSettings to reach Applied state before triggering a ConfigMap update")
+			Eventually(Object(bmcSettings01)).Should(HaveField("Status.State", Equal(metalv1alpha1.BMCSettingsStateApplied)))
+
+			By("Updating ConfigMap to trigger watch-based reconciliation")
+			Eventually(Update(dynamicConfigMap, func() {
+				dynamicConfigMap.Data["suffix"] = "cm2"
+			})).Should(Succeed())
+
+			Eventually(Object(bmcSettings01)).Should(
+				HaveField("Spec.SettingsMap", HaveKeyWithValue("composite", "bar-secret-cm2")),
+			)
+
+			By("Cleaning up")
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcSettingsSet))).To(Succeed())
+			Eventually(Get(bmcSettingsSet)).Should(Satisfy(apierrors.IsNotFound))
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcSettings01))).To(Succeed())
+			Eventually(Get(bmcSettings01)).Should(Satisfy(apierrors.IsNotFound))
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, dynamicConfigMap))).To(Succeed())
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, dynamicSecret))).To(Succeed())
+		})
+
+		It("Should fail to create child BMCSettings when dynamic source is missing", func(ctx SpecContext) {
+			By("Creating a BMCSettingsSet with a missing BMC label source")
+			bmcSettingsSet := &metalv1alpha1.BMCSettingsSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    ns.Name,
+					GenerateName: "test-bmcsettingsset-missing-dynamic-",
+				},
+				Spec: metalv1alpha1.BMCSettingsSetSpec{
+					BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
+						Version:                 "1.45.455b66-rev4",
+						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+						SettingsMap: map[string]string{
+							"abc": "static-value",
+						},
+					},
+					DynamicSettings: []metalv1alpha1.DynamicSetting{
+						{
+							Key: "missing",
+							ValueFrom: &metalv1alpha1.DynamicSettingSource{
+								BMCLabel: "metal.ironcore.dev/does-not-exist",
+							},
+						},
+					},
+					BMCSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"metal.ironcore.dev/Manufacturer": "foo",
+							"metal.ironcore.dev/Model":        "bar",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, bmcSettingsSet)).To(Succeed())
+
+			By("Verifying child BMCSettings is not created")
+			bmcSettings01 := &metalv1alpha1.BMCSettings{ObjectMeta: metav1.ObjectMeta{Name: bmcSettingsSet.Name + "-" + bmc01.Name}}
+			Consistently(Get(bmcSettings01)).Should(Satisfy(apierrors.IsNotFound))
+
+			By("Cleaning up")
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcSettingsSet))).To(Succeed())
+			Eventually(Get(bmcSettingsSet)).Should(Satisfy(apierrors.IsNotFound))
+		})
 	})
 })


### PR DESCRIPTION
# Proposed Changes
Adds Controller for Dynamic Settings in BMCSettingsController.

Fixes #781 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for composite dynamic settings that build values from labels, ConfigMaps, and Secrets, with automatic reconciliation when those sources change.
  * Added a new "composite" setting attribute to defaults.

* **Documentation**
  * Clarified that composite format uses Go template syntax (e.g., {{.name}}).

* **Tests**
  * Added end-to-end tests for composite resolution, reconciliation on source updates, and missing-source behavior.

* **Chores**
  * Expanded controller permissions to watch referenced ConfigMaps and Secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->