### PR TITLE
Centralize and harmonize condition/reason constants across controllers

### DIFF
--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -63,6 +63,19 @@ const (
 	ReasonSettingsInvalid               = "SettingsProvidedAreNotValid"
 )
 
+// legacyBIOSSettingsConditionTypes maps old condition type strings to their new values.
+// This ensures backward compatibility with existing CRs created before the rename.
+var legacyBIOSSettingsConditionTypes = map[string]string{
+	"BIOSSettingsCheckPendingSettings":    ConditionPendingSettingsCheck,
+	"BIOSSettingsDuplicateKeys":           ConditionSettingsDuplicateKeys,
+	"BIOSSettingUpdateStartTime":          ConditionSettingsUpdateStartTime,
+	"BIOSSettingsTimedOut":                ConditionSettingsTimedOut,
+	"ServerPowerOnCondition":              ConditionSettingsServerPowerOn,
+	"ServerRebootPostUpdateHasBeenIssued": ConditionSettingsRebootPostUpdate,
+	"BMCResetIssued":                      ConditionResetIssued,
+	"BIOSVersionUpdatePending":            ConditionVersionUpdatePending,
+}
+
 // BIOSSettingsReconciler reconciles a BIOSSettings object
 type BIOSSettingsReconciler struct {
 	client.Client
@@ -93,7 +106,28 @@ func (r *BIOSSettingsReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err := r.Get(ctx, req.NamespacedName, biosSettings); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	if err := r.migrateLegacyConditions(ctx, biosSettings); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
+	}
 	return r.reconcileExists(ctx, biosSettings)
+}
+
+// migrateLegacyConditions renames legacy condition type strings on existing CRs.
+// TODO: Remove this migration in the next release once all CRs have been reconciled.
+func (r *BIOSSettingsReconciler) migrateLegacyConditions(ctx context.Context, settings *metalv1alpha1.BIOSSettings) error {
+	settingsBase := settings.DeepCopy()
+	migrated := migrateConditionTypes(settings.Status.Conditions, legacyBIOSSettingsConditionTypes)
+	for i := range settings.Status.FlowState {
+		if migrateConditionTypes(settings.Status.FlowState[i].Conditions, legacyBIOSSettingsConditionTypes) {
+			migrated = true
+		}
+	}
+	if !migrated {
+		return nil
+	}
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Migrated legacy condition types on BIOSSettings")
+	return r.Status().Patch(ctx, settings, client.MergeFrom(settingsBase))
 }
 
 func (r *BIOSSettingsReconciler) reconcileExists(ctx context.Context, settings *metalv1alpha1.BIOSSettings) (ctrl.Result, error) {

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -66,14 +66,15 @@ const (
 // legacyBIOSSettingsConditionTypes maps old condition type strings to their new values.
 // This ensures backward compatibility with existing CRs created before the rename.
 var legacyBIOSSettingsConditionTypes = map[string]string{
-	"BIOSSettingsCheckPendingSettings":    ConditionPendingSettingsCheck,
-	"BIOSSettingsDuplicateKeys":           ConditionSettingsDuplicateKeys,
-	"BIOSSettingUpdateStartTime":          ConditionSettingsUpdateStartTime,
-	"BIOSSettingsTimedOut":                ConditionSettingsTimedOut,
-	"ServerPowerOnCondition":              ConditionSettingsServerPowerOn,
-	"ServerRebootPostUpdateHasBeenIssued": ConditionSettingsRebootPostUpdate,
-	"BMCResetIssued":                      ConditionResetIssued,
-	"BIOSVersionUpdatePending":            ConditionVersionUpdatePending,
+	"BIOSSettingsCheckPendingSettings":     ConditionPendingSettingsCheck,
+	"BIOSSettingsDuplicateKeys":            ConditionSettingsDuplicateKeys,
+	"BIOSSettingUpdateStartTime":           ConditionSettingsUpdateStartTime,
+	"BIOSSettingsTimedOut":                 ConditionSettingsTimedOut,
+	"ServerPowerOnCondition":               ConditionSettingsServerPowerOn,
+	"ServerRebootPostUpdateHasBeenIssued":  ConditionSettingsRebootPostUpdate,
+	"BMCResetIssued":                       ConditionResetIssued,
+	"BIOSVersionUpdatePending":             ConditionVersionUpdatePending,
+	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
 }
 
 // BIOSSettingsReconciler reconciles a BIOSSettings object
@@ -1080,7 +1081,7 @@ func (r *BIOSSettingsReconciler) handleFailedState(ctx context.Context, settings
 		settings.Status.FlowState = []metalv1alpha1.BIOSSettingsFlowStatus{}
 		settings.Status.ObservedGeneration = settings.Generation
 		annotations := settings.GetAnnotations()
-		retryCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, RetryOfFailedResourceConditionIssued)
+		retryCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionRetryOfFailedResourceIssued)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get retry condition for BIOSSettings: %w", err)
 		}
@@ -1088,7 +1089,7 @@ func (r *BIOSSettingsReconciler) handleFailedState(ctx context.Context, settings
 		if retryCondition.Status != metav1.ConditionTrue {
 			err := r.Conditions.Update(retryCondition,
 				conditionutils.UpdateStatus(metav1.ConditionTrue),
-				conditionutils.UpdateReason(RetryOfFailedResourceReasonIssued),
+				conditionutils.UpdateReason(ReasonRetryOfFailedResourceIssued),
 				conditionutils.UpdateMessage(annotations[metalv1alpha1.OperationAnnotation]),
 			)
 			if err != nil {
@@ -1123,7 +1124,7 @@ func (r *BIOSSettingsReconciler) handleFailedState(ctx context.Context, settings
 			settings.Status.State = metalv1alpha1.BIOSSettingsStatePending
 			settings.Status.FlowState = []metalv1alpha1.BIOSSettingsFlowStatus{}
 			settings.Status.ObservedGeneration = settings.Generation
-			retryCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, RetryOfFailedResourceConditionIssued)
+			retryCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionRetryOfFailedResourceIssued)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to get Retry condition for BIOSSettings: %w", err)
 			}

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -34,36 +34,33 @@ import (
 const (
 	BIOSSettingsFinalizer = "metal.ironcore.dev/biossettings"
 
-	BIOSVersionUpdateConditionPending           = "BIOSVersionUpdatePending"
-	BIOSVersionUpgradeReasonPending             = "BIOSVersionNeedsTObeUpgraded"
-	BIOSPendingSettingConditionCheck            = "BIOSSettingsCheckPendingSettings"
-	BIOSPendingSettingsReasonFound              = "BIOSPendingSettingsFound"
-	BIOSSettingsConditionDuplicateKey           = "BIOSSettingsDuplicateKeys"
-	BIOSSettingsReasonFoundDuplicateKeys        = "BIOSSettingsDuplicateKeysFound"
-	BIOSSettingConditionUpdateStartTime         = "BIOSSettingUpdateStartTime"
-	BIOSSettingsReasonUpdateStartTime           = "BIOSSettingsUpdateHasStarted"
-	BIOSSettingConditionUpdateTimedOut          = "BIOSSettingsTimedOut"
-	BIOSSettingsReasonUpdateTimedOut            = "BIOSSettingsTimedOutDuringUpdate"
-	BIOSSettingsConditionServerPowerOn          = "ServerPowerOnCondition"
-	BIOSSettingsReasonServerPoweredOn           = "ServerPoweredHasBeenPoweredOn"
-	BMCConditionReset                           = "BMCResetIssued"
-	BMCReasonReset                              = "BMCResetIssued"
-	BIOSSettingsConditionIssuedUpdate           = "SettingsUpdateIssued"
-	BIOSSettingReasonIssuedUpdate               = "BIOSSettingUpdateIssued"
-	BIOSSettingsConditionUnknownPendingSettings = "UnknownPendingSettingState"
-	BIOSSettingsReasonUnexpectedPendingSettings = "UnexpectedPendingSettingsPostUpdateHasBeenIssued"
-	BIOSSettingsConditionRebootPostUpdate       = "ServerRebootPostUpdateHasBeenIssued"
-	BIOSSettingsReasonSkipReboot                = "SkipServerRebootPostUpdateHasBeenIssued"
-	BIOSSettingsReasonRebootNeeded              = "RebootPostSettingUpdate"
-	BIOSSettingsConditionRebootPowerOff         = "RebootPowerOff"
-	BIOSSettingsReasonRebootServerPowerOff      = "PowerOffCompletedDuringReboot"
-	BIOSSettingsConditionRebootPowerOn          = "RebootPowerOn"
-	BIOSSettingsReasonRebootServerPowerOn       = "PowerOnCompletedDuringReboot"
-	BIOSSettingsConditionVerifySettings         = "VerifySettingsPostUpdate"
-	BIOSSettingsReasonVerificationCompleted     = "VerificationCompleted"
-	BIOSSettingsReasonVerificationNotCompleted  = "VerificationNotCompleted"
-	BIOSSettingsConditionWrongSettings          = "SettingsProvidedNotValid"
-	BIOSSettingsReasonWrongSettings             = "SettingsProvidedAreNotValid"
+	ConditionPendingSettingsCheck     = "PendingSettingsCheck"
+	ConditionSettingsDuplicateKeys    = "SettingsDuplicateKeys"
+	ConditionSettingsUpdateStartTime  = "SettingsUpdateStartTime"
+	ConditionSettingsTimedOut         = "SettingsTimedOut"
+	ConditionSettingsServerPowerOn    = "ServerPowerOn"
+	ConditionSettingsUpdateIssued     = "SettingsUpdateIssued"
+	ConditionSettingsUnknownPending   = "UnknownPendingSettingState"
+	ConditionSettingsRebootPostUpdate = "RebootPostUpdate"
+	ConditionSettingsRebootPowerOff   = "RebootPowerOff"
+	ConditionSettingsRebootPowerOn    = "RebootPowerOn"
+	ConditionSettingsVerify           = "VerifySettingsPostUpdate"
+	ConditionSettingsInvalid          = "SettingsProvidedNotValid"
+
+	ReasonPendingSettingsFound          = "PendingSettingsFound"
+	ReasonSettingsDuplicateKeysFound    = "SettingsDuplicateKeysFound"
+	ReasonSettingsUpdateStarted         = "SettingsUpdateStarted"
+	ReasonSettingsTimedOut              = "SettingsTimedOutDuringUpdate"
+	ReasonSettingsServerPoweredOn       = "ServerPoweredOn"
+	ReasonSettingsUpdateIssued          = "SettingsUpdateIssued"
+	ReasonSettingsUnexpectedPending     = "UnexpectedPendingSettings"
+	ReasonSettingsSkipReboot            = "SkipServerReboot"
+	ReasonSettingsRebootNeeded          = "RebootPostSettingUpdate"
+	ReasonSettingsRebootPowerOff        = "PowerOffCompletedDuringReboot"
+	ReasonSettingsRebootPowerOn         = "PowerOnCompletedDuringReboot"
+	ReasonSettingsVerificationCompleted = "VerificationCompleted"
+	ReasonSettingsVerificationNotDone   = "VerificationNotCompleted"
+	ReasonSettingsInvalid               = "SettingsProvidedAreNotValid"
 )
 
 // BIOSSettingsReconciler reconciles a BIOSSettings object
@@ -158,14 +155,14 @@ func (r *BIOSSettingsReconciler) removeServerMaintenance(ctx context.Context, se
 	if err == nil && maintenance.DeletionTimestamp.IsZero() {
 		if metav1.IsControlledBy(maintenance, settings) {
 			log.V(1).Info("Deleting ServerMaintenance", "ServerMaintenance", client.ObjectKeyFromObject(maintenance), "State", maintenance.Status.State)
-			condition, err = GetCondition(r.Conditions, settings.Status.Conditions, ServerMaintenanceConditionDeleted)
+			condition, err = GetCondition(r.Conditions, settings.Status.Conditions, ConditionServerMaintenanceDeleted)
 			if err != nil {
 				return fmt.Errorf("failed to get the delete condition for ServerMaintenance: %w", err)
 			}
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonDeleted),
+				conditionutils.UpdateReason(ReasonMaintenanceDeleted),
 				conditionutils.UpdateMessage(fmt.Sprintf("Deleting %s", maintenance.Name)),
 			); err != nil {
 				return fmt.Errorf("failed to update deleting ServerMaintenance condition: %w", err)
@@ -337,7 +334,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 	if len(pendingSettings) > 0 {
 		log.V(1).Info("Pending BIOS setting tasks found", "TaskCount", len(pendingSettings))
 
-		pendingSettingStateCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BIOSPendingSettingConditionCheck)
+		pendingSettingStateCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionPendingSettingsCheck)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for pending BIOSSettings state: %w", err)
 		}
@@ -345,7 +342,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 		if err := r.Conditions.Update(
 			pendingSettingStateCheckCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSPendingSettingsReasonFound),
+			conditionutils.UpdateReason(ReasonPendingSettingsFound),
 			conditionutils.UpdateMessage(fmt.Sprintf("Found pending BIOS settings (%d)", len(pendingSettings))),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update pending BIOSSettings update condition: %w", err)
@@ -374,14 +371,14 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 
 	if len(duplicateName) > 0 || len(duplicateSettingsNames) > 0 {
 		log.V(1).Info("Found duplicate keys", "DuplicatesCount", len(duplicateName), "DuplicatesSettingsCound", len(duplicateSettingsNames))
-		duplicateCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BIOSSettingsConditionDuplicateKey)
+		duplicateCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionSettingsDuplicateKeys)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for duplicate-key BIOSSettings state: %w", err)
 		}
 		if err := r.Conditions.Update(
 			duplicateCheckCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSSettingsReasonFoundDuplicateKeys),
+			conditionutils.UpdateReason(ReasonSettingsDuplicateKeysFound),
 			conditionutils.UpdateMessage(fmt.Sprintf("Found duplicate keys (%d) and settings (%d)", len(duplicateName), len(duplicateSettingsNames))),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update pending BIOSSettings update condition: %w", err)
@@ -398,7 +395,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 	// if conditions are present, skip this shortcut to be able to capture all conditions states (ex: verifySetting, reboot etc)
 	if len(settingsDiff) == 0 && len(settings.Status.Conditions) == 0 {
 		// move status to completed
-		verifySettingUpdate, err := GetCondition(r.Conditions, settings.Status.Conditions, BIOSSettingsConditionVerifySettings)
+		verifySettingUpdate, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionSettingsVerify)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for verified BIOSSettings condition: %w", err)
 		}
@@ -406,7 +403,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 		if err := r.Conditions.Update(
 			verifySettingUpdate,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSSettingsReasonVerificationCompleted),
+			conditionutils.UpdateReason(ReasonSettingsVerificationCompleted),
 			conditionutils.UpdateMessage("Required BIOS settings has been verified on the server"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update verify biossetting condition: %w", err)
@@ -417,7 +414,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 	var state = metalv1alpha1.BIOSSettingsStateInProgress
 	var condition *metav1.Condition
 	if biosVersion != settings.Spec.Version {
-		versionCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BIOSVersionUpdateConditionPending)
+		versionCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionVersionUpdatePending)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for pending BIOSVersion update state: %w", err)
 		}
@@ -428,7 +425,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 		if err := r.Conditions.Update(
 			versionCheckCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSVersionUpgradeReasonPending),
+			conditionutils.UpdateReason(ReasonVersionUpgradePending),
 			conditionutils.UpdateMessage(fmt.Sprintf("Waiting to update biosVersion: %s, current biosVersion: %s", settings.Spec.Version, biosVersion)),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update Pending BIOSVersion update condition: %w", err)
@@ -445,7 +442,7 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 		return ctrl.Result{}, err
 	}
 
-	condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ServerMaintenanceConditionWaiting)
+	condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionServerMaintenanceWaiting)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -455,7 +452,7 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+				conditionutils.UpdateReason(ReasonMaintenanceWaiting),
 				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", settings.Spec.ServerMaintenanceRef.Name)),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -467,11 +464,11 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 		return ctrl.Result{}, nil
 	}
 	// once in maintenance, clear the waiting condition if present
-	if condition.Reason != ServerMaintenanceReasonApproved {
+	if condition.Reason != ReasonMaintenanceApproved {
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
+			conditionutils.UpdateReason(ReasonMaintenanceApproved),
 			conditionutils.UpdateMessage("Server is now in Maintenance mode"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -524,7 +521,7 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 					continue
 				}
 				// mark completed, and move on
-				verifySettingUpdate, err := GetCondition(r.Conditions, currentSettingsFlowStatus.Conditions, BIOSSettingsConditionVerifySettings)
+				verifySettingUpdate, err := GetCondition(r.Conditions, currentSettingsFlowStatus.Conditions, ConditionSettingsVerify)
 				if err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to get Condition for verified BIOSSettings condition: %w", err)
 				}
@@ -532,7 +529,7 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 				if err := r.Conditions.Update(
 					verifySettingUpdate,
 					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(BIOSSettingsReasonVerificationCompleted),
+					conditionutils.UpdateReason(ReasonSettingsVerificationCompleted),
 					conditionutils.UpdateMessage("Required BIOS settings has been RE verified on the server. Hence, moving out of Pending state"),
 				); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update verified BIOSSettings condition: %w", err)
@@ -564,7 +561,7 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 
 func (r *BIOSSettingsReconciler) handleBMCReset(ctx context.Context, bmcClient bmc.BMC, settings *metalv1alpha1.BIOSSettings, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	resetBMC, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCConditionReset)
+	resetBMC, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionResetIssued)
 	if err != nil {
 		return false, fmt.Errorf("failed to get condition for reset of BMC of server: %w", err)
 	}
@@ -572,13 +569,13 @@ func (r *BIOSSettingsReconciler) handleBMCReset(ctx context.Context, bmcClient b
 	if resetBMC.Status != metav1.ConditionTrue {
 		// once the server is powered on, reset the BMC to make sure its in stable state
 		// this avoids problems with some BMCs that hang up in subsequent operations
-		if resetBMC.Reason != BMCReasonReset {
+		if resetBMC.Reason != ReasonResetIssued {
 			if err := resetBMCOfServer(ctx, r.Client, server, bmcClient); err == nil {
 				// mark reset to be issued, wait for next reconcile
 				if err := r.Conditions.Update(
 					resetBMC,
 					conditionutils.UpdateStatus(corev1.ConditionFalse),
-					conditionutils.UpdateReason(BMCReasonReset),
+					conditionutils.UpdateReason(ReasonResetIssued),
 					conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 				); err != nil {
 					return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -604,7 +601,7 @@ func (r *BIOSSettingsReconciler) handleBMCReset(ctx context.Context, bmcClient b
 		if err := r.Conditions.Update(
 			resetBMC,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCReasonReset),
+			conditionutils.UpdateReason(ReasonResetIssued),
 			conditionutils.UpdateMessage("BMC reset to stabilize BMC of the server is completed"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -619,7 +616,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 	if modified, err := r.setTimeoutForAppliedSettings(ctx, settings, flowStatus); modified || err != nil {
 		return false, err
 	}
-	turnOnServer, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionServerPowerOn)
+	turnOnServer, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsServerPowerOn)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for Initial powerOn of server: %w", err)
 	}
@@ -629,7 +626,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			if err := r.Conditions.Update(
 				turnOnServer,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonServerPoweredOn),
+				conditionutils.UpdateReason(ReasonSettingsServerPoweredOn),
 				conditionutils.UpdateMessage("Server is powered On to start the biosUpdate process"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -653,9 +650,9 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 
 	// check if we have already determined if we need reboot of not.
 	// if the condition is present, we have checked the skip reboot condition.
-	condFound, err := r.Conditions.FindSlice(flowStatus.Conditions, BIOSSettingsConditionRebootPostUpdate, &metav1.Condition{})
+	condFound, err := r.Conditions.FindSlice(flowStatus.Conditions, ConditionSettingsRebootPostUpdate, &metav1.Condition{})
 	if err != nil {
-		return false, fmt.Errorf("failed to find Condition %v. error: %w", BIOSSettingsConditionRebootPostUpdate, err)
+		return false, fmt.Errorf("failed to find Condition %v. error: %w", ConditionSettingsRebootPostUpdate, err)
 	}
 
 	if !condFound {
@@ -673,14 +670,14 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			log.Error(err, "Could not validate settings and determine if reboot needed")
 			var invalidSettingsErr *bmc.InvalidBIOSSettingsError
 			if errors.As(err, &invalidSettingsErr) {
-				inValidSettings, errCond := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionWrongSettings)
+				inValidSettings, errCond := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsInvalid)
 				if errCond != nil {
 					return false, errors.Join(fmt.Errorf("failed to get Condition for skip reboot post setting update: %w", errCond), err)
 				}
 				if errCond := r.Conditions.Update(
 					inValidSettings,
 					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(BIOSSettingsReasonWrongSettings),
+					conditionutils.UpdateReason(ReasonSettingsInvalid),
 					conditionutils.UpdateMessage(fmt.Sprintf("Settings provided is invalid. error: %v", err)),
 				); errCond != nil {
 					return false, fmt.Errorf("failed to update Invalid Settings condition: %w", errors.Join(err, errCond))
@@ -691,7 +688,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			return false, err
 		}
 
-		skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPostUpdate)
+		skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPostUpdate)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Condition for skip reboot post setting update: %w", err)
 		}
@@ -702,7 +699,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			if err := r.Conditions.Update(
 				skipReboot,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonSkipReboot),
+				conditionutils.UpdateReason(ReasonSettingsSkipReboot),
 				conditionutils.UpdateMessage("Settings provided does not need server reboot"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update skip reboot condition: %w", err)
@@ -711,7 +708,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			if err := r.Conditions.Update(
 				skipReboot,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(BIOSSettingsReasonRebootNeeded),
+				conditionutils.UpdateReason(ReasonSettingsRebootNeeded),
 				conditionutils.UpdateMessage("Settings provided needs server reboot"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update skip reboot condition: %w", err)
@@ -722,7 +719,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 		return false, err
 	}
 
-	issueBiosUpdate, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionIssuedUpdate)
+	issueBiosUpdate, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsUpdateIssued)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for issuing BIOSSetting update to server: %w", err)
 	}
@@ -731,13 +728,13 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 		return false, r.applyBIOSSettings(ctx, bmcClient, settings, flowItem, flowStatus, server, issueBiosUpdate)
 	}
 
-	skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPostUpdate)
+	skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPostUpdate)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for reboot needed condition: %w", err)
 	}
 
 	if skipReboot.Status != metav1.ConditionTrue {
-		rebootPowerOnCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPowerOn)
+		rebootPowerOnCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPowerOn)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Condition for reboot PowerOn condition: %w", err)
 		}
@@ -751,7 +748,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 
 func (r *BIOSSettingsReconciler) setTimeoutForAppliedSettings(ctx context.Context, settings *metalv1alpha1.BIOSSettings, flowStatus *metalv1alpha1.BIOSSettingsFlowStatus) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	timeoutCheck, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingConditionUpdateStartTime)
+	timeoutCheck, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsUpdateStartTime)
 	if err != nil {
 		return false, fmt.Errorf("failed to get condition for TimeOut during setting update: %w", err)
 	}
@@ -759,7 +756,7 @@ func (r *BIOSSettingsReconciler) setTimeoutForAppliedSettings(ctx context.Contex
 		if err := r.Conditions.Update(
 			timeoutCheck,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSSettingsReasonUpdateStartTime),
+			conditionutils.UpdateReason(ReasonSettingsUpdateStarted),
 			conditionutils.UpdateMessage("Settings are being updated on Server. Timeout will occur beyond this point if settings are not applied"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update starting setting update condition: %w", err)
@@ -769,14 +766,14 @@ func (r *BIOSSettingsReconciler) setTimeoutForAppliedSettings(ctx context.Contex
 		startTime := timeoutCheck.LastTransitionTime.Time
 		if time.Now().After(startTime.Add(r.TimeoutExpiry)) {
 			log.V(1).Info("Timeout while updating the biosSettings")
-			timedOut, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingConditionUpdateTimedOut)
+			timedOut, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsTimedOut)
 			if err != nil {
 				return false, fmt.Errorf("failed to get Condition for Timeout of BIOSSettings update: %w", err)
 			}
 			if err := r.Conditions.Update(
 				timedOut,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonUpdateTimedOut),
+				conditionutils.UpdateReason(ReasonSettingsTimedOut),
 				conditionutils.UpdateMessage(fmt.Sprintf("Timeout after: %v. startTime: %v. timedOut on: %v", r.TimeoutExpiry, startTime, time.Now().String())),
 			); err != nil {
 				return false, fmt.Errorf("failed to update timeout during settings update condition: %w", err)
@@ -790,7 +787,7 @@ func (r *BIOSSettingsReconciler) setTimeoutForAppliedSettings(ctx context.Contex
 
 func (r *BIOSSettingsReconciler) verifySettingsUpdateComplete(ctx context.Context, bmcClient bmc.BMC, biosSettings *metalv1alpha1.BIOSSettings, flowItem *metalv1alpha1.SettingsFlowItem, flowStatus *metalv1alpha1.BIOSSettingsFlowStatus, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	verifySettingUpdate, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionVerifySettings)
+	verifySettingUpdate, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsVerify)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for Verification condition: %w", err)
 	}
@@ -807,7 +804,7 @@ func (r *BIOSSettingsReconciler) verifySettingsUpdateComplete(ctx context.Contex
 			if err := r.Conditions.Update(
 				verifySettingUpdate,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonVerificationCompleted),
+				conditionutils.UpdateReason(ReasonSettingsVerificationCompleted),
 				conditionutils.UpdateMessage("Required BIOS settings has been applied and verified on the server"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update verify BIOSSetting condition: %w", err)
@@ -817,11 +814,11 @@ func (r *BIOSSettingsReconciler) verifySettingsUpdateComplete(ctx context.Contex
 		}
 
 		log.V(1).Info("Waiting on the BIOS setting to take place")
-		if verifySettingUpdate.Reason != BIOSSettingsReasonVerificationNotCompleted {
+		if verifySettingUpdate.Reason != ReasonSettingsVerificationNotDone {
 			if err := r.Conditions.Update(
 				verifySettingUpdate,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(BIOSSettingsReasonVerificationNotCompleted),
+				conditionutils.UpdateReason(ReasonSettingsVerificationNotDone),
 				conditionutils.UpdateMessage("Required BIOS settings has not yet verified on the server"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update verify BIOSSetting condition: %w", err)
@@ -837,7 +834,7 @@ func (r *BIOSSettingsReconciler) verifySettingsUpdateComplete(ctx context.Contex
 
 func (r *BIOSSettingsReconciler) rebootServer(ctx context.Context, settings *metalv1alpha1.BIOSSettings, flowStatus *metalv1alpha1.BIOSSettingsFlowStatus, server *metalv1alpha1.Server) error {
 	log := ctrl.LoggerFrom(ctx)
-	rebootPowerOffCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPowerOff)
+	rebootPowerOffCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPowerOff)
 	if err != nil {
 		return fmt.Errorf("failed to get PowerOff condition: %w", err)
 	}
@@ -853,7 +850,7 @@ func (r *BIOSSettingsReconciler) rebootServer(ctx context.Context, settings *met
 			if err := r.Conditions.Update(
 				rebootPowerOffCondition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonRebootServerPowerOff),
+				conditionutils.UpdateReason(ReasonSettingsRebootPowerOff),
 				conditionutils.UpdateMessage("Server has entered power off state"),
 			); err != nil {
 				return fmt.Errorf("failed to update powerOff condition: %w", err)
@@ -864,7 +861,7 @@ func (r *BIOSSettingsReconciler) rebootServer(ctx context.Context, settings *met
 		return nil
 	}
 
-	rebootPowerOnCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPowerOn)
+	rebootPowerOnCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPowerOn)
 	if err != nil {
 		return fmt.Errorf("failed to get PowerOn condition: %w", err)
 	}
@@ -880,7 +877,7 @@ func (r *BIOSSettingsReconciler) rebootServer(ctx context.Context, settings *met
 			if err := r.Conditions.Update(
 				rebootPowerOnCondition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonRebootServerPowerOn),
+				conditionutils.UpdateReason(ReasonSettingsRebootPowerOn),
 				conditionutils.UpdateMessage("Server has entered power on state"),
 			); err != nil {
 				return fmt.Errorf("failed to update reboot server powerOn condition: %w", err)
@@ -906,7 +903,7 @@ func (r *BIOSSettingsReconciler) applyBIOSSettings(ctx context.Context, bmcClien
 		if err := r.Conditions.Update(
 			issueBiosUpdate,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSSettingReasonIssuedUpdate),
+			conditionutils.UpdateReason(ReasonSettingsUpdateIssued),
 			conditionutils.UpdateMessage("BIOS Settings issue has been Skipped on the server as no difference found"),
 		); err != nil {
 			return fmt.Errorf("failed to update issued settings update condition: %w", err)
@@ -939,7 +936,7 @@ func (r *BIOSSettingsReconciler) applyBIOSSettings(ctx context.Context, bmcClien
 		return fmt.Errorf("failed to get pending BIOS settings: %w", err)
 	}
 
-	skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPostUpdate)
+	skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPostUpdate)
 	if err != nil {
 		return fmt.Errorf("failed to get Condition for reboot needed condition: %w", err)
 	}
@@ -963,14 +960,14 @@ func (r *BIOSSettingsReconciler) applyBIOSSettings(ctx context.Context, bmcClien
 	// all required settings should in pending settings.
 	if len(pendingSettingsDiff) > 0 {
 		log.V(1).Info("Difference between the pending settings and that of required", "SettingsDiff", pendingSettingsDiff)
-		unexpectedPendingSettings, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionUnknownPendingSettings)
+		unexpectedPendingSettings, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsUnknownPending)
 		if err != nil {
 			return fmt.Errorf("failed to get Condition for unexpected pending BIOSSetting state: %w", err)
 		}
 		if err := r.Conditions.Update(
 			unexpectedPendingSettings,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSSettingsReasonUnexpectedPendingSettings),
+			conditionutils.UpdateReason(ReasonSettingsUnexpectedPending),
 			conditionutils.UpdateMessage(fmt.Sprintf("Found unexpected settings after issuing settings update for BIOS. unexpected settings %v", pendingSettingsDiff)),
 		); err != nil {
 			return fmt.Errorf("failed to update unexpected pending BIOSSettings found condition: %w", err)
@@ -982,7 +979,7 @@ func (r *BIOSSettingsReconciler) applyBIOSSettings(ctx context.Context, bmcClien
 	if err := r.Conditions.Update(
 		issueBiosUpdate,
 		conditionutils.UpdateStatus(corev1.ConditionTrue),
-		conditionutils.UpdateReason(BIOSSettingReasonIssuedUpdate),
+		conditionutils.UpdateReason(ReasonSettingsUpdateIssued),
 		conditionutils.UpdateMessage("BIOS settings update has been triggered on the server"),
 	); err != nil {
 		return fmt.Errorf("failed to update issued BIOSSettings update condition: %w", err)
@@ -1128,7 +1125,7 @@ func (r *BIOSSettingsReconciler) handleFailedState(ctx context.Context, settings
 	if settings.Spec.ServerMaintenanceRef == nil {
 		// Check if the failure is due to pending settings
 		for _, condition := range settings.Status.Conditions {
-			if condition.Type == BIOSPendingSettingConditionCheck && condition.Status == metav1.ConditionTrue {
+			if condition.Type == ConditionPendingSettingsCheck && condition.Status == metav1.ConditionTrue {
 				if _, err := r.requestMaintenanceForServer(ctx, settings, server); err != nil {
 					return ctrl.Result{}, err
 				}
@@ -1252,7 +1249,7 @@ func (r *BIOSSettingsReconciler) requestMaintenanceForServer(ctx context.Context
 		} else if err != nil {
 			return false, fmt.Errorf("failed to verify ServerMaintenance existence: %w", err)
 		}
-		condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ServerMaintenanceConditionCreated)
+		condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionServerMaintenanceCreated)
 		if err != nil {
 			return false, err
 		}
@@ -1264,7 +1261,7 @@ func (r *BIOSSettingsReconciler) requestMaintenanceForServer(ctx context.Context
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ServerMaintenanceReasonCreated),
+			conditionutils.UpdateReason(ReasonMaintenanceCreated),
 			conditionutils.UpdateMessage(fmt.Sprintf("Created/present %v at %v", settings.Spec.ServerMaintenanceRef.Name, time.Now())),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -1531,8 +1528,8 @@ func (r *BIOSSettingsReconciler) enqueueBiosSettingsByBMC(ctx context.Context, o
 
 		// Only enqueue if BMC reset was issued but not yet completed
 		if settings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress {
-			resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCConditionReset)
-			if err == nil && resetCond.Status != metav1.ConditionTrue && resetCond.Reason == BMCReasonReset {
+			resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionResetIssued)
+			if err == nil && resetCond.Status != metav1.ConditionTrue && resetCond.Reason == ReasonResetIssued {
 				reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: settings.Name}})
 			}
 		}

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -78,6 +78,11 @@ var legacyBIOSSettingsConditionTypes = map[string]string{
 	"SettingsProvidedNotValid":             ConditionSettingsValidationFailed,
 }
 
+// legacyBIOSSettingsConditionReasons maps old condition reason strings to their new values.
+var legacyBIOSSettingsConditionReasons = map[string]string{
+	"BMCResetIssued": ReasonResetIssued,
+}
+
 // BIOSSettingsReconciler reconciles a BIOSSettings object
 type BIOSSettingsReconciler struct {
 	client.Client
@@ -120,8 +125,14 @@ func (r *BIOSSettingsReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *BIOSSettingsReconciler) migrateLegacyConditions(ctx context.Context, settings *metalv1alpha1.BIOSSettings) error {
 	settingsBase := settings.DeepCopy()
 	migrated := migrateConditionTypes(settings.Status.Conditions, legacyBIOSSettingsConditionTypes)
+	if migrateConditionReasons(settings.Status.Conditions, legacyBIOSSettingsConditionReasons) {
+		migrated = true
+	}
 	for i := range settings.Status.FlowState {
 		if migrateConditionTypes(settings.Status.FlowState[i].Conditions, legacyBIOSSettingsConditionTypes) {
+			migrated = true
+		}
+		if migrateConditionReasons(settings.Status.FlowState[i].Conditions, legacyBIOSSettingsConditionReasons) {
 			migrated = true
 		}
 	}

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -63,6 +63,19 @@ const (
 	ReasonSettingsInvalid               = "SettingsProvidedAreNotValid"
 )
 
+// legacyBIOSSettingsConditionTypes maps old condition type strings to their new values.
+// This ensures backward compatibility with existing CRs created before the rename.
+var legacyBIOSSettingsConditionTypes = map[string]string{
+	"BIOSSettingsCheckPendingSettings":    ConditionPendingSettingsCheck,
+	"BIOSSettingsDuplicateKeys":           ConditionSettingsDuplicateKeys,
+	"BIOSSettingUpdateStartTime":          ConditionSettingsUpdateStartTime,
+	"BIOSSettingsTimedOut":                ConditionSettingsTimedOut,
+	"ServerPowerOnCondition":              ConditionSettingsServerPowerOn,
+	"ServerRebootPostUpdateHasBeenIssued": ConditionSettingsRebootPostUpdate,
+	"BMCResetIssued":                      ConditionResetIssued,
+	"BIOSVersionUpdatePending":            ConditionVersionUpdatePending,
+}
+
 // BIOSSettingsReconciler reconciles a BIOSSettings object
 type BIOSSettingsReconciler struct {
 	client.Client
@@ -94,7 +107,28 @@ func (r *BIOSSettingsReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err := r.Get(ctx, req.NamespacedName, biosSettings); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	if err := r.migrateLegacyConditions(ctx, biosSettings); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
+	}
 	return r.reconcileExists(ctx, biosSettings)
+}
+
+// migrateLegacyConditions renames legacy condition type strings on existing CRs.
+// TODO: Remove this migration in the next release once all CRs have been reconciled.
+func (r *BIOSSettingsReconciler) migrateLegacyConditions(ctx context.Context, settings *metalv1alpha1.BIOSSettings) error {
+	settingsBase := settings.DeepCopy()
+	migrated := migrateConditionTypes(settings.Status.Conditions, legacyBIOSSettingsConditionTypes)
+	for i := range settings.Status.FlowState {
+		if migrateConditionTypes(settings.Status.FlowState[i].Conditions, legacyBIOSSettingsConditionTypes) {
+			migrated = true
+		}
+	}
+	if !migrated {
+		return nil
+	}
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Migrated legacy condition types on BIOSSettings")
+	return r.Status().Patch(ctx, settings, client.MergeFrom(settingsBase))
 }
 
 func (r *BIOSSettingsReconciler) reconcileExists(ctx context.Context, settings *metalv1alpha1.BIOSSettings) (ctrl.Result, error) {

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -45,7 +45,7 @@ const (
 	ConditionSettingsRebootPowerOff   = "RebootPowerOff"
 	ConditionSettingsRebootPowerOn    = "RebootPowerOn"
 	ConditionSettingsVerify           = "VerifySettingsPostUpdate"
-	ConditionSettingsInvalid          = "SettingsProvidedNotValid"
+	ConditionSettingsValidationFailed = "SettingsValidationFailed"
 
 	ReasonPendingSettingsFound          = "PendingSettingsFound"
 	ReasonSettingsDuplicateKeysFound    = "SettingsDuplicateKeysFound"
@@ -60,7 +60,7 @@ const (
 	ReasonSettingsRebootPowerOn         = "PowerOnCompletedDuringReboot"
 	ReasonSettingsVerificationCompleted = "VerificationCompleted"
 	ReasonSettingsVerificationNotDone   = "VerificationNotCompleted"
-	ReasonSettingsInvalid               = "SettingsProvidedAreNotValid"
+	ReasonSettingsValidationFailed      = "SettingsValidationFailed"
 )
 
 // legacyBIOSSettingsConditionTypes maps old condition type strings to their new values.
@@ -75,6 +75,7 @@ var legacyBIOSSettingsConditionTypes = map[string]string{
 	"BMCResetIssued":                       ConditionResetIssued,
 	"BIOSVersionUpdatePending":             ConditionVersionUpdatePending,
 	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
+	"SettingsProvidedNotValid":             ConditionSettingsValidationFailed,
 }
 
 // BIOSSettingsReconciler reconciles a BIOSSettings object
@@ -705,14 +706,14 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			log.Error(err, "Could not validate settings and determine if reboot needed")
 			var invalidSettingsErr *bmc.InvalidBIOSSettingsError
 			if errors.As(err, &invalidSettingsErr) {
-				inValidSettings, errCond := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsInvalid)
+				inValidSettings, errCond := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsValidationFailed)
 				if errCond != nil {
 					return false, errors.Join(fmt.Errorf("failed to get Condition for skip reboot post setting update: %w", errCond), err)
 				}
 				if errCond := r.Conditions.Update(
 					inValidSettings,
 					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(ReasonSettingsInvalid),
+					conditionutils.UpdateReason(ReasonSettingsValidationFailed),
 					conditionutils.UpdateMessage(fmt.Sprintf("Settings provided is invalid. error: %v", err)),
 				); errCond != nil {
 					return false, fmt.Errorf("failed to update Invalid Settings condition: %w", errors.Join(err, errCond))

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -80,7 +80,17 @@ var legacyBIOSSettingsConditionTypes = map[string]string{
 
 // legacyBIOSSettingsConditionReasons maps old condition reason strings to their new values.
 var legacyBIOSSettingsConditionReasons = map[string]string{
-	"BMCResetIssued": ReasonResetIssued,
+	"BMCResetIssued":                                   ReasonResetIssued,
+	"BIOSVersionNeedsTObeUpgraded":                     ReasonVersionUpgradePending,
+	"BIOSPendingSettingsFound":                         ReasonPendingSettingsFound,
+	"BIOSSettingsDuplicateKeysFound":                   ReasonSettingsDuplicateKeysFound,
+	"BIOSSettingsUpdateHasStarted":                     ReasonSettingsUpdateStarted,
+	"BIOSSettingsTimedOutDuringUpdate":                 ReasonSettingsTimedOut,
+	"ServerPoweredHasBeenPoweredOn":                    ReasonSettingsServerPoweredOn,
+	"BIOSSettingUpdateIssued":                          ReasonSettingsUpdateIssued,
+	"UnexpectedPendingSettingsPostUpdateHasBeenIssued": ReasonSettingsUnexpectedPending,
+	"SkipServerRebootPostUpdateHasBeenIssued":          ReasonSettingsSkipReboot,
+	"SettingsProvidedAreNotValid":                      ReasonSettingsValidationFailed,
 }
 
 // BIOSSettingsReconciler reconciles a BIOSSettings object
@@ -1575,7 +1585,12 @@ func (r *BIOSSettingsReconciler) enqueueBiosSettingsByBMC(ctx context.Context, o
 
 		// Only enqueue if BMC reset was issued but not yet completed
 		if settings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress {
-			resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionResetIssued)
+			// Normalize legacy condition types/reasons so unmigrated CRs are handled correctly.
+			conditions := settings.Status.Conditions
+			migrateConditionTypes(conditions, legacyBIOSSettingsConditionTypes)
+			migrateConditionReasons(conditions, legacyBIOSSettingsConditionReasons)
+
+			resetCond, err := GetCondition(r.Conditions, conditions, ConditionResetIssued)
 			if err == nil && resetCond.Status != metav1.ConditionTrue && resetCond.Reason == ReasonResetIssued {
 				reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: settings.Name}})
 			}

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -34,36 +34,33 @@ import (
 const (
 	BIOSSettingsFinalizer = "metal.ironcore.dev/biossettings"
 
-	BIOSVersionUpdateConditionPending           = "BIOSVersionUpdatePending"
-	BIOSVersionUpgradeReasonPending             = "BIOSVersionNeedsTObeUpgraded"
-	BIOSPendingSettingConditionCheck            = "BIOSSettingsCheckPendingSettings"
-	BIOSPendingSettingsReasonFound              = "BIOSPendingSettingsFound"
-	BIOSSettingsConditionDuplicateKey           = "BIOSSettingsDuplicateKeys"
-	BIOSSettingsReasonFoundDuplicateKeys        = "BIOSSettingsDuplicateKeysFound"
-	BIOSSettingConditionUpdateStartTime         = "BIOSSettingUpdateStartTime"
-	BIOSSettingsReasonUpdateStartTime           = "BIOSSettingsUpdateHasStarted"
-	BIOSSettingConditionUpdateTimedOut          = "BIOSSettingsTimedOut"
-	BIOSSettingsReasonUpdateTimedOut            = "BIOSSettingsTimedOutDuringUpdate"
-	BIOSSettingsConditionServerPowerOn          = "ServerPowerOnCondition"
-	BIOSSettingsReasonServerPoweredOn           = "ServerPoweredHasBeenPoweredOn"
-	BMCConditionReset                           = "BMCResetIssued"
-	BMCReasonReset                              = "BMCResetIssued"
-	BIOSSettingsConditionIssuedUpdate           = "SettingsUpdateIssued"
-	BIOSSettingReasonIssuedUpdate               = "BIOSSettingUpdateIssued"
-	BIOSSettingsConditionUnknownPendingSettings = "UnknownPendingSettingState"
-	BIOSSettingsReasonUnexpectedPendingSettings = "UnexpectedPendingSettingsPostUpdateHasBeenIssued"
-	BIOSSettingsConditionRebootPostUpdate       = "ServerRebootPostUpdateHasBeenIssued"
-	BIOSSettingsReasonSkipReboot                = "SkipServerRebootPostUpdateHasBeenIssued"
-	BIOSSettingsReasonRebootNeeded              = "RebootPostSettingUpdate"
-	BIOSSettingsConditionRebootPowerOff         = "RebootPowerOff"
-	BIOSSettingsReasonRebootServerPowerOff      = "PowerOffCompletedDuringReboot"
-	BIOSSettingsConditionRebootPowerOn          = "RebootPowerOn"
-	BIOSSettingsReasonRebootServerPowerOn       = "PowerOnCompletedDuringReboot"
-	BIOSSettingsConditionVerifySettings         = "VerifySettingsPostUpdate"
-	BIOSSettingsReasonVerificationCompleted     = "VerificationCompleted"
-	BIOSSettingsReasonVerificationNotCompleted  = "VerificationNotCompleted"
-	BIOSSettingsConditionWrongSettings          = "SettingsProvidedNotValid"
-	BIOSSettingsReasonWrongSettings             = "SettingsProvidedAreNotValid"
+	ConditionPendingSettingsCheck     = "PendingSettingsCheck"
+	ConditionSettingsDuplicateKeys    = "SettingsDuplicateKeys"
+	ConditionSettingsUpdateStartTime  = "SettingsUpdateStartTime"
+	ConditionSettingsTimedOut         = "SettingsTimedOut"
+	ConditionSettingsServerPowerOn    = "ServerPowerOn"
+	ConditionSettingsUpdateIssued     = "SettingsUpdateIssued"
+	ConditionSettingsUnknownPending   = "UnknownPendingSettingState"
+	ConditionSettingsRebootPostUpdate = "RebootPostUpdate"
+	ConditionSettingsRebootPowerOff   = "RebootPowerOff"
+	ConditionSettingsRebootPowerOn    = "RebootPowerOn"
+	ConditionSettingsVerify           = "VerifySettingsPostUpdate"
+	ConditionSettingsInvalid          = "SettingsProvidedNotValid"
+
+	ReasonPendingSettingsFound          = "PendingSettingsFound"
+	ReasonSettingsDuplicateKeysFound    = "SettingsDuplicateKeysFound"
+	ReasonSettingsUpdateStarted         = "SettingsUpdateStarted"
+	ReasonSettingsTimedOut              = "SettingsTimedOutDuringUpdate"
+	ReasonSettingsServerPoweredOn       = "ServerPoweredOn"
+	ReasonSettingsUpdateIssued          = "SettingsUpdateIssued"
+	ReasonSettingsUnexpectedPending     = "UnexpectedPendingSettings"
+	ReasonSettingsSkipReboot            = "SkipServerReboot"
+	ReasonSettingsRebootNeeded          = "RebootPostSettingUpdate"
+	ReasonSettingsRebootPowerOff        = "PowerOffCompletedDuringReboot"
+	ReasonSettingsRebootPowerOn         = "PowerOnCompletedDuringReboot"
+	ReasonSettingsVerificationCompleted = "VerificationCompleted"
+	ReasonSettingsVerificationNotDone   = "VerificationNotCompleted"
+	ReasonSettingsInvalid               = "SettingsProvidedAreNotValid"
 )
 
 // BIOSSettingsReconciler reconciles a BIOSSettings object
@@ -157,14 +154,14 @@ func (r *BIOSSettingsReconciler) removeServerMaintenance(ctx context.Context, se
 	if err == nil && maintenance.DeletionTimestamp.IsZero() {
 		if metav1.IsControlledBy(maintenance, settings) {
 			log.V(1).Info("Deleting ServerMaintenance", "ServerMaintenance", client.ObjectKeyFromObject(maintenance), "State", maintenance.Status.State)
-			condition, err = GetCondition(r.Conditions, settings.Status.Conditions, ServerMaintenanceConditionDeleted)
+			condition, err = GetCondition(r.Conditions, settings.Status.Conditions, ConditionServerMaintenanceDeleted)
 			if err != nil {
 				return fmt.Errorf("failed to get the delete condition for ServerMaintenance: %w", err)
 			}
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonDeleted),
+				conditionutils.UpdateReason(ReasonMaintenanceDeleted),
 				conditionutils.UpdateMessage(fmt.Sprintf("Deleting %s", maintenance.Name)),
 			); err != nil {
 				return fmt.Errorf("failed to update deleting ServerMaintenance condition: %w", err)
@@ -325,7 +322,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 	if len(pendingSettings) > 0 {
 		log.V(1).Info("Pending BIOS setting tasks found", "TaskCount", len(pendingSettings))
 
-		pendingSettingStateCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BIOSPendingSettingConditionCheck)
+		pendingSettingStateCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionPendingSettingsCheck)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for pending BIOSSettings state: %w", err)
 		}
@@ -333,7 +330,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 		if err := r.Conditions.Update(
 			pendingSettingStateCheckCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSPendingSettingsReasonFound),
+			conditionutils.UpdateReason(ReasonPendingSettingsFound),
 			conditionutils.UpdateMessage(fmt.Sprintf("Found pending BIOS settings (%d)", len(pendingSettings))),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update pending BIOSSettings update condition: %w", err)
@@ -362,14 +359,14 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 
 	if len(duplicateName) > 0 || len(duplicateSettingsNames) > 0 {
 		log.V(1).Info("Found duplicate keys", "DuplicatesCount", len(duplicateName), "DuplicatesSettingsCound", len(duplicateSettingsNames))
-		duplicateCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BIOSSettingsConditionDuplicateKey)
+		duplicateCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionSettingsDuplicateKeys)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for duplicate-key BIOSSettings state: %w", err)
 		}
 		if err := r.Conditions.Update(
 			duplicateCheckCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSSettingsReasonFoundDuplicateKeys),
+			conditionutils.UpdateReason(ReasonSettingsDuplicateKeysFound),
 			conditionutils.UpdateMessage(fmt.Sprintf("Found duplicate keys (%d) and settings (%d)", len(duplicateName), len(duplicateSettingsNames))),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update pending BIOSSettings update condition: %w", err)
@@ -386,7 +383,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 	// if conditions are present, skip this shortcut to be able to capture all conditions states (ex: verifySetting, reboot etc)
 	if len(settingsDiff) == 0 && len(settings.Status.Conditions) == 0 {
 		// move status to completed
-		verifySettingUpdate, err := GetCondition(r.Conditions, settings.Status.Conditions, BIOSSettingsConditionVerifySettings)
+		verifySettingUpdate, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionSettingsVerify)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for verified BIOSSettings condition: %w", err)
 		}
@@ -394,7 +391,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 		if err := r.Conditions.Update(
 			verifySettingUpdate,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSSettingsReasonVerificationCompleted),
+			conditionutils.UpdateReason(ReasonSettingsVerificationCompleted),
 			conditionutils.UpdateMessage("Required BIOS settings has been verified on the server"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update verify biossetting condition: %w", err)
@@ -405,7 +402,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 	var state = metalv1alpha1.BIOSSettingsStateInProgress
 	var condition *metav1.Condition
 	if biosVersion != settings.Spec.Version {
-		versionCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BIOSVersionUpdateConditionPending)
+		versionCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionVersionUpdatePending)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for pending BIOSVersion update state: %w", err)
 		}
@@ -416,7 +413,7 @@ func (r *BIOSSettingsReconciler) handleSettingPendingState(ctx context.Context, 
 		if err := r.Conditions.Update(
 			versionCheckCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSVersionUpgradeReasonPending),
+			conditionutils.UpdateReason(ReasonVersionUpgradePending),
 			conditionutils.UpdateMessage(fmt.Sprintf("Waiting to update biosVersion: %s, current biosVersion: %s", settings.Spec.Version, biosVersion)),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update Pending BIOSVersion update condition: %w", err)
@@ -433,7 +430,7 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 		return ctrl.Result{}, err
 	}
 
-	condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ServerMaintenanceConditionWaiting)
+	condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionServerMaintenanceWaiting)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -443,7 +440,7 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+				conditionutils.UpdateReason(ReasonMaintenanceWaiting),
 				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", settings.Spec.ServerMaintenanceRef.Name)),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -455,11 +452,11 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 		return ctrl.Result{}, nil
 	}
 	// once in maintenance, clear the waiting condition if present
-	if condition.Reason != ServerMaintenanceReasonApproved {
+	if condition.Reason != ReasonMaintenanceApproved {
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
+			conditionutils.UpdateReason(ReasonMaintenanceApproved),
 			conditionutils.UpdateMessage("Server is now in Maintenance mode"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -512,7 +509,7 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 					continue
 				}
 				// mark completed, and move on
-				verifySettingUpdate, err := GetCondition(r.Conditions, currentSettingsFlowStatus.Conditions, BIOSSettingsConditionVerifySettings)
+				verifySettingUpdate, err := GetCondition(r.Conditions, currentSettingsFlowStatus.Conditions, ConditionSettingsVerify)
 				if err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to get Condition for verified BIOSSettings condition: %w", err)
 				}
@@ -520,7 +517,7 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 				if err := r.Conditions.Update(
 					verifySettingUpdate,
 					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(BIOSSettingsReasonVerificationCompleted),
+					conditionutils.UpdateReason(ReasonSettingsVerificationCompleted),
 					conditionutils.UpdateMessage("Required BIOS settings has been RE verified on the server. Hence, moving out of Pending state"),
 				); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update verified BIOSSettings condition: %w", err)
@@ -552,7 +549,7 @@ func (r *BIOSSettingsReconciler) handleSettingInProgressState(ctx context.Contex
 
 func (r *BIOSSettingsReconciler) handleBMCReset(ctx context.Context, bmcClient bmc.BMC, settings *metalv1alpha1.BIOSSettings, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	resetBMC, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCConditionReset)
+	resetBMC, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionResetIssued)
 	if err != nil {
 		return false, fmt.Errorf("failed to get condition for reset of BMC of server: %w", err)
 	}
@@ -560,13 +557,13 @@ func (r *BIOSSettingsReconciler) handleBMCReset(ctx context.Context, bmcClient b
 	if resetBMC.Status != metav1.ConditionTrue {
 		// once the server is powered on, reset the BMC to make sure its in stable state
 		// this avoids problems with some BMCs that hang up in subsequent operations
-		if resetBMC.Reason != BMCReasonReset {
+		if resetBMC.Reason != ReasonResetIssued {
 			if err := resetBMCOfServer(ctx, r.Client, server, bmcClient); err == nil {
 				// mark reset to be issued, wait for next reconcile
 				if err := r.Conditions.Update(
 					resetBMC,
 					conditionutils.UpdateStatus(corev1.ConditionFalse),
-					conditionutils.UpdateReason(BMCReasonReset),
+					conditionutils.UpdateReason(ReasonResetIssued),
 					conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 				); err != nil {
 					return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -592,7 +589,7 @@ func (r *BIOSSettingsReconciler) handleBMCReset(ctx context.Context, bmcClient b
 		if err := r.Conditions.Update(
 			resetBMC,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCReasonReset),
+			conditionutils.UpdateReason(ReasonResetIssued),
 			conditionutils.UpdateMessage("BMC reset to stabilize BMC of the server is completed"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -607,7 +604,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 	if modified, err := r.setTimeoutForAppliedSettings(ctx, settings, flowStatus); modified || err != nil {
 		return false, err
 	}
-	turnOnServer, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionServerPowerOn)
+	turnOnServer, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsServerPowerOn)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for Initial powerOn of server: %w", err)
 	}
@@ -617,7 +614,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			if err := r.Conditions.Update(
 				turnOnServer,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonServerPoweredOn),
+				conditionutils.UpdateReason(ReasonSettingsServerPoweredOn),
 				conditionutils.UpdateMessage("Server is powered On to start the biosUpdate process"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -641,9 +638,9 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 
 	// check if we have already determined if we need reboot of not.
 	// if the condition is present, we have checked the skip reboot condition.
-	condFound, err := r.Conditions.FindSlice(flowStatus.Conditions, BIOSSettingsConditionRebootPostUpdate, &metav1.Condition{})
+	condFound, err := r.Conditions.FindSlice(flowStatus.Conditions, ConditionSettingsRebootPostUpdate, &metav1.Condition{})
 	if err != nil {
-		return false, fmt.Errorf("failed to find Condition %v. error: %w", BIOSSettingsConditionRebootPostUpdate, err)
+		return false, fmt.Errorf("failed to find Condition %v. error: %w", ConditionSettingsRebootPostUpdate, err)
 	}
 
 	if !condFound {
@@ -661,14 +658,14 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			log.Error(err, "Could not validate settings and determine if reboot needed")
 			var invalidSettingsErr *bmc.InvalidBIOSSettingsError
 			if errors.As(err, &invalidSettingsErr) {
-				inValidSettings, errCond := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionWrongSettings)
+				inValidSettings, errCond := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsInvalid)
 				if errCond != nil {
 					return false, errors.Join(fmt.Errorf("failed to get Condition for skip reboot post setting update: %w", errCond), err)
 				}
 				if errCond := r.Conditions.Update(
 					inValidSettings,
 					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(BIOSSettingsReasonWrongSettings),
+					conditionutils.UpdateReason(ReasonSettingsInvalid),
 					conditionutils.UpdateMessage(fmt.Sprintf("Settings provided is invalid. error: %v", err)),
 				); errCond != nil {
 					return false, fmt.Errorf("failed to update Invalid Settings condition: %w", errCond)
@@ -679,7 +676,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			return false, err
 		}
 
-		skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPostUpdate)
+		skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPostUpdate)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Condition for skip reboot post setting update: %w", err)
 		}
@@ -690,7 +687,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			if err := r.Conditions.Update(
 				skipReboot,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonSkipReboot),
+				conditionutils.UpdateReason(ReasonSettingsSkipReboot),
 				conditionutils.UpdateMessage("Settings provided does not need server reboot"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update skip reboot condition: %w", err)
@@ -699,7 +696,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 			if err := r.Conditions.Update(
 				skipReboot,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(BIOSSettingsReasonRebootNeeded),
+				conditionutils.UpdateReason(ReasonSettingsRebootNeeded),
 				conditionutils.UpdateMessage("Settings provided needs server reboot"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update skip reboot condition: %w", err)
@@ -710,7 +707,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 		return false, err
 	}
 
-	issueBiosUpdate, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionIssuedUpdate)
+	issueBiosUpdate, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsUpdateIssued)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for issuing BIOSSetting update to server: %w", err)
 	}
@@ -719,13 +716,13 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 		return false, r.applyBIOSSettings(ctx, bmcClient, settings, flowItem, flowStatus, server, issueBiosUpdate)
 	}
 
-	skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPostUpdate)
+	skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPostUpdate)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for reboot needed condition: %w", err)
 	}
 
 	if skipReboot.Status != metav1.ConditionTrue {
-		rebootPowerOnCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPowerOn)
+		rebootPowerOnCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPowerOn)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Condition for reboot PowerOn condition: %w", err)
 		}
@@ -739,7 +736,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 
 func (r *BIOSSettingsReconciler) setTimeoutForAppliedSettings(ctx context.Context, settings *metalv1alpha1.BIOSSettings, flowStatus *metalv1alpha1.BIOSSettingsFlowStatus) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	timeoutCheck, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingConditionUpdateStartTime)
+	timeoutCheck, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsUpdateStartTime)
 	if err != nil {
 		return false, fmt.Errorf("failed to get condition for TimeOut during setting update: %w", err)
 	}
@@ -747,7 +744,7 @@ func (r *BIOSSettingsReconciler) setTimeoutForAppliedSettings(ctx context.Contex
 		if err := r.Conditions.Update(
 			timeoutCheck,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSSettingsReasonUpdateStartTime),
+			conditionutils.UpdateReason(ReasonSettingsUpdateStarted),
 			conditionutils.UpdateMessage("Settings are being updated on Server. Timeout will occur beyond this point if settings are not applied"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update starting setting update condition: %w", err)
@@ -757,14 +754,14 @@ func (r *BIOSSettingsReconciler) setTimeoutForAppliedSettings(ctx context.Contex
 		startTime := timeoutCheck.LastTransitionTime.Time
 		if time.Now().After(startTime.Add(r.TimeoutExpiry)) {
 			log.V(1).Info("Timeout while updating the biosSettings")
-			timedOut, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingConditionUpdateTimedOut)
+			timedOut, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsTimedOut)
 			if err != nil {
 				return false, fmt.Errorf("failed to get Condition for Timeout of BIOSSettings update: %w", err)
 			}
 			if err := r.Conditions.Update(
 				timedOut,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonUpdateTimedOut),
+				conditionutils.UpdateReason(ReasonSettingsTimedOut),
 				conditionutils.UpdateMessage(fmt.Sprintf("Timeout after: %v. startTime: %v. timedOut on: %v", r.TimeoutExpiry, startTime, time.Now().String())),
 			); err != nil {
 				return false, fmt.Errorf("failed to update timeout during settings update condition: %w", err)
@@ -778,7 +775,7 @@ func (r *BIOSSettingsReconciler) setTimeoutForAppliedSettings(ctx context.Contex
 
 func (r *BIOSSettingsReconciler) verifySettingsUpdateComplete(ctx context.Context, bmcClient bmc.BMC, biosSettings *metalv1alpha1.BIOSSettings, flowItem *metalv1alpha1.SettingsFlowItem, flowStatus *metalv1alpha1.BIOSSettingsFlowStatus, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	verifySettingUpdate, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionVerifySettings)
+	verifySettingUpdate, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsVerify)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Condition for Verification condition: %w", err)
 	}
@@ -795,7 +792,7 @@ func (r *BIOSSettingsReconciler) verifySettingsUpdateComplete(ctx context.Contex
 			if err := r.Conditions.Update(
 				verifySettingUpdate,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonVerificationCompleted),
+				conditionutils.UpdateReason(ReasonSettingsVerificationCompleted),
 				conditionutils.UpdateMessage("Required BIOS settings has been applied and verified on the server"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update verify BIOSSetting condition: %w", err)
@@ -805,11 +802,11 @@ func (r *BIOSSettingsReconciler) verifySettingsUpdateComplete(ctx context.Contex
 		}
 
 		log.V(1).Info("Waiting on the BIOS setting to take place")
-		if verifySettingUpdate.Reason != BIOSSettingsReasonVerificationNotCompleted {
+		if verifySettingUpdate.Reason != ReasonSettingsVerificationNotDone {
 			if err := r.Conditions.Update(
 				verifySettingUpdate,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(BIOSSettingsReasonVerificationNotCompleted),
+				conditionutils.UpdateReason(ReasonSettingsVerificationNotDone),
 				conditionutils.UpdateMessage("Required BIOS settings has not yet verified on the server"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update verify BIOSSetting condition: %w", err)
@@ -825,7 +822,7 @@ func (r *BIOSSettingsReconciler) verifySettingsUpdateComplete(ctx context.Contex
 
 func (r *BIOSSettingsReconciler) rebootServer(ctx context.Context, settings *metalv1alpha1.BIOSSettings, flowStatus *metalv1alpha1.BIOSSettingsFlowStatus, server *metalv1alpha1.Server) error {
 	log := ctrl.LoggerFrom(ctx)
-	rebootPowerOffCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPowerOff)
+	rebootPowerOffCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPowerOff)
 	if err != nil {
 		return fmt.Errorf("failed to get PowerOff condition: %w", err)
 	}
@@ -841,7 +838,7 @@ func (r *BIOSSettingsReconciler) rebootServer(ctx context.Context, settings *met
 			if err := r.Conditions.Update(
 				rebootPowerOffCondition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonRebootServerPowerOff),
+				conditionutils.UpdateReason(ReasonSettingsRebootPowerOff),
 				conditionutils.UpdateMessage("Server has entered power off state"),
 			); err != nil {
 				return fmt.Errorf("failed to update powerOff condition: %w", err)
@@ -852,7 +849,7 @@ func (r *BIOSSettingsReconciler) rebootServer(ctx context.Context, settings *met
 		return nil
 	}
 
-	rebootPowerOnCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPowerOn)
+	rebootPowerOnCondition, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPowerOn)
 	if err != nil {
 		return fmt.Errorf("failed to get PowerOn condition: %w", err)
 	}
@@ -868,7 +865,7 @@ func (r *BIOSSettingsReconciler) rebootServer(ctx context.Context, settings *met
 			if err := r.Conditions.Update(
 				rebootPowerOnCondition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BIOSSettingsReasonRebootServerPowerOn),
+				conditionutils.UpdateReason(ReasonSettingsRebootPowerOn),
 				conditionutils.UpdateMessage("Server has entered power on state"),
 			); err != nil {
 				return fmt.Errorf("failed to update reboot server powerOn condition: %w", err)
@@ -894,7 +891,7 @@ func (r *BIOSSettingsReconciler) applyBIOSSettings(ctx context.Context, bmcClien
 		if err := r.Conditions.Update(
 			issueBiosUpdate,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSSettingReasonIssuedUpdate),
+			conditionutils.UpdateReason(ReasonSettingsUpdateIssued),
 			conditionutils.UpdateMessage("BIOS Settings issue has been Skipped on the server as no difference found"),
 		); err != nil {
 			return fmt.Errorf("failed to update issued settings update condition: %w", err)
@@ -927,7 +924,7 @@ func (r *BIOSSettingsReconciler) applyBIOSSettings(ctx context.Context, bmcClien
 		return fmt.Errorf("failed to get pending BIOS settings: %w", err)
 	}
 
-	skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionRebootPostUpdate)
+	skipReboot, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsRebootPostUpdate)
 	if err != nil {
 		return fmt.Errorf("failed to get Condition for reboot needed condition: %w", err)
 	}
@@ -951,14 +948,14 @@ func (r *BIOSSettingsReconciler) applyBIOSSettings(ctx context.Context, bmcClien
 	// all required settings should in pending settings.
 	if len(pendingSettingsDiff) > 0 {
 		log.V(1).Info("Difference between the pending settings and that of required", "SettingsDiff", pendingSettingsDiff)
-		unexpectedPendingSettings, err := GetCondition(r.Conditions, flowStatus.Conditions, BIOSSettingsConditionUnknownPendingSettings)
+		unexpectedPendingSettings, err := GetCondition(r.Conditions, flowStatus.Conditions, ConditionSettingsUnknownPending)
 		if err != nil {
 			return fmt.Errorf("failed to get Condition for unexpected pending BIOSSetting state: %w", err)
 		}
 		if err := r.Conditions.Update(
 			unexpectedPendingSettings,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BIOSSettingsReasonUnexpectedPendingSettings),
+			conditionutils.UpdateReason(ReasonSettingsUnexpectedPending),
 			conditionutils.UpdateMessage(fmt.Sprintf("Found unexpected settings after issuing settings update for BIOS. unexpected settings %v", pendingSettingsDiff)),
 		); err != nil {
 			return fmt.Errorf("failed to update unexpected pending BIOSSettings found condition: %w", err)
@@ -970,7 +967,7 @@ func (r *BIOSSettingsReconciler) applyBIOSSettings(ctx context.Context, bmcClien
 	if err := r.Conditions.Update(
 		issueBiosUpdate,
 		conditionutils.UpdateStatus(corev1.ConditionTrue),
-		conditionutils.UpdateReason(BIOSSettingReasonIssuedUpdate),
+		conditionutils.UpdateReason(ReasonSettingsUpdateIssued),
 		conditionutils.UpdateMessage("BIOS settings update has been triggered on the server"),
 	); err != nil {
 		return fmt.Errorf("failed to update issued BIOSSettings update condition: %w", err)
@@ -1051,7 +1048,7 @@ func (r *BIOSSettingsReconciler) handleFailedState(ctx context.Context, settings
 	if settings.Spec.ServerMaintenanceRef == nil {
 		// Check if the failure is due to pending settings
 		for _, condition := range settings.Status.Conditions {
-			if condition.Type == BIOSPendingSettingConditionCheck && condition.Status == metav1.ConditionTrue {
+			if condition.Type == ConditionPendingSettingsCheck && condition.Status == metav1.ConditionTrue {
 				if _, err := r.requestMaintenanceForServer(ctx, settings, server); err != nil {
 					return ctrl.Result{}, err
 				}
@@ -1175,7 +1172,7 @@ func (r *BIOSSettingsReconciler) requestMaintenanceForServer(ctx context.Context
 		} else if err != nil {
 			return false, fmt.Errorf("failed to verify ServerMaintenance existence: %w", err)
 		}
-		condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ServerMaintenanceConditionCreated)
+		condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionServerMaintenanceCreated)
 		if err != nil {
 			return false, err
 		}
@@ -1187,7 +1184,7 @@ func (r *BIOSSettingsReconciler) requestMaintenanceForServer(ctx context.Context
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ServerMaintenanceReasonCreated),
+			conditionutils.UpdateReason(ReasonMaintenanceCreated),
 			conditionutils.UpdateMessage(fmt.Sprintf("Created/present %v at %v", settings.Spec.ServerMaintenanceRef.Name, time.Now())),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -1454,8 +1451,8 @@ func (r *BIOSSettingsReconciler) enqueueBiosSettingsByBMC(ctx context.Context, o
 
 		// Only enqueue if BMC reset was issued but not yet completed
 		if settings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress {
-			resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCConditionReset)
-			if err == nil && resetCond.Status != metav1.ConditionTrue && resetCond.Reason == BMCReasonReset {
+			resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionResetIssued)
+			if err == nil && resetCond.Status != metav1.ConditionTrue && resetCond.Reason == ReasonResetIssued {
 				reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: settings.Name}})
 			}
 		}

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -135,7 +135,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 		Eventually(Object(biosSettingsV1)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionVerifySettings),
+					HaveField("Type", ConditionSettingsVerify),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -233,7 +233,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionVerifySettings),
+					HaveField("Type", ConditionSettingsVerify),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -285,8 +285,8 @@ var _ = Describe("BIOSSettings Controller", func() {
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.FlowState", ContainElement(SatisfyAll(
 				HaveField("Conditions", ContainElement(SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionRebootPostUpdate),
-					HaveField("Reason", BIOSSettingsReasonRebootNeeded),
+					HaveField("Type", ConditionSettingsRebootPostUpdate),
+					HaveField("Reason", ReasonSettingsRebootNeeded),
 					HaveField("Status", metav1.ConditionFalse)),
 				)),
 				HaveField("Name", "one"),
@@ -1474,8 +1474,8 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 					SatisfyAll(
 						HaveField("Conditions", ContainElement(
 							SatisfyAll(
-								HaveField("Type", BIOSSettingsConditionWrongSettings),
-								HaveField("Reason", BIOSSettingsReasonWrongSettings),
+								HaveField("Type", ConditionSettingsInvalid),
+								HaveField("Reason", ReasonSettingsInvalid),
 							),
 						)),
 						HaveField("Name", "100"),
@@ -1544,7 +1544,7 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionDuplicateKey),
+					HaveField("Type", ConditionSettingsDuplicateKeys),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1592,7 +1592,7 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 		Eventually(Object(biosSettings2)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionDuplicateKey),
+					HaveField("Type", ConditionSettingsDuplicateKeys),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1715,7 +1715,7 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 				HaveField("Status.FlowState", Not(ContainElement(
 					SatisfyAll(
 						HaveField("Conditions", ContainElement(
-							HaveField("Type", BIOSSettingsConditionIssuedUpdate),
+							HaveField("Type", ConditionSettingsUpdateIssued),
 						)),
 						HaveField("Name", oldNames[1]),
 					),
@@ -1779,7 +1779,7 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 	By("Ensuring the wait for version upgrade condition has NOT been added")
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", Not(ContainElement(
-			HaveField("Type", BIOSVersionUpdateConditionPending),
+			HaveField("Type", ConditionVersionUpdatePending),
 		))),
 	)
 
@@ -1787,7 +1787,7 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElement(
 			SatisfyAll(
-				HaveField("Type", ServerMaintenanceConditionCreated),
+				HaveField("Type", ConditionServerMaintenanceCreated),
 				HaveField("Status", metav1.ConditionTrue),
 			),
 		)),
@@ -1800,28 +1800,28 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 		flowStateMatcher := SatisfyAll(
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingConditionUpdateStartTime),
+					HaveField("Type", ConditionSettingsUpdateStartTime),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionServerPowerOn),
+					HaveField("Type", ConditionSettingsServerPowerOn),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
 			HaveField("Conditions", ContainElement(
-				HaveField("Type", BIOSSettingsConditionRebootPostUpdate),
+				HaveField("Type", ConditionSettingsRebootPostUpdate),
 			)),
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionIssuedUpdate),
+					HaveField("Type", ConditionSettingsUpdateIssued),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionVerifySettings),
+					HaveField("Type", ConditionSettingsVerify),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1836,7 +1836,7 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElement(
 			SatisfyAll(
-				HaveField("Type", ServerMaintenanceConditionDeleted),
+				HaveField("Type", ConditionServerMaintenanceDeleted),
 				HaveField("Status", metav1.ConditionTrue),
 			),
 		)),
@@ -1877,7 +1877,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSVersionUpdateConditionPending),
+					HaveField("Type", ConditionVersionUpdatePending),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1886,7 +1886,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		By("Ensuring the wait for version upgrade condition has NOT been added")
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", Not(ContainElement(
-				HaveField("Type", BIOSVersionUpdateConditionPending),
+				HaveField("Type", ConditionVersionUpdatePending),
 			))),
 		)
 	}
@@ -1895,7 +1895,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElement(
 			SatisfyAll(
-				HaveField("Type", ServerMaintenanceConditionCreated),
+				HaveField("Type", ConditionServerMaintenanceCreated),
 				HaveField("Status", metav1.ConditionTrue),
 			),
 		)),
@@ -1906,7 +1906,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElement(
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingConditionUpdateStartTime),
+					HaveField("Type", ConditionSettingsUpdateStartTime),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1918,7 +1918,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElement(
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionServerPowerOn),
+					HaveField("Type", ConditionSettingsServerPowerOn),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1932,12 +1932,12 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 				HaveField("Conditions", SatisfyAll(
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", BIOSSettingsConditionRebootPostUpdate),
+							HaveField("Type", ConditionSettingsRebootPostUpdate),
 							HaveField("Status", metav1.ConditionTrue),
 						),
 					),
-					Not(ContainElement(HaveField("Type", BIOSSettingsConditionRebootPowerOff))),
-					Not(ContainElement(HaveField("Type", BIOSSettingsConditionRebootPowerOn))),
+					Not(ContainElement(HaveField("Type", ConditionSettingsRebootPowerOff))),
+					Not(ContainElement(HaveField("Type", ConditionSettingsRebootPowerOn))),
 				)),
 			)),
 		)
@@ -1948,19 +1948,19 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 				HaveField("Conditions", SatisfyAll(
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", BIOSSettingsConditionRebootPostUpdate),
+							HaveField("Type", ConditionSettingsRebootPostUpdate),
 							HaveField("Status", metav1.ConditionFalse),
 						),
 					),
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", BIOSSettingsConditionRebootPowerOff),
+							HaveField("Type", ConditionSettingsRebootPowerOff),
 							HaveField("Status", metav1.ConditionTrue),
 						),
 					),
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", BIOSSettingsConditionRebootPowerOn),
+							HaveField("Type", ConditionSettingsRebootPowerOn),
 							HaveField("Status", metav1.ConditionTrue),
 						),
 					),
@@ -1974,7 +1974,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElements(
 			SatisfyAll(
 				HaveField("Conditions", ContainElements(
-					HaveField("Type", BIOSSettingsConditionIssuedUpdate),
+					HaveField("Type", ConditionSettingsUpdateIssued),
 					HaveField("Status", metav1.ConditionTrue),
 				)),
 			),
@@ -1986,7 +1986,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElements(
 			SatisfyAll(
 				HaveField("Conditions", ContainElements(
-					HaveField("Type", BIOSSettingsConditionVerifySettings),
+					HaveField("Type", ConditionSettingsVerify),
 					HaveField("Status", metav1.ConditionTrue),
 				)),
 			),
@@ -1996,7 +1996,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 	By("Ensuring the server maintenance has been deleted")
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElements(
-			HaveField("Type", ServerMaintenanceConditionDeleted),
+			HaveField("Type", ConditionServerMaintenanceDeleted),
 			HaveField("Status", metav1.ConditionTrue),
 		)),
 	)

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -134,7 +134,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 		Eventually(Object(biosSettingsV1)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionVerifySettings),
+					HaveField("Type", ConditionSettingsVerify),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -232,7 +232,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionVerifySettings),
+					HaveField("Type", ConditionSettingsVerify),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -284,8 +284,8 @@ var _ = Describe("BIOSSettings Controller", func() {
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.FlowState", ContainElement(SatisfyAll(
 				HaveField("Conditions", ContainElement(SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionRebootPostUpdate),
-					HaveField("Reason", BIOSSettingsReasonRebootNeeded),
+					HaveField("Type", ConditionSettingsRebootPostUpdate),
+					HaveField("Reason", ReasonSettingsRebootNeeded),
 					HaveField("Status", metav1.ConditionFalse)),
 				)),
 				HaveField("Name", "one"),
@@ -1449,8 +1449,8 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 					SatisfyAll(
 						HaveField("Conditions", ContainElement(
 							SatisfyAll(
-								HaveField("Type", BIOSSettingsConditionWrongSettings),
-								HaveField("Reason", BIOSSettingsReasonWrongSettings),
+								HaveField("Type", ConditionSettingsInvalid),
+								HaveField("Reason", ReasonSettingsInvalid),
 							),
 						)),
 						HaveField("Name", "100"),
@@ -1519,7 +1519,7 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionDuplicateKey),
+					HaveField("Type", ConditionSettingsDuplicateKeys),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1567,7 +1567,7 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 		Eventually(Object(biosSettings2)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionDuplicateKey),
+					HaveField("Type", ConditionSettingsDuplicateKeys),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1690,7 +1690,7 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 				HaveField("Status.FlowState", Not(ContainElement(
 					SatisfyAll(
 						HaveField("Conditions", ContainElement(
-							HaveField("Type", BIOSSettingsConditionIssuedUpdate),
+							HaveField("Type", ConditionSettingsUpdateIssued),
 						)),
 						HaveField("Name", oldNames[1]),
 					),
@@ -1754,7 +1754,7 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 	By("Ensuring the wait for version upgrade condition has NOT been added")
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", Not(ContainElement(
-			HaveField("Type", BIOSVersionUpdateConditionPending),
+			HaveField("Type", ConditionVersionUpdatePending),
 		))),
 	)
 
@@ -1762,7 +1762,7 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElement(
 			SatisfyAll(
-				HaveField("Type", ServerMaintenanceConditionCreated),
+				HaveField("Type", ConditionServerMaintenanceCreated),
 				HaveField("Status", metav1.ConditionTrue),
 			),
 		)),
@@ -1775,28 +1775,28 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 		flowStateMatcher := SatisfyAll(
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingConditionUpdateStartTime),
+					HaveField("Type", ConditionSettingsUpdateStartTime),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionServerPowerOn),
+					HaveField("Type", ConditionSettingsServerPowerOn),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
 			HaveField("Conditions", ContainElement(
-				HaveField("Type", BIOSSettingsConditionRebootPostUpdate),
+				HaveField("Type", ConditionSettingsRebootPostUpdate),
 			)),
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionIssuedUpdate),
+					HaveField("Type", ConditionSettingsUpdateIssued),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionVerifySettings),
+					HaveField("Type", ConditionSettingsVerify),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1811,7 +1811,7 @@ func ensureBiosSettingsFlowCondition(biosSettings *metalv1alpha1.BIOSSettings) {
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElement(
 			SatisfyAll(
-				HaveField("Type", ServerMaintenanceConditionDeleted),
+				HaveField("Type", ConditionServerMaintenanceDeleted),
 				HaveField("Status", metav1.ConditionTrue),
 			),
 		)),
@@ -1852,7 +1852,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSVersionUpdateConditionPending),
+					HaveField("Type", ConditionVersionUpdatePending),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1861,7 +1861,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		By("Ensuring the wait for version upgrade condition has NOT been added")
 		Eventually(Object(biosSettings)).Should(
 			HaveField("Status.Conditions", Not(ContainElement(
-				HaveField("Type", BIOSVersionUpdateConditionPending),
+				HaveField("Type", ConditionVersionUpdatePending),
 			))),
 		)
 	}
@@ -1870,7 +1870,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElement(
 			SatisfyAll(
-				HaveField("Type", ServerMaintenanceConditionCreated),
+				HaveField("Type", ConditionServerMaintenanceCreated),
 				HaveField("Status", metav1.ConditionTrue),
 			),
 		)),
@@ -1881,7 +1881,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElement(
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingConditionUpdateStartTime),
+					HaveField("Type", ConditionSettingsUpdateStartTime),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1893,7 +1893,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElement(
 			HaveField("Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", BIOSSettingsConditionServerPowerOn),
+					HaveField("Type", ConditionSettingsServerPowerOn),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -1907,12 +1907,12 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 				HaveField("Conditions", SatisfyAll(
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", BIOSSettingsConditionRebootPostUpdate),
+							HaveField("Type", ConditionSettingsRebootPostUpdate),
 							HaveField("Status", metav1.ConditionTrue),
 						),
 					),
-					Not(ContainElement(HaveField("Type", BIOSSettingsConditionRebootPowerOff))),
-					Not(ContainElement(HaveField("Type", BIOSSettingsConditionRebootPowerOn))),
+					Not(ContainElement(HaveField("Type", ConditionSettingsRebootPowerOff))),
+					Not(ContainElement(HaveField("Type", ConditionSettingsRebootPowerOn))),
 				)),
 			)),
 		)
@@ -1923,19 +1923,19 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 				HaveField("Conditions", SatisfyAll(
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", BIOSSettingsConditionRebootPostUpdate),
+							HaveField("Type", ConditionSettingsRebootPostUpdate),
 							HaveField("Status", metav1.ConditionFalse),
 						),
 					),
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", BIOSSettingsConditionRebootPowerOff),
+							HaveField("Type", ConditionSettingsRebootPowerOff),
 							HaveField("Status", metav1.ConditionTrue),
 						),
 					),
 					ContainElement(
 						SatisfyAll(
-							HaveField("Type", BIOSSettingsConditionRebootPowerOn),
+							HaveField("Type", ConditionSettingsRebootPowerOn),
 							HaveField("Status", metav1.ConditionTrue),
 						),
 					),
@@ -1949,7 +1949,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElements(
 			SatisfyAll(
 				HaveField("Conditions", ContainElements(
-					HaveField("Type", BIOSSettingsConditionIssuedUpdate),
+					HaveField("Type", ConditionSettingsUpdateIssued),
 					HaveField("Status", metav1.ConditionTrue),
 				)),
 			),
@@ -1961,7 +1961,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 		HaveField("Status.FlowState", ContainElements(
 			SatisfyAll(
 				HaveField("Conditions", ContainElements(
-					HaveField("Type", BIOSSettingsConditionVerifySettings),
+					HaveField("Type", ConditionSettingsVerify),
 					HaveField("Status", metav1.ConditionTrue),
 				)),
 			),
@@ -1971,7 +1971,7 @@ func ensureBiosSettingsCondition(biosSettings *metalv1alpha1.BIOSSettings, Reboo
 	By("Ensuring the server maintenance has been deleted")
 	Eventually(Object(biosSettings)).Should(
 		HaveField("Status.Conditions", ContainElements(
-			HaveField("Type", ServerMaintenanceConditionDeleted),
+			HaveField("Type", ConditionServerMaintenanceDeleted),
 			HaveField("Status", metav1.ConditionTrue),
 		)),
 	)

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -1474,8 +1474,8 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 					SatisfyAll(
 						HaveField("Conditions", ContainElement(
 							SatisfyAll(
-								HaveField("Type", ConditionSettingsInvalid),
-								HaveField("Reason", ReasonSettingsInvalid),
+								HaveField("Type", ConditionSettingsValidationFailed),
+								HaveField("Reason", ReasonSettingsValidationFailed),
 							),
 						)),
 						HaveField("Name", "100"),

--- a/internal/controller/biossettingsset_controller.go
+++ b/internal/controller/biossettingsset_controller.go
@@ -27,7 +27,9 @@ import (
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 )
 
-const biosSettingsSetFinalizer = "metal.ironcore.dev/biossettingsset"
+const (
+	biosSettingsSetFinalizer = "metal.ironcore.dev/biossettingsset"
+)
 
 // BIOSSettingsSetReconciler reconciles a BIOSSettingsSet object
 type BIOSSettingsSetReconciler struct {

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -38,6 +38,18 @@ const (
 	ReasonRebootPowerOn  = "RebootPowerOn"
 )
 
+// legacyBIOSVersionConditionTypes maps old condition type strings to their new values.
+// TODO: Remove this migration in the next release once all CRs have been reconciled.
+var legacyBIOSVersionConditionTypes = map[string]string{
+	"BIOSUpgradeIssued":        ConditionVersionUpgradeIssued,
+	"BIOSUpgradeCompleted":     ConditionVersionUpgradeCompleted,
+	"BIOSUpgradePowerOn":       ConditionUpgradePowerOn,
+	"BIOSUpgradePowerOff":      ConditionUpgradePowerOff,
+	"BIOSUpgradeVerification":  ConditionVersionUpgradeVerification,
+	"BIOSVersionUpdatePending": ConditionVersionUpdatePending,
+	"BMCResetIssued":           ConditionResetIssued,
+}
+
 type BIOSVersionReconciler struct {
 	client.Client
 	ManagerNamespace   string
@@ -63,6 +75,14 @@ func (r *BIOSVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	biosVersion := &metalv1alpha1.BIOSVersion{}
 	if err := r.Get(ctx, req.NamespacedName, biosVersion); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	// TODO: Remove this migration in the next release once all CRs have been reconciled.
+	biosVersionBase := biosVersion.DeepCopy()
+	if migrateConditionTypes(biosVersion.Status.Conditions, legacyBIOSVersionConditionTypes) {
+		log.Info("Migrated legacy condition types on BIOSVersion")
+		if err := r.Status().Patch(ctx, biosVersion, client.MergeFrom(biosVersionBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
+		}
 	}
 	log.V(1).Info("Reconciling BIOSVersion")
 

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -38,6 +38,18 @@ const (
 	ReasonRebootPowerOn  = "RebootPowerOn"
 )
 
+// legacyBIOSVersionConditionTypes maps old condition type strings to their new values.
+// TODO: Remove this migration in the next release once all CRs have been reconciled.
+var legacyBIOSVersionConditionTypes = map[string]string{
+	"BIOSUpgradeIssued":        ConditionVersionUpgradeIssued,
+	"BIOSUpgradeCompleted":     ConditionVersionUpgradeCompleted,
+	"BIOSUpgradePowerOn":       ConditionUpgradePowerOn,
+	"BIOSUpgradePowerOff":      ConditionUpgradePowerOff,
+	"BIOSUpgradeVerification":  ConditionVersionUpgradeVerification,
+	"BIOSVersionUpdatePending": ConditionVersionUpdatePending,
+	"BMCResetIssued":           ConditionResetIssued,
+}
+
 type BIOSVersionReconciler struct {
 	client.Client
 	ManagerNamespace            string
@@ -64,6 +76,14 @@ func (r *BIOSVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	biosVersion := &metalv1alpha1.BIOSVersion{}
 	if err := r.Get(ctx, req.NamespacedName, biosVersion); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	// TODO: Remove this migration in the next release once all CRs have been reconciled.
+	biosVersionBase := biosVersion.DeepCopy()
+	if migrateConditionTypes(biosVersion.Status.Conditions, legacyBIOSVersionConditionTypes) {
+		log.Info("Migrated legacy condition types on BIOSVersion")
+		if err := r.Status().Patch(ctx, biosVersion, client.MergeFrom(biosVersionBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
+		}
 	}
 	log.V(1).Info("Reconciling BIOSVersion")
 

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -53,7 +53,9 @@ var legacyBIOSVersionConditionTypes = map[string]string{
 
 // legacyBIOSVersionConditionReasons maps old condition reason strings to their new values.
 var legacyBIOSVersionConditionReasons = map[string]string{
-	"BMCResetIssued": ReasonResetIssued,
+	"BMCResetIssued":                ReasonResetIssued,
+	"BIOSVersionVerified":           ReasonVersionUpdateVerified,
+	"BIOSVersionVerificationFailed": ReasonVersionVerificationFailed,
 }
 
 type BIOSVersionReconciler struct {
@@ -1062,7 +1064,12 @@ func (r *BIOSVersionReconciler) enqueueBiosSettingsByBMC(ctx context.Context, ob
 	reqs := make([]ctrl.Request, 0)
 	for _, biosVersion := range biosVersionList.Items {
 		if biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
-			resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionResetIssued)
+			// Normalize legacy condition types/reasons so unmigrated CRs are handled correctly.
+			conditions := biosVersion.Status.Conditions
+			migrateConditionTypes(conditions, legacyBIOSVersionConditionTypes)
+			migrateConditionReasons(conditions, legacyBIOSVersionConditionReasons)
+
+			resetBMC, err := GetCondition(r.Conditions, conditions, ConditionResetIssued)
 			if err != nil {
 				log.Error(err, "Failed to get reset BMC condition")
 				continue

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -28,6 +28,16 @@ import (
 )
 
 // BIOSVersionReconciler reconciles a BIOSVersion object
+const (
+	BIOSVersionFinalizer = "metal.ironcore.dev/biosversion"
+
+	ConditionUpgradePowerOn  = "VersionUpgradePowerOn"
+	ConditionUpgradePowerOff = "VersionUpgradePowerOff"
+
+	ReasonRebootPowerOff = "RebootPowerOff"
+	ReasonRebootPowerOn  = "RebootPowerOn"
+)
+
 type BIOSVersionReconciler struct {
 	client.Client
 	ManagerNamespace            string
@@ -39,25 +49,6 @@ type BIOSVersionReconciler struct {
 	Conditions                  *conditionutils.Accessor
 	DefaultFailedAutoRetryCount int32
 }
-
-const (
-	BIOSVersionFinalizer = "metal.ironcore.dev/biosversion"
-
-	ConditionBIOSUpgradeIssued       = "BIOSUpgradeIssued"
-	ConditionBIOSUpgradeCompleted    = "BIOSUpgradeCompleted"
-	ConditionBIOSUpgradePowerOn      = "BIOSUpgradePowerOn"
-	ConditionBIOSUpgradePowerOff     = "BIOSUpgradePowerOff"
-	ConditionBIOSUpgradeVerification = "BIOSUpgradeVerification"
-
-	ReasonUpgradeIssued           = "UpgradeIssued"
-	ReasonUpgradeIssueFailed      = "UpgradeIssueFailed"
-	ReasonRebootPowerOff          = "RebootPowerOff"
-	ReasonRebootPowerOn           = "RebootPowerOn"
-	ReasonBIOSVersionVerified     = "BIOSVersionVerified"
-	ReasonBIOSVersionVerification = "BIOSVersionVerificationFailed"
-	ReasonUpgradeTaskFailed       = "UpgradeTaskFailed"
-	ReasonUpgradeTaskCompleted    = "UpgradeTaskCompleted"
-)
 
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversions/status,verbs=get;update;patch
@@ -245,7 +236,7 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 		}
 	}
 
-	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ServerMaintenanceConditionWaiting)
+	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionServerMaintenanceWaiting)
 	if err != nil {
 		return false, err
 	}
@@ -256,7 +247,7 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+				conditionutils.UpdateReason(ReasonMaintenanceWaiting),
 				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", biosVersion.Spec.ServerMaintenanceRef.Name)),
 			); err != nil {
 				return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -274,7 +265,7 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+				conditionutils.UpdateReason(ReasonMaintenanceWaiting),
 				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", biosVersion.Spec.ServerMaintenanceRef.Name)),
 			); err != nil {
 				return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -286,11 +277,11 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 		return false, nil
 	}
 
-	if condition.Reason != ServerMaintenanceReasonApproved {
+	if condition.Reason != ReasonMaintenanceApproved {
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
+			conditionutils.UpdateReason(ReasonMaintenanceApproved),
 			conditionutils.UpdateMessage("Server is now in Maintenance mode"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -309,7 +300,7 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 
 func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcClient bmc.BMC, biosVersion *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	issuedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradeIssued)
+	issuedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionVersionUpgradeIssued)
 	if err != nil {
 		return false, err
 	}
@@ -331,7 +322,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 		return false, r.upgradeBIOSVersion(ctx, bmcClient, biosVersion, server, issuedCondition)
 	}
 
-	completedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted)
+	completedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionVersionUpgradeCompleted)
 	if err != nil {
 		return false, err
 	}
@@ -369,7 +360,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 		return requeue, err
 	}
 
-	rebootPowerOffCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradePowerOff)
+	rebootPowerOffCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionUpgradePowerOff)
 	if err != nil {
 		return false, err
 	}
@@ -393,7 +384,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 		return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, rebootPowerOffCondition)
 	}
 
-	rebootPowerOnCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradePowerOn)
+	rebootPowerOnCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionUpgradePowerOn)
 	if err != nil {
 		return false, err
 	}
@@ -417,7 +408,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 		return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, rebootPowerOnCondition)
 	}
 
-	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradeVerification)
+	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionVersionUpgradeVerification)
 	if err != nil {
 		return false, err
 	}
@@ -436,7 +427,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 				if err := r.Conditions.Update(
 					condition,
 					conditionutils.UpdateStatus(corev1.ConditionFalse),
-					conditionutils.UpdateReason(ReasonBIOSVersionVerification),
+					conditionutils.UpdateReason(ReasonVersionVerificationFailed),
 					conditionutils.UpdateMessage("waiting for BIOS Version update"),
 				); err != nil {
 					return false, fmt.Errorf("failed to update the verification condition: %w", err)
@@ -449,7 +440,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ReasonBIOSVersionVerified),
+			conditionutils.UpdateReason(ReasonVersionUpdateVerified),
 			conditionutils.UpdateMessage("BIOS Version updated"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update conditions: %w", err)
@@ -551,7 +542,7 @@ func (r *BIOSVersionReconciler) handleBMCReset(
 ) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	// reset BMC if not already done
-	resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, BMCConditionReset)
+	resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionResetIssued)
 	if err != nil {
 		return false, fmt.Errorf("failed to get condition for reset of BMC of server: %w", err)
 	}
@@ -559,13 +550,13 @@ func (r *BIOSVersionReconciler) handleBMCReset(
 	if resetBMC.Status != metav1.ConditionTrue {
 		// once the server is powered on, reset the BMC to make sure its in stable state
 		// this avoids problems with some BMCs that hang up in subsequent operations
-		if resetBMC.Reason != BMCReasonReset {
+		if resetBMC.Reason != ReasonResetIssued {
 			if err := resetBMCOfServer(ctx, r.Client, server, bmcClient); err == nil {
 				// mark reset to be issued, wait for next reconcile
 				if err := r.Conditions.Update(
 					resetBMC,
 					conditionutils.UpdateStatus(corev1.ConditionFalse),
-					conditionutils.UpdateReason(BMCReasonReset),
+					conditionutils.UpdateReason(ReasonResetIssued),
 					conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 				); err != nil {
 					return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -595,7 +586,7 @@ func (r *BIOSVersionReconciler) handleBMCReset(
 		if err := r.Conditions.Update(
 			resetBMC,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCReasonReset),
+			conditionutils.UpdateReason(ReasonResetIssued),
 			conditionutils.UpdateMessage("BMC reset to stabilize BMC of the server is completed"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -739,7 +730,7 @@ func (r *BIOSVersionReconciler) requestServerMaintenance(ctx context.Context, bi
 		} else if err != nil {
 			return false, fmt.Errorf("failed to verify ServerMaintenance existence: %w", err)
 		}
-		condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ServerMaintenanceConditionCreated)
+		condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionServerMaintenanceCreated)
 		if err != nil {
 			return false, err
 		}
@@ -749,7 +740,7 @@ func (r *BIOSVersionReconciler) requestServerMaintenance(ctx context.Context, bi
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ServerMaintenanceReasonCreated),
+			conditionutils.UpdateReason(ReasonMaintenanceCreated),
 			conditionutils.UpdateMessage(fmt.Sprintf("Created/Present %v at %v", biosVersion.Spec.ServerMaintenanceRef.Name, time.Now())),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -1041,7 +1032,7 @@ func (r *BIOSVersionReconciler) enqueueBiosSettingsByBMC(ctx context.Context, ob
 	reqs := make([]ctrl.Request, 0)
 	for _, biosVersion := range biosVersionList.Items {
 		if biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
-			resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, BMCConditionReset)
+			resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionResetIssued)
 			if err != nil {
 				log.Error(err, "Failed to get reset BMC condition")
 				continue
@@ -1050,7 +1041,7 @@ func (r *BIOSVersionReconciler) enqueueBiosSettingsByBMC(ctx context.Context, ob
 				continue
 			}
 			// enqueue only if the BMC reset is requested for this BMC
-			if resetBMC.Reason == BMCReasonReset {
+			if resetBMC.Reason == ReasonResetIssued {
 				reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: biosVersion.Namespace, Name: biosVersion.Name}})
 			}
 		}

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -51,6 +51,11 @@ var legacyBIOSVersionConditionTypes = map[string]string{
 	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
 }
 
+// legacyBIOSVersionConditionReasons maps old condition reason strings to their new values.
+var legacyBIOSVersionConditionReasons = map[string]string{
+	"BMCResetIssued": ReasonResetIssued,
+}
+
 type BIOSVersionReconciler struct {
 	client.Client
 	ManagerNamespace            string
@@ -80,8 +85,12 @@ func (r *BIOSVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	// TODO: Remove this migration in the next release once all CRs have been reconciled.
 	biosVersionBase := biosVersion.DeepCopy()
-	if migrateConditionTypes(biosVersion.Status.Conditions, legacyBIOSVersionConditionTypes) {
-		log.Info("Migrated legacy condition types on BIOSVersion")
+	migrated := migrateConditionTypes(biosVersion.Status.Conditions, legacyBIOSVersionConditionTypes)
+	if migrateConditionReasons(biosVersion.Status.Conditions, legacyBIOSVersionConditionReasons) {
+		migrated = true
+	}
+	if migrated {
+		log.Info("Migrated legacy conditions on BIOSVersion")
 		if err := r.Status().Patch(ctx, biosVersion, client.MergeFrom(biosVersionBase)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
 		}

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -28,6 +28,16 @@ import (
 )
 
 // BIOSVersionReconciler reconciles a BIOSVersion object
+const (
+	BIOSVersionFinalizer = "metal.ironcore.dev/biosversion"
+
+	ConditionUpgradePowerOn  = "VersionUpgradePowerOn"
+	ConditionUpgradePowerOff = "VersionUpgradePowerOff"
+
+	ReasonRebootPowerOff = "RebootPowerOff"
+	ReasonRebootPowerOn  = "RebootPowerOn"
+)
+
 type BIOSVersionReconciler struct {
 	client.Client
 	ManagerNamespace   string
@@ -38,25 +48,6 @@ type BIOSVersionReconciler struct {
 	ResyncInterval     time.Duration
 	Conditions         *conditionutils.Accessor
 }
-
-const (
-	BIOSVersionFinalizer = "metal.ironcore.dev/biosversion"
-
-	ConditionBIOSUpgradeIssued       = "BIOSUpgradeIssued"
-	ConditionBIOSUpgradeCompleted    = "BIOSUpgradeCompleted"
-	ConditionBIOSUpgradePowerOn      = "BIOSUpgradePowerOn"
-	ConditionBIOSUpgradePowerOff     = "BIOSUpgradePowerOff"
-	ConditionBIOSUpgradeVerification = "BIOSUpgradeVerification"
-
-	ReasonUpgradeIssued           = "UpgradeIssued"
-	ReasonUpgradeIssueFailed      = "UpgradeIssueFailed"
-	ReasonRebootPowerOff          = "RebootPowerOff"
-	ReasonRebootPowerOn           = "RebootPowerOn"
-	ReasonBIOSVersionVerified     = "BIOSVersionVerified"
-	ReasonBIOSVersionVerification = "BIOSVersionVerificationFailed"
-	ReasonUpgradeTaskFailed       = "UpgradeTaskFailed"
-	ReasonUpgradeTaskCompleted    = "UpgradeTaskCompleted"
-)
 
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversions/status,verbs=get;update;patch
@@ -247,7 +238,7 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 		}
 	}
 
-	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ServerMaintenanceConditionWaiting)
+	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionServerMaintenanceWaiting)
 	if err != nil {
 		return false, err
 	}
@@ -258,7 +249,7 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+				conditionutils.UpdateReason(ReasonMaintenanceWaiting),
 				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", biosVersion.Spec.ServerMaintenanceRef.Name)),
 			); err != nil {
 				return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -276,7 +267,7 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+				conditionutils.UpdateReason(ReasonMaintenanceWaiting),
 				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", biosVersion.Spec.ServerMaintenanceRef.Name)),
 			); err != nil {
 				return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -288,11 +279,11 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 		return false, nil
 	}
 
-	if condition.Reason != ServerMaintenanceReasonApproved {
+	if condition.Reason != ReasonMaintenanceApproved {
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
+			conditionutils.UpdateReason(ReasonMaintenanceApproved),
 			conditionutils.UpdateMessage("Server is now in Maintenance mode"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -311,7 +302,7 @@ func (r *BIOSVersionReconciler) handleServerMaintenance(ctx context.Context, bmc
 
 func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcClient bmc.BMC, biosVersion *metalv1alpha1.BIOSVersion, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	issuedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradeIssued)
+	issuedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionVersionUpgradeIssued)
 	if err != nil {
 		return false, err
 	}
@@ -333,7 +324,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 		return false, r.upgradeBIOSVersion(ctx, bmcClient, biosVersion, server, issuedCondition)
 	}
 
-	completedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted)
+	completedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionVersionUpgradeCompleted)
 	if err != nil {
 		return false, err
 	}
@@ -371,7 +362,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 		return requeue, err
 	}
 
-	rebootPowerOffCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradePowerOff)
+	rebootPowerOffCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionUpgradePowerOff)
 	if err != nil {
 		return false, err
 	}
@@ -395,7 +386,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 		return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, rebootPowerOffCondition)
 	}
 
-	rebootPowerOnCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradePowerOn)
+	rebootPowerOnCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionUpgradePowerOn)
 	if err != nil {
 		return false, err
 	}
@@ -419,7 +410,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 		return false, r.updateStatus(ctx, biosVersion, biosVersion.Status.State, biosVersion.Status.UpgradeTask, rebootPowerOnCondition)
 	}
 
-	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionBIOSUpgradeVerification)
+	condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionVersionUpgradeVerification)
 	if err != nil {
 		return false, err
 	}
@@ -438,7 +429,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 				if err := r.Conditions.Update(
 					condition,
 					conditionutils.UpdateStatus(corev1.ConditionFalse),
-					conditionutils.UpdateReason(ReasonBIOSVersionVerification),
+					conditionutils.UpdateReason(ReasonVersionVerificationFailed),
 					conditionutils.UpdateMessage("waiting for BIOS Version update"),
 				); err != nil {
 					return false, fmt.Errorf("failed to update the verification condition: %w", err)
@@ -451,7 +442,7 @@ func (r *BIOSVersionReconciler) processInProgressState(ctx context.Context, bmcC
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ReasonBIOSVersionVerified),
+			conditionutils.UpdateReason(ReasonVersionUpdateVerified),
 			conditionutils.UpdateMessage("BIOS Version updated"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update conditions: %w", err)
@@ -472,7 +463,7 @@ func (r *BIOSVersionReconciler) handleBMCReset(
 ) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	// reset BMC if not already done
-	resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, BMCConditionReset)
+	resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionResetIssued)
 	if err != nil {
 		return false, fmt.Errorf("failed to get condition for reset of BMC of server: %w", err)
 	}
@@ -480,13 +471,13 @@ func (r *BIOSVersionReconciler) handleBMCReset(
 	if resetBMC.Status != metav1.ConditionTrue {
 		// once the server is powered on, reset the BMC to make sure its in stable state
 		// this avoids problems with some BMCs that hang up in subsequent operations
-		if resetBMC.Reason != BMCReasonReset {
+		if resetBMC.Reason != ReasonResetIssued {
 			if err := resetBMCOfServer(ctx, r.Client, server, bmcClient); err == nil {
 				// mark reset to be issued, wait for next reconcile
 				if err := r.Conditions.Update(
 					resetBMC,
 					conditionutils.UpdateStatus(corev1.ConditionFalse),
-					conditionutils.UpdateReason(BMCReasonReset),
+					conditionutils.UpdateReason(ReasonResetIssued),
 					conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 				); err != nil {
 					return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -516,7 +507,7 @@ func (r *BIOSVersionReconciler) handleBMCReset(
 		if err := r.Conditions.Update(
 			resetBMC,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCReasonReset),
+			conditionutils.UpdateReason(ReasonResetIssued),
 			conditionutils.UpdateMessage("BMC reset to stabilize BMC of the server is completed"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -652,7 +643,7 @@ func (r *BIOSVersionReconciler) requestServerMaintenance(ctx context.Context, bi
 		} else if err != nil {
 			return false, fmt.Errorf("failed to verify ServerMaintenance existence: %w", err)
 		}
-		condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ServerMaintenanceConditionCreated)
+		condition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionServerMaintenanceCreated)
 		if err != nil {
 			return false, err
 		}
@@ -662,7 +653,7 @@ func (r *BIOSVersionReconciler) requestServerMaintenance(ctx context.Context, bi
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ServerMaintenanceReasonCreated),
+			conditionutils.UpdateReason(ReasonMaintenanceCreated),
 			conditionutils.UpdateMessage(fmt.Sprintf("Created/Present %v at %v", biosVersion.Spec.ServerMaintenanceRef.Name, time.Now())),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -954,7 +945,7 @@ func (r *BIOSVersionReconciler) enqueueBiosSettingsByBMC(ctx context.Context, ob
 	reqs := make([]ctrl.Request, 0)
 	for _, biosVersion := range biosVersionList.Items {
 		if biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
-			resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, BMCConditionReset)
+			resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionResetIssued)
 			if err != nil {
 				log.Error(err, "Failed to get reset BMC condition")
 				continue
@@ -963,7 +954,7 @@ func (r *BIOSVersionReconciler) enqueueBiosSettingsByBMC(ctx context.Context, ob
 				continue
 			}
 			// enqueue only if the BMC reset is requested for this BMC
-			if resetBMC.Reason == BMCReasonReset {
+			if resetBMC.Reason == ReasonResetIssued {
 				reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: biosVersion.Namespace, Name: biosVersion.Name}})
 			}
 		}

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -41,13 +41,14 @@ const (
 // legacyBIOSVersionConditionTypes maps old condition type strings to their new values.
 // TODO: Remove this migration in the next release once all CRs have been reconciled.
 var legacyBIOSVersionConditionTypes = map[string]string{
-	"BIOSUpgradeIssued":        ConditionVersionUpgradeIssued,
-	"BIOSUpgradeCompleted":     ConditionVersionUpgradeCompleted,
-	"BIOSUpgradePowerOn":       ConditionUpgradePowerOn,
-	"BIOSUpgradePowerOff":      ConditionUpgradePowerOff,
-	"BIOSUpgradeVerification":  ConditionVersionUpgradeVerification,
-	"BIOSVersionUpdatePending": ConditionVersionUpdatePending,
-	"BMCResetIssued":           ConditionResetIssued,
+	"BIOSUpgradeIssued":                    ConditionVersionUpgradeIssued,
+	"BIOSUpgradeCompleted":                 ConditionVersionUpgradeCompleted,
+	"BIOSUpgradePowerOn":                   ConditionUpgradePowerOn,
+	"BIOSUpgradePowerOff":                  ConditionUpgradePowerOff,
+	"BIOSUpgradeVerification":              ConditionVersionUpgradeVerification,
+	"BIOSVersionUpdatePending":             ConditionVersionUpdatePending,
+	"BMCResetIssued":                       ConditionResetIssued,
+	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
 }
 
 type BIOSVersionReconciler struct {
@@ -482,7 +483,7 @@ func (r *BIOSVersionReconciler) processFailedState(ctx context.Context, biosVers
 		biosVersion.Status.State = metalv1alpha1.BIOSVersionStatePending
 		biosVersion.Status.ObservedGeneration = biosVersion.Generation
 		annotations := biosVersion.GetAnnotations()
-		retryCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, RetryOfFailedResourceConditionIssued)
+		retryCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionRetryOfFailedResourceIssued)
 		if err != nil {
 			return true, fmt.Errorf("failed to get retry condition for BIOSVersion: %w", err)
 		}
@@ -490,7 +491,7 @@ func (r *BIOSVersionReconciler) processFailedState(ctx context.Context, biosVers
 		if retryCondition.Status != metav1.ConditionTrue {
 			err := r.Conditions.Update(retryCondition,
 				conditionutils.UpdateStatus(metav1.ConditionTrue),
-				conditionutils.UpdateReason(RetryOfFailedResourceReasonIssued),
+				conditionutils.UpdateReason(ReasonRetryOfFailedResourceIssued),
 				conditionutils.UpdateMessage(annotations[metalv1alpha1.OperationAnnotation]),
 			)
 			if err != nil {
@@ -521,7 +522,7 @@ func (r *BIOSVersionReconciler) processFailedState(ctx context.Context, biosVers
 			biosVersionBase := biosVersion.DeepCopy()
 			biosVersion.Status.State = metalv1alpha1.BIOSVersionStatePending
 			biosVersion.Status.ObservedGeneration = biosVersion.Generation
-			retryCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, RetryOfFailedResourceConditionIssued)
+			retryCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionRetryOfFailedResourceIssued)
 			if err != nil {
 				return true, fmt.Errorf("failed to get Retry condition for BIOSVersion: %w", err)
 			}
@@ -640,7 +641,7 @@ func (r *BIOSVersionReconciler) cleanup(ctx context.Context, bmcClient bmc.BMC, 
 		log.V(1).Info("Upgraded BIOS version", "Version", currentBiosVersion, "Server", server.Name)
 		return r.updateStatus(ctx, biosVersion, metalv1alpha1.BIOSVersionStateCompleted, nil, nil)
 	}
-	retryFailedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, RetryOfFailedResourceConditionIssued)
+	retryFailedCondition, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionRetryOfFailedResourceIssued)
 	if err != nil {
 		return fmt.Errorf("failed to get retry condition for BIOSVersion: %w", err)
 	}

--- a/internal/controller/biosversion_controller_test.go
+++ b/internal/controller/biosversion_controller_test.go
@@ -558,7 +558,7 @@ func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVers
 	Eventually(
 		func(g Gomega) bool {
 			g.Expect(Get(biosVersion)()).To(Succeed())
-			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeIssued, condIssue)).To(BeTrue())
+			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionVersionUpgradeIssued, condIssue)).To(BeTrue())
 			return condIssue.Status == metav1.ConditionTrue
 		}).Should(BeTrue())
 
@@ -579,7 +579,7 @@ func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVers
 	Eventually(
 		func(g Gomega) bool {
 			g.Expect(Get(biosVersion)()).To(Succeed())
-			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted, condComplete)).To(BeTrue())
+			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionVersionUpgradeCompleted, condComplete)).To(BeTrue())
 			return condComplete.Status == metav1.ConditionTrue
 		}).Should(BeTrue())
 
@@ -600,7 +600,7 @@ func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVers
 	Eventually(
 		func(g Gomega) bool {
 			g.Expect(Get(biosVersion)()).To(Succeed())
-			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted, rebootStart)).To(BeTrue())
+			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionVersionUpgradeCompleted, rebootStart)).To(BeTrue())
 			return rebootStart.Status == metav1.ConditionTrue
 		}).Should(BeTrue())
 
@@ -619,7 +619,7 @@ func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVers
 	}).Should(BeNumerically(">=", 4))
 	Eventually(func(g Gomega) bool {
 		g.Expect(Get(biosVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted, rebootComplete)).To(BeTrue())
+		g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionVersionUpgradeCompleted, rebootComplete)).To(BeTrue())
 		return rebootComplete.Status == metav1.ConditionTrue
 	}).Should(BeTrue())
 
@@ -631,7 +631,7 @@ func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVers
 	}).Should(BeNumerically(">=", 5))
 	Eventually(func(g Gomega) bool {
 		g.Expect(Get(biosVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeVerification, verificationComplete)).To(BeTrue())
+		g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionVersionUpgradeVerification, verificationComplete)).To(BeTrue())
 		return verificationComplete.Status == metav1.ConditionTrue
 	}).Should(BeTrue())
 }

--- a/internal/controller/biosversion_controller_test.go
+++ b/internal/controller/biosversion_controller_test.go
@@ -586,7 +586,7 @@ func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVers
 	Eventually(
 		func(g Gomega) bool {
 			g.Expect(Get(biosVersion)()).To(Succeed())
-			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeIssued, condIssue)).To(BeTrue())
+			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionVersionUpgradeIssued, condIssue)).To(BeTrue())
 			return condIssue.Status == metav1.ConditionTrue
 		}).Should(BeTrue())
 
@@ -607,7 +607,7 @@ func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVers
 	Eventually(
 		func(g Gomega) bool {
 			g.Expect(Get(biosVersion)()).To(Succeed())
-			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted, condComplete)).To(BeTrue())
+			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionVersionUpgradeCompleted, condComplete)).To(BeTrue())
 			return condComplete.Status == metav1.ConditionTrue
 		}).Should(BeTrue())
 
@@ -628,7 +628,7 @@ func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVers
 	Eventually(
 		func(g Gomega) bool {
 			g.Expect(Get(biosVersion)()).To(Succeed())
-			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted, rebootStart)).To(BeTrue())
+			g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionVersionUpgradeCompleted, rebootStart)).To(BeTrue())
 			return rebootStart.Status == metav1.ConditionTrue
 		}).Should(BeTrue())
 
@@ -647,7 +647,7 @@ func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVers
 	}).Should(BeNumerically(">=", 4))
 	Eventually(func(g Gomega) bool {
 		g.Expect(Get(biosVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeCompleted, rebootComplete)).To(BeTrue())
+		g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionVersionUpgradeCompleted, rebootComplete)).To(BeTrue())
 		return rebootComplete.Status == metav1.ConditionTrue
 	}).Should(BeTrue())
 
@@ -659,7 +659,7 @@ func ensureBiosVersionConditionTransition(acc *conditionutils.Accessor, biosVers
 	}).Should(BeNumerically(">=", 5))
 	Eventually(func(g Gomega) bool {
 		g.Expect(Get(biosVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionBIOSUpgradeVerification, verificationComplete)).To(BeTrue())
+		g.Expect(acc.FindSlice(biosVersion.Status.Conditions, ConditionVersionUpgradeVerification, verificationComplete)).To(BeTrue())
 		return verificationComplete.Status == metav1.ConditionTrue
 	}).Should(BeTrue())
 }

--- a/internal/controller/biosversionset_controller.go
+++ b/internal/controller/biosversionset_controller.go
@@ -25,7 +25,9 @@ import (
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 )
 
-const BIOSVersionSetFinalizer = "metal.ironcore.dev/biosversionset"
+const (
+	BIOSVersionSetFinalizer = "metal.ironcore.dev/biosversionset"
+)
 
 // BIOSVersionSetReconciler reconciles a BIOSVersionSet object
 type BIOSVersionSetReconciler struct {

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -38,17 +38,6 @@ import (
 const (
 	BMCFinalizer = "metal.ironcore.dev/bmc"
 
-	bmcResetConditionType = "Reset"
-	bmcReadyConditionType = "Ready"
-
-	bmcAuthenticationFailedReason = "AuthenticationFailed"
-	bmcInternalErrorReason        = "InternalServerError"
-	bmcUnknownErrorReason         = "UnknownError"
-	bmcConnectionFailedReason     = "ConnectionFailed"
-	bmcUserResetReason            = "UserRequested"
-	bmcAutoResetReason            = "AutoResetting"
-	bmcConnectedReason            = "BMCConnected"
-
 	bmcUserResetMessage = "BMC reset initiated by user. Waiting for it to come back online."
 	bmcAutoResetMessage = "BMC reset initiated automatically after repeated connection failures. Waiting for it to come back online."
 )
@@ -147,7 +136,7 @@ func (r *BMCReconciler) reconcile(ctx context.Context, bmcObj *metalv1alpha1.BMC
 	if err != nil {
 		if r.shouldResetBMC(bmcObj) {
 			log.V(1).Info("BMC needs reset, resetting", "BMC", bmcObj.Name)
-			if err := r.resetBMC(ctx, bmcObj, bmcClient, bmcAutoResetReason, bmcAutoResetMessage); err != nil {
+			if err := r.resetBMC(ctx, bmcObj, bmcClient, ReasonAutoReset, bmcAutoResetMessage); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to reset BMC: %w", err)
 			}
 			log.V(1).Info("BMC reset initiated", "BMC", bmcObj.Name)
@@ -171,10 +160,10 @@ func (r *BMCReconciler) reconcile(ctx context.Context, bmcObj *metalv1alpha1.BMC
 		return ctrl.Result{}, err
 	}
 
-	if err := r.updateConditions(ctx, bmcObj, true, bmcReadyConditionType, corev1.ConditionTrue, bmcConnectedReason, "BMC is connected"); err != nil {
+	if err := r.updateConditions(ctx, bmcObj, true, ConditionReady, corev1.ConditionTrue, ReasonConnected, "BMC is connected"); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set BMC connected condition: %w", err)
 	}
-	if err := r.updateConditions(ctx, bmcObj, false, bmcResetConditionType, corev1.ConditionFalse, "ResetComplete", "BMC reset is complete"); err != nil {
+	if err := r.updateConditions(ctx, bmcObj, false, ConditionReset, corev1.ConditionFalse, "ResetComplete", "BMC reset is complete"); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set BMC reset complete condition: %w", err)
 	}
 
@@ -380,7 +369,7 @@ func (r *BMCReconciler) handleAnnotationOperations(ctx context.Context, bmcObj *
 	switch value {
 	case schemas.GracefulRestartResetType:
 		log.V(1).Info("Handling operation", "Operation", operation, "RedfishResetType", value)
-		if err := r.resetBMC(ctx, bmcObj, bmcClient, bmcUserResetReason, bmcUserResetMessage); err != nil {
+		if err := r.resetBMC(ctx, bmcObj, bmcClient, ReasonUserReset, bmcUserResetMessage); err != nil {
 			return false, fmt.Errorf("failed to reset BMC: %w", err)
 		}
 		log.Info("Handled operation", "Operation", operation)
@@ -404,27 +393,27 @@ func (r *BMCReconciler) updateReadyConditionOnBMCFailure(ctx context.Context, bm
 		switch httpErr.HTTPReturnedStatusCode {
 		case 401:
 			// Unauthorized error, likely due to bad credentials
-			if err := r.updateConditions(ctx, bmcObj, true, bmcReadyConditionType, corev1.ConditionFalse, bmcAuthenticationFailedReason, "BMC credentials are invalid"); err != nil {
+			if err := r.updateConditions(ctx, bmcObj, true, ConditionReady, corev1.ConditionFalse, ReasonAuthenticationFailed, "BMC credentials are invalid"); err != nil {
 				return fmt.Errorf("failed to set BMC unauthorized condition: %w", err)
 			}
 
 		case 500:
 			// Internal Server Error, might be transient
-			if err := r.updateConditions(ctx, bmcObj, true, bmcReadyConditionType, corev1.ConditionFalse, bmcInternalErrorReason, "BMC internal server error"); err != nil {
+			if err := r.updateConditions(ctx, bmcObj, true, ConditionReady, corev1.ConditionFalse, ReasonInternalError, "BMC internal server error"); err != nil {
 				return fmt.Errorf("failed to set BMC internal server error condition: %w", err)
 			}
 		case 503:
 			// Service Unavailable, might be transient
-			if err := r.updateConditions(ctx, bmcObj, true, bmcReadyConditionType, corev1.ConditionFalse, bmcConnectionFailedReason, "BMC service unavailable"); err != nil {
+			if err := r.updateConditions(ctx, bmcObj, true, ConditionReady, corev1.ConditionFalse, ReasonConnectionFailed, "BMC service unavailable"); err != nil {
 				return fmt.Errorf("failed to set BMC service unavailable condition: %w", err)
 			}
 		default:
-			if err := r.updateConditions(ctx, bmcObj, true, bmcReadyConditionType, corev1.ConditionFalse, bmcUnknownErrorReason, fmt.Sprintf("BMC connection error: %v", err)); err != nil {
+			if err := r.updateConditions(ctx, bmcObj, true, ConditionReady, corev1.ConditionFalse, ReasonUnknownError, fmt.Sprintf("BMC connection error: %v", err)); err != nil {
 				return fmt.Errorf("failed to set BMC error condition: %w", err)
 			}
 		}
 	} else {
-		if err := r.updateConditions(ctx, bmcObj, true, bmcReadyConditionType, corev1.ConditionFalse, bmcUnknownErrorReason, fmt.Sprintf("BMC connection error: %v", err)); err != nil {
+		if err := r.updateConditions(ctx, bmcObj, true, ConditionReady, corev1.ConditionFalse, ReasonUnknownError, fmt.Sprintf("BMC connection error: %v", err)); err != nil {
 			return fmt.Errorf("failed to set BMC error condition: %w", err)
 		}
 	}
@@ -433,7 +422,7 @@ func (r *BMCReconciler) updateReadyConditionOnBMCFailure(ctx context.Context, bm
 
 func (r *BMCReconciler) waitForBMCReset(bmcObj *metalv1alpha1.BMC, delay time.Duration) bool {
 	condition := &metav1.Condition{}
-	found, err := r.Conditions.FindSlice(bmcObj.Status.Conditions, bmcResetConditionType, condition)
+	found, err := r.Conditions.FindSlice(bmcObj.Status.Conditions, ConditionReset, condition)
 	if err != nil || !found {
 		return false
 	}
@@ -449,7 +438,7 @@ func (r *BMCReconciler) waitForBMCReset(bmcObj *metalv1alpha1.BMC, delay time.Du
 func (r *BMCReconciler) handlePreviousBMCResetAnnotations(ctx context.Context, bmcObj *metalv1alpha1.BMC) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	condition := &metav1.Condition{}
-	found, err := r.Conditions.FindSlice(bmcObj.Status.Conditions, bmcResetConditionType, condition)
+	found, err := r.Conditions.FindSlice(bmcObj.Status.Conditions, ConditionReset, condition)
 	if err != nil || !found {
 		return false, nil
 	}
@@ -472,16 +461,16 @@ func (r *BMCReconciler) shouldResetBMC(bmcObj *metalv1alpha1.BMC) bool {
 		return false
 	}
 	bmcResetCondition := &metav1.Condition{}
-	found, err := r.Conditions.FindSlice(bmcObj.Status.Conditions, bmcResetConditionType, bmcResetCondition)
+	found, err := r.Conditions.FindSlice(bmcObj.Status.Conditions, ConditionReset, bmcResetCondition)
 	if err != nil || (found && bmcResetCondition.Status == metav1.ConditionTrue) {
 		return false
 	}
 	readyCondition := &metav1.Condition{}
-	found, err = r.Conditions.FindSlice(bmcObj.Status.Conditions, bmcReadyConditionType, readyCondition)
+	found, err = r.Conditions.FindSlice(bmcObj.Status.Conditions, ConditionReady, readyCondition)
 	if err != nil || !found {
 		return false
 	}
-	if readyCondition.Status == metav1.ConditionFalse && (readyCondition.Reason == bmcInternalErrorReason || readyCondition.Reason == bmcConnectionFailedReason) {
+	if readyCondition.Status == metav1.ConditionFalse && (readyCondition.Reason == ReasonInternalError || readyCondition.Reason == ReasonConnectionFailed) {
 		if time.Since(readyCondition.LastTransitionTime.Time) > r.BMCFailureResetDelay {
 			return true
 		}
@@ -503,7 +492,7 @@ func (r *BMCReconciler) updateBMCState(ctx context.Context, bmcObj *metalv1alpha
 
 func (r *BMCReconciler) resetBMC(ctx context.Context, bmcObj *metalv1alpha1.BMC, bmcClient bmc.BMC, reason, message string) error {
 	log := ctrl.LoggerFrom(ctx)
-	if err := r.updateConditions(ctx, bmcObj, true, bmcResetConditionType, corev1.ConditionTrue, reason, message); err != nil {
+	if err := r.updateConditions(ctx, bmcObj, true, ConditionReset, corev1.ConditionTrue, reason, message); err != nil {
 		return fmt.Errorf("failed to set BMC resetting condition: %w", err)
 	}
 	var err error

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -42,6 +42,12 @@ const (
 	bmcAutoResetMessage = "BMC reset initiated automatically after repeated connection failures. Waiting for it to come back online."
 )
 
+// legacyBMCConditionReasons maps old condition reason strings to their new values.
+// TODO: Remove this migration in the next release once all CRs have been reconciled.
+var legacyBMCConditionReasons = map[string]string{
+	"BMCConnected": ReasonConnected,
+}
+
 // BMCReconciler reconciles a BMC object
 type BMCReconciler struct {
 	client.Client
@@ -74,6 +80,15 @@ func (r *BMCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	bmcObj := &metalv1alpha1.BMC{}
 	if err := r.Get(ctx, req.NamespacedName, bmcObj); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	// TODO: Remove this migration in the next release once all CRs have been reconciled.
+	bmcBase := bmcObj.DeepCopy()
+	if migrateConditionReasons(bmcObj.Status.Conditions, legacyBMCConditionReasons) {
+		log := ctrl.LoggerFrom(ctx)
+		log.Info("Migrated legacy condition reasons on BMC")
+		if err := r.Status().Patch(ctx, bmcObj, client.MergeFrom(bmcBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
+		}
 	}
 
 	return r.reconcileExists(ctx, bmcObj)

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -625,7 +625,7 @@ var _ = Describe("BMC Conditions", func() {
 		Eventually(Object(bmc)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", bmcReadyConditionType),
+					HaveField("Type", ConditionReady),
 					HaveField("Status", metav1.ConditionFalse),
 				),
 			)),
@@ -640,7 +640,7 @@ var _ = Describe("BMC Conditions", func() {
 		Eventually(Object(bmc)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", bmcReadyConditionType),
+					HaveField("Type", ConditionReady),
 					HaveField("Status", metav1.ConditionTrue),
 				),
 			)),
@@ -659,9 +659,9 @@ var _ = Describe("BMC Conditions", func() {
 			HaveField("Status.Conditions", HaveLen(2)),
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", bmcResetConditionType),
+					HaveField("Type", ConditionReset),
 					HaveField("Status", metav1.ConditionTrue),
-					HaveField("Reason", bmcUserResetReason),
+					HaveField("Reason", ReasonUserReset),
 				),
 			)),
 		))
@@ -673,7 +673,7 @@ var _ = Describe("BMC Conditions", func() {
 		Eventually(Object(bmc)).Should(
 			HaveField("Status.Conditions", ContainElement(
 				SatisfyAll(
-					HaveField("Type", bmcResetConditionType),
+					HaveField("Type", ConditionReset),
 					HaveField("Status", metav1.ConditionFalse),
 					HaveField("Reason", "ResetComplete"),
 				),

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -44,18 +44,18 @@ type BMCSettingsReconciler struct {
 const (
 	BMCSettingFinalizer = "metal.ironcore.dev/bmcsettings"
 
-	ConditionBMCResetPostSettingApply   = "ResetPostSettingApply"
-	ConditionBMCPoweredOff              = "PoweredOff"
-	ConditionBMCSettingsChangesIssued   = "ChangesIssued"
-	ConditionBMCSettingsChangesVerified = "ChangesVerified"
-	ConditionBMCSettingsWrongSettings   = "SettingsProvidedNotValid"
+	ConditionBMCResetPostSettingApply    = "ResetPostSettingApply"
+	ConditionBMCPoweredOff               = "PoweredOff"
+	ConditionBMCSettingsChangesIssued    = "ChangesIssued"
+	ConditionBMCSettingsChangesVerified  = "ChangesVerified"
+	ConditionBMCSettingsValidationFailed = "SettingsValidationFailed"
 
-	ReasonBMCPoweredOff                    = "PoweredOff"
-	ReasonBMCVersionMatching               = "VersionMatching"
-	ReasonBMCSettingsChangesIssued         = "ChangesIssued"
-	ReasonBMCSettingsChangesVerified       = "ChangesVerified"
-	ReasonBMCSettingsChangesNotYetVerified = "ChangesNotYetVerified"
-	ReasonBMCSettingsWrongSettings         = "SettingsProvidedAreNotValid"
+	ReasonBMCPoweredOff                  = "PoweredOff"
+	ReasonBMCVersionMatching             = "VersionMatching"
+	ReasonBMCSettingsChangesIssued       = "ChangesIssued"
+	ReasonBMCSettingsChangesVerified     = "ChangesVerified"
+	ReasonBMCSettingsVerificationPending = "SettingsVerificationPending"
+	ReasonBMCSettingsValidationFailed    = "SettingsValidationFailed"
 )
 
 // legacyBMCSettingsConditionTypes maps old condition type strings to their new values.
@@ -434,14 +434,14 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 				log.Error(err, "could not validate settings and determine if reboot needed")
 				var invalidSettingsErr *bmc.InvalidBMCSettingsError
 				if errors.As(err, &invalidSettingsErr) {
-					inValidSettings, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsWrongSettings)
+					inValidSettings, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsValidationFailed)
 					if errCond != nil {
 						return ctrl.Result{}, fmt.Errorf("failed to get Condition for invalid BMC settings %v", errors.Join(err, errCond))
 					}
 					if errCond := r.Conditions.Update(
 						inValidSettings,
 						conditionutils.UpdateStatus(corev1.ConditionTrue),
-						conditionutils.UpdateReason(ReasonBMCSettingsWrongSettings),
+						conditionutils.UpdateReason(ReasonBMCSettingsValidationFailed),
 						conditionutils.UpdateMessage(fmt.Sprintf("Settings provided is invalid. error: %v", err)),
 					); errCond != nil {
 						return ctrl.Result{}, fmt.Errorf("failed to update Invalid Settings condition: %w", errors.Join(err, errCond))
@@ -506,11 +506,11 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 		return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, metalv1alpha1.BMCSettingsStateApplied, BMCSettingsVerifiedCondition)
 	}
 
-	if BMCSettingsVerifiedCondition.Status == metav1.ConditionFalse && BMCSettingsVerifiedCondition.Reason != ReasonBMCSettingsChangesNotYetVerified {
+	if BMCSettingsVerifiedCondition.Status == metav1.ConditionFalse && BMCSettingsVerifiedCondition.Reason != ReasonBMCSettingsVerificationPending {
 		if err := r.Conditions.Update(
 			BMCSettingsVerifiedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(ReasonBMCSettingsChangesNotYetVerified),
+			conditionutils.UpdateReason(ReasonBMCSettingsVerificationPending),
 			conditionutils.UpdateMessage("BMC Settings changes are not yet verified on the server's BMC"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings verified condition: %w", err)

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -42,21 +42,20 @@ type BMCSettingsReconciler struct {
 }
 
 const (
-	BMCSettingFinalizer               = "metal.ironcore.dev/bmcsettings"
-	BMCResetPostSettingApplyCondition = "ResetPostSettingApply"
-	BMCPoweredOffCondition            = "PoweredOff"
-	BMCPoweredOffReason               = "PoweredOff"
-	BMCVersionUpdatePendingCondition  = "VersionUpdatePending"
-	BMCVersionUpgradePendingReason    = "VersionUpgradePending"
-	BMCVersionMatchingReason          = "VersionMatching"
+	BMCSettingFinalizer = "metal.ironcore.dev/bmcsettings"
 
-	BMCSettingsChangesIssuedCondition      = "ChangesIssued"
-	BMCSettingsChangesIssuedReason         = "ChangesIssued"
-	BMCSettingsChangesVerifiedCondition    = "ChangesVerified"
-	BMCSettingsChangesVerifiedReason       = "ChangesVerified"
-	BMCSettingsChangesNotYetVerifiedReason = "ChangesNotYetVerified"
-	BMCSettingsConditionWrongSettings      = "SettingsProvidedNotValid"
-	BMCSettingsReasonWrongSettings         = "SettingsProvidedAreNotValid"
+	ConditionBMCResetPostSettingApply   = "ResetPostSettingApply"
+	ConditionBMCPoweredOff              = "PoweredOff"
+	ConditionBMCSettingsChangesIssued   = "ChangesIssued"
+	ConditionBMCSettingsChangesVerified = "ChangesVerified"
+	ConditionBMCSettingsWrongSettings   = "SettingsProvidedNotValid"
+
+	ReasonBMCPoweredOff                    = "PoweredOff"
+	ReasonBMCVersionMatching               = "VersionMatching"
+	ReasonBMCSettingsChangesIssued         = "ChangesIssued"
+	ReasonBMCSettingsChangesVerified       = "ChangesVerified"
+	ReasonBMCSettingsChangesNotYetVerified = "ChangesNotYetVerified"
+	ReasonBMCSettingsWrongSettings         = "SettingsProvidedAreNotValid"
 )
 
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings,verbs=get;list;watch;create;update;patch;delete
@@ -293,7 +292,7 @@ func (r *BMCSettingsReconciler) ensureBMCSettingsMaintenanceStateTransition(ctx 
 			return ctrl.Result{}, nil
 		}
 		var state = metalv1alpha1.BMCSettingsStateInProgress
-		versionCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCVersionUpdatePendingCondition)
+		versionCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionVersionUpdatePending)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for pending BMCVersion update state: %w", err)
 		}
@@ -302,7 +301,7 @@ func (r *BMCSettingsReconciler) ensureBMCSettingsMaintenanceStateTransition(ctx 
 			if err := r.Conditions.Update(
 				versionCheckCondition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BMCVersionUpgradePendingReason),
+				conditionutils.UpdateReason(ReasonVersionUpgradePending),
 				conditionutils.UpdateMessage(fmt.Sprintf("Waiting to update BMCVersion: %v, current BMCVersion: %v", settings.Spec.Version, bmcObj.Status.FirmwareVersion)),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update Pending BMCVersion update condition: %w", err)
@@ -312,7 +311,7 @@ func (r *BMCSettingsReconciler) ensureBMCSettingsMaintenanceStateTransition(ctx 
 			if err := r.Conditions.Update(
 				versionCheckCondition,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(BMCVersionMatchingReason),
+				conditionutils.UpdateReason(ReasonBMCVersionMatching),
 				conditionutils.UpdateMessage(fmt.Sprintf("BMCVersion matches: %v", settings.Spec.Version)),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update Pending BMCVersion update condition: %w", err)
@@ -346,7 +345,7 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 		return ctrl.Result{}, err
 	}
 
-	condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ServerMaintenanceConditionWaiting)
+	condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionServerMaintenanceWaiting)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -361,7 +360,7 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+				conditionutils.UpdateReason(ReasonMaintenanceWaiting),
 				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", settings.Spec.ServerMaintenanceRefs)),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -374,11 +373,11 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 	}
 
 	// Once in maintenance, clear the waiting condition if present
-	if condition.Reason != ServerMaintenanceReasonApproved {
+	if condition.Reason != ReasonMaintenanceApproved {
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
+			conditionutils.UpdateReason(ReasonMaintenanceApproved),
 			conditionutils.UpdateMessage("Server is now in Maintenance mode"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -390,7 +389,7 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 	}
 
 	// Reset the BMC to ensure it's in a stable state before proceeding
-	if ok, err := r.handleBMCReset(ctx, settings, bmcObj, BMCConditionReset); !ok || err != nil {
+	if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionResetIssued); !ok || err != nil {
 		return ctrl.Result{}, err
 	}
 	return r.updateSettingsAndVerify(ctx, settings, bmcObj, settingsDiff, bmcClient)
@@ -398,12 +397,12 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 
 func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, settings *metalv1alpha1.BMCSettings, bmcObj *metalv1alpha1.BMC, settingsDiff schemas.SettingsAttributes, bmcClient bmc.BMC) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	resetBMC, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCResetPostSettingApplyCondition)
+	resetBMC, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get condition for reset of BMC of server: %w", err)
 	}
 
-	if resetBMC.Reason != BMCReasonReset {
+	if resetBMC.Reason != ReasonResetIssued {
 		// apply the BMC Settings if not done.
 		if ok, err := r.handleBMCPowerState(ctx, bmcObj, settings); err != nil || ok {
 			return ctrl.Result{}, err
@@ -420,14 +419,14 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 				log.Error(err, "could not validate settings and determine if reboot needed")
 				var invalidSettingsErr *bmc.InvalidBMCSettingsError
 				if errors.As(err, &invalidSettingsErr) {
-					inValidSettings, errCond := GetCondition(r.Conditions, settings.Status.Conditions, BMCSettingsConditionWrongSettings)
+					inValidSettings, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsWrongSettings)
 					if errCond != nil {
 						return ctrl.Result{}, fmt.Errorf("failed to get Condition for invalid BMC settings %v", errors.Join(err, errCond))
 					}
 					if errCond := r.Conditions.Update(
 						inValidSettings,
 						conditionutils.UpdateStatus(corev1.ConditionTrue),
-						conditionutils.UpdateReason(BMCSettingsReasonWrongSettings),
+						conditionutils.UpdateReason(ReasonBMCSettingsWrongSettings),
 						conditionutils.UpdateMessage(fmt.Sprintf("Settings provided is invalid. error: %v", err)),
 					); errCond != nil {
 						return ctrl.Result{}, fmt.Errorf("failed to update Invalid Settings condition: %w", errors.Join(err, errCond))
@@ -444,14 +443,14 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 			}
 			log.V(1).Info("BMC settings issued successfully", "SettingKeys", settingKeys(settingsDiff))
 
-			BMCSettingsAppliedCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCSettingsChangesIssuedCondition)
+			BMCSettingsAppliedCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesIssued)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to get Condition for Successful issue of BMC Settings: %w", err)
 			}
 			if err := r.Conditions.Update(
 				BMCSettingsAppliedCondition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BMCSettingsChangesIssuedReason),
+				conditionutils.UpdateReason(ReasonBMCSettingsChangesIssued),
 				conditionutils.UpdateMessage("BMC settings have been issued on the server's BMC"),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings Applied condition: %w", err)
@@ -460,14 +459,14 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 				return ctrl.Result{}, fmt.Errorf("failed to update Condition for Successful issue of BMC Settings: %w", err)
 			}
 			if resetBMCReq {
-				if ok, err := r.handleBMCReset(ctx, settings, bmcObj, BMCResetPostSettingApplyCondition); !ok || err != nil {
+				if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionBMCResetPostSettingApply); !ok || err != nil {
 					return ctrl.Result{}, err
 				}
 			}
 		}
 	} else {
 		log.V(1).Info("Waiting for BMC reset post applying BMC settings")
-		if ok, err := r.handleBMCReset(ctx, settings, bmcObj, BMCResetPostSettingApplyCondition); !ok || err != nil {
+		if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionBMCResetPostSettingApply); !ok || err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -476,7 +475,7 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get BMC settings: %w", err)
 	}
-	BMCSettingsVerifiedCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCSettingsChangesVerifiedCondition)
+	BMCSettingsVerifiedCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesVerified)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get Condition for verification BMC settings changes: %w", err)
 	}
@@ -484,7 +483,7 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 		if err := r.Conditions.Update(
 			BMCSettingsVerifiedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCSettingsChangesVerifiedReason),
+			conditionutils.UpdateReason(ReasonBMCSettingsChangesVerified),
 			conditionutils.UpdateMessage("BMC settings changes have been verified on the server's BMC"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings verified condition: %w", err)
@@ -492,11 +491,11 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 		return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, metalv1alpha1.BMCSettingsStateApplied, BMCSettingsVerifiedCondition)
 	}
 
-	if BMCSettingsVerifiedCondition.Status == metav1.ConditionFalse && BMCSettingsVerifiedCondition.Reason != BMCSettingsChangesNotYetVerifiedReason {
+	if BMCSettingsVerifiedCondition.Status == metav1.ConditionFalse && BMCSettingsVerifiedCondition.Reason != ReasonBMCSettingsChangesNotYetVerified {
 		if err := r.Conditions.Update(
 			BMCSettingsVerifiedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(BMCSettingsChangesNotYetVerifiedReason),
+			conditionutils.UpdateReason(ReasonBMCSettingsChangesNotYetVerified),
 			conditionutils.UpdateMessage("BMC Settings changes are not yet verified on the server's BMC"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings verified condition: %w", err)
@@ -536,7 +535,7 @@ func (r *BMCSettingsReconciler) handleBMCPowerState(
 	case metalv1alpha1.OnPowerState:
 		fallthrough
 	case metalv1alpha1.UnknownPowerState:
-		BMCPoweredOffCond, err := GetCondition(r.Conditions, bmcSetting.Status.Conditions, BMCPoweredOffCondition)
+		BMCPoweredOffCond, err := GetCondition(r.Conditions, bmcSetting.Status.Conditions, ConditionBMCPoweredOff)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Condition for powered off BMC state %v", err)
 		}
@@ -554,14 +553,14 @@ func (r *BMCSettingsReconciler) handleBMCPowerState(
 		}
 	default:
 		log.V(1).Info("BMC is not Powered On. Can not proceed", "PowerState", BMC.Status.PowerState)
-		BMCPoweredOffCond, err := GetCondition(r.Conditions, bmcSetting.Status.Conditions, BMCPoweredOffCondition)
+		BMCPoweredOffCond, err := GetCondition(r.Conditions, bmcSetting.Status.Conditions, ConditionBMCPoweredOff)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Condition for powered off BMC state %v", err)
 		}
 		if err := r.Conditions.Update(
 			BMCPoweredOffCond,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCPoweredOffReason),
+			conditionutils.UpdateReason(ReasonBMCPoweredOff),
 			conditionutils.UpdateMessage(fmt.Sprintf("BMC in not Powered On, Power State: %v", BMC.Status.PowerState)),
 		); err != nil {
 			return false, fmt.Errorf("failed to update Pending BMCSetting update condition: %w", err)
@@ -586,7 +585,7 @@ func (r *BMCSettingsReconciler) handleBMCReset(
 
 	if resetBMC.Status != metav1.ConditionTrue {
 		annotations := bmcObj.GetAnnotations()
-		if resetBMC.Reason != BMCReasonReset {
+		if resetBMC.Reason != ReasonResetIssued {
 			if annotations != nil {
 				if op, ok := annotations[metalv1alpha1.OperationAnnotation]; ok {
 					if op == metalv1alpha1.GracefulRestartBMC {
@@ -594,7 +593,7 @@ func (r *BMCSettingsReconciler) handleBMCReset(
 						if err := r.Conditions.Update(
 							resetBMC,
 							conditionutils.UpdateStatus(corev1.ConditionFalse),
-							conditionutils.UpdateReason(BMCReasonReset),
+							conditionutils.UpdateReason(ReasonResetIssued),
 							conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 						); err != nil {
 							return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -620,7 +619,7 @@ func (r *BMCSettingsReconciler) handleBMCReset(
 			if err := r.Conditions.Update(
 				resetBMC,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(BMCReasonReset),
+				conditionutils.UpdateReason(ReasonResetIssued),
 				conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -641,7 +640,7 @@ func (r *BMCSettingsReconciler) handleBMCReset(
 		if err := r.Conditions.Update(
 			resetBMC,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCReasonReset),
+			conditionutils.UpdateReason(ReasonResetIssued),
 			conditionutils.UpdateMessage("BMC reset of the server is completed"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -888,7 +887,7 @@ func (r *BMCSettingsReconciler) requestMaintenanceOnServers(ctx context.Context,
 				return false, fmt.Errorf("failed to verify ServerMaintenance existence: %w", errors.Join(errs...))
 			}
 		}
-		condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ServerMaintenanceConditionCreated)
+		condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionServerMaintenanceCreated)
 		if err != nil {
 			return false, err
 		}
@@ -898,7 +897,7 @@ func (r *BMCSettingsReconciler) requestMaintenanceOnServers(ctx context.Context,
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ServerMaintenanceReasonCreated),
+			conditionutils.UpdateReason(ReasonMaintenanceCreated),
 			conditionutils.UpdateMessage(fmt.Sprintf("Created/present %v at %v", settings.Spec.ServerMaintenanceRefs, time.Now())),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -61,7 +61,8 @@ const (
 // legacyBMCSettingsConditionTypes maps old condition type strings to their new values.
 // TODO: Remove this migration in the next release once all CRs have been reconciled.
 var legacyBMCSettingsConditionTypes = map[string]string{
-	"BMCResetIssued": ConditionResetIssued,
+	"BMCResetIssued":                       ConditionResetIssued,
+	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
 }
 
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings,verbs=get;list;watch;create;update;patch;delete
@@ -673,14 +674,14 @@ func (r *BMCSettingsReconciler) handleFailedState(ctx context.Context, settings 
 		settings.Status.State = metalv1alpha1.BMCSettingsStatePending
 		settings.Status.ObservedGeneration = settings.Generation
 		annotations := settings.GetAnnotations()
-		retryCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, RetryOfFailedResourceConditionIssued)
+		retryCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionRetryOfFailedResourceIssued)
 		if err != nil {
 			return fmt.Errorf("failed to get retry condition for BMCSettings: %w", err)
 		}
 		if retryCondition.Status != metav1.ConditionTrue {
 			err := r.Conditions.Update(retryCondition,
 				conditionutils.UpdateStatus(metav1.ConditionTrue),
-				conditionutils.UpdateReason(RetryOfFailedResourceReasonIssued),
+				conditionutils.UpdateReason(ReasonRetryOfFailedResourceIssued),
 				conditionutils.UpdateMessage(annotations[metalv1alpha1.OperationAnnotation]),
 			)
 			if err != nil {
@@ -711,7 +712,7 @@ func (r *BMCSettingsReconciler) handleFailedState(ctx context.Context, settings 
 			settingsBase := settings.DeepCopy()
 			settings.Status.State = metalv1alpha1.BMCSettingsStatePending
 			settings.Status.ObservedGeneration = settings.Generation
-			retryCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, RetryOfFailedResourceConditionIssued)
+			retryCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionRetryOfFailedResourceIssued)
 			if err != nil {
 				return fmt.Errorf("failed to get Retry condition for BMCSettings: %w", err)
 			}

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -65,6 +65,11 @@ var legacyBMCSettingsConditionTypes = map[string]string{
 	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
 }
 
+// legacyBMCSettingsConditionReasons maps old condition reason strings to their new values.
+var legacyBMCSettingsConditionReasons = map[string]string{
+	"BMCResetIssued": ReasonResetIssued,
+}
+
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings/finalizers,verbs=update
@@ -83,8 +88,12 @@ func (r *BMCSettingsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	log := ctrl.LoggerFrom(ctx)
 	// TODO: Remove this migration in the next release once all CRs have been reconciled.
 	settingsBase := settings.DeepCopy()
-	if migrateConditionTypes(settings.Status.Conditions, legacyBMCSettingsConditionTypes) {
-		log.Info("Migrated legacy condition types on BMCSettings")
+	migrated := migrateConditionTypes(settings.Status.Conditions, legacyBMCSettingsConditionTypes)
+	if migrateConditionReasons(settings.Status.Conditions, legacyBMCSettingsConditionReasons) {
+		migrated = true
+	}
+	if migrated {
+		log.Info("Migrated legacy conditions on BMCSettings")
 		if err := r.Status().Patch(ctx, settings, client.MergeFrom(settingsBase)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
 		}

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -58,6 +58,12 @@ const (
 	ReasonBMCSettingsWrongSettings         = "SettingsProvidedAreNotValid"
 )
 
+// legacyBMCSettingsConditionTypes maps old condition type strings to their new values.
+// TODO: Remove this migration in the next release once all CRs have been reconciled.
+var legacyBMCSettingsConditionTypes = map[string]string{
+	"BMCResetIssued": ConditionResetIssued,
+}
+
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings/finalizers,verbs=update
@@ -74,6 +80,14 @@ func (r *BMCSettingsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log := ctrl.LoggerFrom(ctx)
+	// TODO: Remove this migration in the next release once all CRs have been reconciled.
+	settingsBase := settings.DeepCopy()
+	if migrateConditionTypes(settings.Status.Conditions, legacyBMCSettingsConditionTypes) {
+		log.Info("Migrated legacy condition types on BMCSettings")
+		if err := r.Status().Patch(ctx, settings, client.MergeFrom(settingsBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
+		}
+	}
 	log.V(1).Info("Reconciling BMCSettings")
 
 	return r.reconcileExists(ctx, settings)

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -55,6 +55,12 @@ const (
 	ReasonBMCSettingsChangesNotYetVerified = "ChangesNotYetVerified"
 )
 
+// legacyBMCSettingsConditionTypes maps old condition type strings to their new values.
+// TODO: Remove this migration in the next release once all CRs have been reconciled.
+var legacyBMCSettingsConditionTypes = map[string]string{
+	"BMCResetIssued": ConditionResetIssued,
+}
+
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings/finalizers,verbs=update
@@ -70,6 +76,14 @@ func (r *BMCSettingsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log := ctrl.LoggerFrom(ctx)
+	// TODO: Remove this migration in the next release once all CRs have been reconciled.
+	settingsBase := settings.DeepCopy()
+	if migrateConditionTypes(settings.Status.Conditions, legacyBMCSettingsConditionTypes) {
+		log.Info("Migrated legacy condition types on BMCSettings")
+		if err := r.Status().Patch(ctx, settings, client.MergeFrom(settingsBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
+		}
+	}
 	log.V(1).Info("Reconciling BMCSettings")
 
 	return r.reconcileExists(ctx, settings)

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -41,19 +41,18 @@ type BMCSettingsReconciler struct {
 }
 
 const (
-	BMCSettingFinalizer               = "metal.ironcore.dev/bmcsettings"
-	BMCResetPostSettingApplyCondition = "ResetPostSettingApply"
-	BMCPoweredOffCondition            = "PoweredOff"
-	BMCPoweredOffReason               = "PoweredOff"
-	BMCVersionUpdatePendingCondition  = "VersionUpdatePending"
-	BMCVersionUpgradePendingReason    = "VersionUpgradePending"
-	BMCVersionMatchingReason          = "VersionMatching"
+	BMCSettingFinalizer = "metal.ironcore.dev/bmcsettings"
 
-	BMCSettingsChangesIssuedCondition      = "ChangesIssued"
-	BMCSettingsChangesIssuedReason         = "ChangesIssued"
-	BMCSettingsChangesVerifiedCondition    = "ChangesVerified"
-	BMCSettingsChangesVerifiedReason       = "ChangesVerified"
-	BMCSettingsChangesNotYetVerifiedReason = "ChangesNotYetVerified"
+	ConditionBMCResetPostSettingApply   = "ResetPostSettingApply"
+	ConditionBMCPoweredOff              = "PoweredOff"
+	ConditionBMCSettingsChangesIssued   = "ChangesIssued"
+	ConditionBMCSettingsChangesVerified = "ChangesVerified"
+
+	ReasonBMCPoweredOff                    = "PoweredOff"
+	ReasonBMCVersionMatching               = "VersionMatching"
+	ReasonBMCSettingsChangesIssued         = "ChangesIssued"
+	ReasonBMCSettingsChangesVerified       = "ChangesVerified"
+	ReasonBMCSettingsChangesNotYetVerified = "ChangesNotYetVerified"
 )
 
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings,verbs=get;list;watch;create;update;patch;delete
@@ -278,7 +277,7 @@ func (r *BMCSettingsReconciler) ensureBMCSettingsMaintenanceStateTransition(ctx 
 	switch settings.Status.State {
 	case "", metalv1alpha1.BMCSettingsStatePending:
 		var state = metalv1alpha1.BMCSettingsStateInProgress
-		versionCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCVersionUpdatePendingCondition)
+		versionCheckCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionVersionUpdatePending)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get Condition for pending BMCVersion update state: %w", err)
 		}
@@ -287,7 +286,7 @@ func (r *BMCSettingsReconciler) ensureBMCSettingsMaintenanceStateTransition(ctx 
 			if err := r.Conditions.Update(
 				versionCheckCondition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BMCVersionUpgradePendingReason),
+				conditionutils.UpdateReason(ReasonVersionUpgradePending),
 				conditionutils.UpdateMessage(fmt.Sprintf("Waiting to update BMCVersion: %v, current BMCVersion: %v", settings.Spec.Version, bmcObj.Status.FirmwareVersion)),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update Pending BMCVersion update condition: %w", err)
@@ -297,7 +296,7 @@ func (r *BMCSettingsReconciler) ensureBMCSettingsMaintenanceStateTransition(ctx 
 			if err := r.Conditions.Update(
 				versionCheckCondition,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(BMCVersionMatchingReason),
+				conditionutils.UpdateReason(ReasonBMCVersionMatching),
 				conditionutils.UpdateMessage(fmt.Sprintf("BMCVersion matches: %v", settings.Spec.Version)),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update Pending BMCVersion update condition: %w", err)
@@ -331,7 +330,7 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 		return ctrl.Result{}, err
 	}
 
-	condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ServerMaintenanceConditionWaiting)
+	condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionServerMaintenanceWaiting)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -346,7 +345,7 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+				conditionutils.UpdateReason(ReasonMaintenanceWaiting),
 				conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", settings.Spec.ServerMaintenanceRefs)),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -359,11 +358,11 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 	}
 
 	// Once in maintenance, clear the waiting condition if present
-	if condition.Reason != ServerMaintenanceReasonApproved {
+	if condition.Reason != ReasonMaintenanceApproved {
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
+			conditionutils.UpdateReason(ReasonMaintenanceApproved),
 			conditionutils.UpdateMessage("Server is now in Maintenance mode"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -375,7 +374,7 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 	}
 
 	// Reset the BMC to ensure it's in a stable state before proceeding
-	if ok, err := r.handleBMCReset(ctx, settings, bmcObj, BMCConditionReset); !ok || err != nil {
+	if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionResetIssued); !ok || err != nil {
 		return ctrl.Result{}, err
 	}
 	return r.updateSettingsAndVerify(ctx, settings, bmcObj, settingsDiff, bmcClient)
@@ -383,46 +382,46 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 
 func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, settings *metalv1alpha1.BMCSettings, bmcObj *metalv1alpha1.BMC, settingsDiff schemas.SettingsAttributes, bmcClient bmc.BMC) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	resetBMC, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCResetPostSettingApplyCondition)
+	resetBMC, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get condition for reset of BMC of server: %w", err)
 	}
 
-	if resetBMC.Reason != BMCReasonReset {
+	if resetBMC.Reason != ReasonResetIssued {
 		switch bmcObj.Status.PowerState {
 		case metalv1alpha1.OnPowerState:
 			fallthrough
 		case metalv1alpha1.UnknownPowerState:
-			BMCPoweredOffCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCPoweredOffCondition)
+			ConditionBMCPoweredOff, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCPoweredOff)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to get Condition for powered off BMC state: %w", err)
 			}
-			if BMCPoweredOffCondition.Status == metav1.ConditionTrue {
+			if ConditionBMCPoweredOff.Status == metav1.ConditionTrue {
 				if err := r.Conditions.Update(
-					BMCPoweredOffCondition,
+					ConditionBMCPoweredOff,
 					conditionutils.UpdateStatus(corev1.ConditionFalse),
 					conditionutils.UpdateReason("BMCPoweredOn"),
 					conditionutils.UpdateMessage(fmt.Sprintf("BMC in Powered On, Power State: %v", bmcObj.Status.PowerState)),
 				); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update Pending BMCVersion update condition: %w", err)
 				}
-				return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, BMCPoweredOffCondition)
+				return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, ConditionBMCPoweredOff)
 			}
 		default:
 			log.V(1).Info("BMC is not powered on, could not proceed", "PowerState", bmcObj.Status.PowerState)
-			BMCPoweredOffCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCPoweredOffCondition)
+			ConditionBMCPoweredOff, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCPoweredOff)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to get Condition for powered off BMC state: %w", err)
 			}
 			if err := r.Conditions.Update(
-				BMCPoweredOffCondition,
+				ConditionBMCPoweredOff,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BMCPoweredOffReason),
+				conditionutils.UpdateReason(ReasonBMCPoweredOff),
 				conditionutils.UpdateMessage(fmt.Sprintf("BMC is not powered on, Power State: %v", bmcObj.Status.PowerState)),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update Pending BMCVersion update condition: %w", err)
 			}
-			return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, metalv1alpha1.BMCSettingsStateFailed, BMCPoweredOffCondition)
+			return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, metalv1alpha1.BMCSettingsStateFailed, ConditionBMCPoweredOff)
 		}
 
 		pendingAttr, err := bmcClient.GetBMCPendingAttributeValues(ctx, bmcObj.Spec.BMCUUID)
@@ -442,14 +441,14 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 			}
 			log.V(1).Info("BMC settings issued successfully", "Settings", settingsDiff)
 
-			BMCSettingsAppliedCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCSettingsChangesIssuedCondition)
+			BMCSettingsAppliedCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesIssued)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to get Condition for Successful issue of BMC Settings: %w", err)
 			}
 			if err := r.Conditions.Update(
 				BMCSettingsAppliedCondition,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
-				conditionutils.UpdateReason(BMCSettingsChangesIssuedReason),
+				conditionutils.UpdateReason(ReasonBMCSettingsChangesIssued),
 				conditionutils.UpdateMessage("BMC settings have been issued on the server's BMC"),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings Applied condition: %w", err)
@@ -458,14 +457,14 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 				return ctrl.Result{}, fmt.Errorf("failed to update Condition for Successful issue of BMC Settings: %w", err)
 			}
 			if resetBMCReq {
-				if ok, err := r.handleBMCReset(ctx, settings, bmcObj, BMCResetPostSettingApplyCondition); !ok || err != nil {
+				if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionBMCResetPostSettingApply); !ok || err != nil {
 					return ctrl.Result{}, err
 				}
 			}
 		}
 	} else {
 		log.V(1).Info("Waiting for BMC reset post applying BMC settings")
-		if ok, err := r.handleBMCReset(ctx, settings, bmcObj, BMCResetPostSettingApplyCondition); !ok || err != nil {
+		if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionBMCResetPostSettingApply); !ok || err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -474,7 +473,7 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get BMC settings: %w", err)
 	}
-	BMCSettingsVerifiedCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, BMCSettingsChangesVerifiedCondition)
+	BMCSettingsVerifiedCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesVerified)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get Condition for verification BMC settings changes: %w", err)
 	}
@@ -482,7 +481,7 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 		if err := r.Conditions.Update(
 			BMCSettingsVerifiedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCSettingsChangesVerifiedReason),
+			conditionutils.UpdateReason(ReasonBMCSettingsChangesVerified),
 			conditionutils.UpdateMessage("BMC settings changes have been verified on the server's BMC"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings verified condition: %w", err)
@@ -490,11 +489,11 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 		return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, metalv1alpha1.BMCSettingsStateApplied, BMCSettingsVerifiedCondition)
 	}
 
-	if BMCSettingsVerifiedCondition.Status == metav1.ConditionFalse && BMCSettingsVerifiedCondition.Reason != BMCSettingsChangesNotYetVerifiedReason {
+	if BMCSettingsVerifiedCondition.Status == metav1.ConditionFalse && BMCSettingsVerifiedCondition.Reason != ReasonBMCSettingsChangesNotYetVerified {
 		if err := r.Conditions.Update(
 			BMCSettingsVerifiedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(BMCSettingsChangesNotYetVerifiedReason),
+			conditionutils.UpdateReason(ReasonBMCSettingsChangesNotYetVerified),
 			conditionutils.UpdateMessage("BMC Settings changes are not yet verified on the server's BMC"),
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings verified condition: %w", err)
@@ -533,7 +532,7 @@ func (r *BMCSettingsReconciler) handleBMCReset(ctx context.Context, settings *me
 
 	if resetBMC.Status != metav1.ConditionTrue {
 		annotations := bmcObj.GetAnnotations()
-		if resetBMC.Reason != BMCReasonReset {
+		if resetBMC.Reason != ReasonResetIssued {
 			if annotations != nil {
 				if op, ok := annotations[metalv1alpha1.OperationAnnotation]; ok {
 					if op == metalv1alpha1.GracefulRestartBMC {
@@ -541,7 +540,7 @@ func (r *BMCSettingsReconciler) handleBMCReset(ctx context.Context, settings *me
 						if err := r.Conditions.Update(
 							resetBMC,
 							conditionutils.UpdateStatus(corev1.ConditionFalse),
-							conditionutils.UpdateReason(BMCReasonReset),
+							conditionutils.UpdateReason(ReasonResetIssued),
 							conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 						); err != nil {
 							return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -567,7 +566,7 @@ func (r *BMCSettingsReconciler) handleBMCReset(ctx context.Context, settings *me
 			if err := r.Conditions.Update(
 				resetBMC,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(BMCReasonReset),
+				conditionutils.UpdateReason(ReasonResetIssued),
 				conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -588,7 +587,7 @@ func (r *BMCSettingsReconciler) handleBMCReset(ctx context.Context, settings *me
 		if err := r.Conditions.Update(
 			resetBMC,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCReasonReset),
+			conditionutils.UpdateReason(ReasonResetIssued),
 			conditionutils.UpdateMessage("BMC reset of the server is completed"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -764,7 +763,7 @@ func (r *BMCSettingsReconciler) requestMaintenanceOnServers(ctx context.Context,
 				return false, fmt.Errorf("failed to verify ServerMaintenance existence: %w", errors.Join(errs...))
 			}
 		}
-		condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ServerMaintenanceConditionCreated)
+		condition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionServerMaintenanceCreated)
 		if err != nil {
 			return false, err
 		}
@@ -774,7 +773,7 @@ func (r *BMCSettingsReconciler) requestMaintenanceOnServers(ctx context.Context,
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ServerMaintenanceReasonCreated),
+			conditionutils.UpdateReason(ReasonMaintenanceCreated),
 			conditionutils.UpdateMessage(fmt.Sprintf("Created/present %v at %v", settings.Spec.ServerMaintenanceRefs, time.Now())),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -67,7 +67,9 @@ var legacyBMCSettingsConditionTypes = map[string]string{
 
 // legacyBMCSettingsConditionReasons maps old condition reason strings to their new values.
 var legacyBMCSettingsConditionReasons = map[string]string{
-	"BMCResetIssued": ReasonResetIssued,
+	"BMCResetIssued":              ReasonResetIssued,
+	"SettingsProvidedAreNotValid": ReasonBMCSettingsValidationFailed,
+	"ChangesNotYetVerified":       ReasonBMCSettingsVerificationPending,
 }
 
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/bmcsettingsset_controller.go
+++ b/internal/controller/bmcsettingsset_controller.go
@@ -26,13 +26,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+const (
+	BMCSettingsSetFinalizer = "metal.ironcore.dev/bmcsettingsset"
+)
+
 type BMCSettingsSetReconciler struct {
 	client.Client
 	Scheme         *runtime.Scheme
 	ResyncInterval time.Duration
 }
-
-const BMCSettingsSetFinalizer = "metal.ironcore.dev/bmcsettingsset"
 
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettingssets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettingssets/status,verbs=get;update;patch

--- a/internal/controller/bmcuser_controller.go
+++ b/internal/controller/bmcuser_controller.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	BMCUserFinalizer = "metal.ironcore.dev/bmcuser"
+	bmcUserFinalizer = "metal.ironcore.dev/bmcuser"
 )
 
 // BMCUserReconciler reconciles a BMCUser object
@@ -71,7 +71,7 @@ func (r *BMCUserReconciler) reconcile(ctx context.Context, user *metalv1alpha1.B
 	if err := r.updateEffectiveSecret(ctx, user, bmcObj); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update effective BMCSecret: %w", err)
 	}
-	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, user, BMCUserFinalizer); err != nil || modified {
+	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, user, bmcUserFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}
 	bmcClient, err := r.getBMCClient(ctx, bmcObj)
@@ -375,7 +375,7 @@ func (r *BMCUserReconciler) delete(ctx context.Context, user *metalv1alpha1.BMCU
 	log := ctrl.LoggerFrom(ctx)
 	if user.Spec.BMCRef == nil {
 		log.Info("No BMC reference set for User, removing finalizer")
-		if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, user, BMCUserFinalizer); err != nil || modified {
+		if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, user, bmcUserFinalizer); err != nil || modified {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -385,7 +385,7 @@ func (r *BMCUserReconciler) delete(ctx context.Context, user *metalv1alpha1.BMCU
 	if err := r.Get(ctx, client.ObjectKey{Name: user.Spec.BMCRef.Name}, bmcObj); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			log.Info("BMC not found, removing finalizer")
-			if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, user, BMCUserFinalizer); err != nil || modified {
+			if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, user, bmcUserFinalizer); err != nil || modified {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
@@ -408,7 +408,7 @@ func (r *BMCUserReconciler) delete(ctx context.Context, user *metalv1alpha1.BMCU
 			return ctrl.Result{}, fmt.Errorf("failed to delete BMC account: %w", err)
 		}
 	}
-	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, user, BMCUserFinalizer); err != nil || modified {
+	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, user, bmcUserFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}
 	log.Info("Successfully deleted BMC account and removed finalizer for User")

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -28,16 +28,7 @@ import (
 )
 
 const (
-	bmcVersionFinalizer                    = "metal.ironcore.dev/bmcversion"
-	bmcVersionUpgradeIssued                = "VersionUpgradeIssued"
-	bmcVersionUpgradeCompleted             = "VersionUpgradeCompleted"
-	bmcVersionUpgradeRebootBMC             = "VersionUpgradeReboot"
-	bmcVersionUpgradeVerificationCondition = "VersionUpgradeVerification"
-	bmcUpgradeIssuedReason                 = "UpgradeIssued"
-	bmcFailedUpgradeIssueReason            = "IssueBMCUpgradeFailed"
-	bmcTaskCompletedReason                 = "TaskCompleted"
-	bmcUpgradeTaskFailedReason             = "UpgradeTaskFailed"
-	bmcVerifiedVersionUpdateReason         = "VerifiedBMCVersionUpdate"
+	bmcVersionFinalizer = "metal.ironcore.dev/bmcversion"
 )
 
 // BMCVersionReconciler reconciles a BMCVersion object
@@ -226,7 +217,7 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 				return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
 			}
 		}
-		condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ServerMaintenanceConditionWaiting)
+		condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionServerMaintenanceWaiting)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -236,7 +227,7 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 				if err := r.Conditions.Update(
 					condition,
 					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+					conditionutils.UpdateReason(ReasonMaintenanceWaiting),
 					conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", bmcVersion.Spec.ServerMaintenanceRefs)),
 				); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -249,11 +240,11 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 		}
 
 		// once in maintenance, clear the waiting condition if present
-		if condition.Reason != ServerMaintenanceReasonApproved {
+		if condition.Reason != ReasonMaintenanceApproved {
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
+				conditionutils.UpdateReason(ReasonMaintenanceApproved),
 				conditionutils.UpdateMessage("Servers are now in Maintenance mode"),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update ServerMaintenance condition: %w", err)
@@ -265,7 +256,7 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 			return ctrl.Result{}, nil
 		}
 
-		if ok, err := r.resetBMC(ctx, bmcVersion, bmcObj, BMCConditionReset); !ok || err != nil {
+		if ok, err := r.resetBMC(ctx, bmcVersion, bmcObj, ConditionResetIssued); !ok || err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reset bmc %s: %w", client.ObjectKeyFromObject(bmcObj), err)
 		}
 
@@ -300,7 +291,7 @@ func (r *BMCVersionReconciler) handleUpgradeInProgressState(
 	BMC *metalv1alpha1.BMC,
 ) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	issuedCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, bmcVersionUpgradeIssued)
+	issuedCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionVersionUpgradeIssued)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -327,7 +318,7 @@ func (r *BMCVersionReconciler) handleUpgradeInProgressState(
 		return ctrl.Result{}, r.issueBMCUpgrade(ctx, bmcVersion, bmcClient, BMC, issuedCondition)
 	}
 
-	completedCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, bmcVersionUpgradeCompleted)
+	completedCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionVersionUpgradeCompleted)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -352,7 +343,7 @@ func (r *BMCVersionReconciler) handleUpgradeInProgressState(
 				if err := r.Conditions.Update(
 					completedCondition,
 					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(bmcTaskCompletedReason),
+					conditionutils.UpdateReason(ReasonUpgradeTaskCompleted),
 					conditionutils.UpdateMessage("Upgrade Task is missing. BMC version successfully upgraded to: "+bmcVersion.Spec.Version),
 				); err != nil {
 					return ctrlResult, fmt.Errorf("failed to update conditions: %w", err)
@@ -365,11 +356,11 @@ func (r *BMCVersionReconciler) handleUpgradeInProgressState(
 		return ctrlResult, err
 	}
 
-	if ok, err := r.resetBMC(ctx, bmcVersion, BMC, bmcVersionUpgradeRebootBMC); !ok || err != nil {
+	if ok, err := r.resetBMC(ctx, bmcVersion, BMC, ConditionVersionUpgradeReboot); !ok || err != nil {
 		return ctrl.Result{}, err
 	}
 
-	condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, bmcVersionUpgradeVerificationCondition)
+	condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionVersionUpgradeVerification)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -402,7 +393,7 @@ func (r *BMCVersionReconciler) handleUpgradeInProgressState(
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(bmcVerifiedVersionUpdateReason),
+			conditionutils.UpdateReason(ReasonVersionUpdateVerified),
 			conditionutils.UpdateMessage("BMC Version updated"),
 		); err != nil {
 			log.Error(err, "Failed to update the conditions status, retrying")
@@ -535,7 +526,7 @@ func (r *BMCVersionReconciler) resetBMC(ctx context.Context, bmcVersion *metalv1
 		annotations := bmcObj.GetAnnotations()
 		// Once the server is powered on, reset the BMC to make sure it is in stable state.
 		// This avoids problems with some BMCs that hang up in subsequent operations.
-		if condition.Reason != BMCReasonReset {
+		if condition.Reason != ReasonResetIssued {
 			if annotations != nil {
 				if op, ok := annotations[metalv1alpha1.OperationAnnotation]; ok {
 					if op == metalv1alpha1.GracefulRestartBMC {
@@ -543,7 +534,7 @@ func (r *BMCVersionReconciler) resetBMC(ctx context.Context, bmcVersion *metalv1
 						if err := r.Conditions.Update(
 							condition,
 							conditionutils.UpdateStatus(corev1.ConditionFalse),
-							conditionutils.UpdateReason(BMCReasonReset),
+							conditionutils.UpdateReason(ReasonResetIssued),
 							conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 						); err != nil {
 							return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -570,7 +561,7 @@ func (r *BMCVersionReconciler) resetBMC(ctx context.Context, bmcVersion *metalv1
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(BMCReasonReset),
+				conditionutils.UpdateReason(ReasonResetIssued),
 				conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -592,7 +583,7 @@ func (r *BMCVersionReconciler) resetBMC(ctx context.Context, bmcVersion *metalv1
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCReasonReset),
+			conditionutils.UpdateReason(ReasonResetIssued),
 			conditionutils.UpdateMessage("BMC reset to stabilize BMC of the server is completed"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -780,7 +771,7 @@ func (r *BMCVersionReconciler) requestMaintenanceOnServers(ctx context.Context, 
 				return false, fmt.Errorf("failed to verify ServerMaintenance existence: %w", errors.Join(errs...))
 			}
 		}
-		condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ServerMaintenanceConditionCreated)
+		condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionServerMaintenanceCreated)
 		if err != nil {
 			return false, err
 		}
@@ -792,7 +783,7 @@ func (r *BMCVersionReconciler) requestMaintenanceOnServers(ctx context.Context, 
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ServerMaintenanceReasonCreated),
+			conditionutils.UpdateReason(ReasonMaintenanceCreated),
 			conditionutils.UpdateMessage(fmt.Sprintf("Created/present %v at %v", bmcVersion.Spec.ServerMaintenanceRefs, time.Now())),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -939,7 +930,7 @@ func (r *BMCVersionReconciler) checkBMCUpgradeStatus(
 		if err := r.Conditions.Update(
 			completedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(bmcUpgradeTaskFailedReason),
+			conditionutils.UpdateReason(ReasonUpgradeTaskFailed),
 			conditionutils.UpdateMessage(message),
 		); err != nil {
 			log.Error(err, "Failed to update the conditions status, reconciling again")
@@ -959,7 +950,7 @@ func (r *BMCVersionReconciler) checkBMCUpgradeStatus(
 		if err := r.Conditions.Update(
 			completedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(bmcTaskCompletedReason),
+			conditionutils.UpdateReason(ReasonUpgradeTaskCompleted),
 			conditionutils.UpdateMessage("BMC successfully upgraded to: "+bmcVersion.Spec.Version),
 		); err != nil {
 			log.Error(err, "Failed to update the conditions status, reconciling again")
@@ -1048,7 +1039,7 @@ func (r *BMCVersionReconciler) issueBMCUpgrade(
 		if errCond = r.Conditions.Update(
 			issuedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(bmcFailedUpgradeIssueReason),
+			conditionutils.UpdateReason(ReasonUpgradeIssueFailed),
 			conditionutils.UpdateMessage("Fatal error occurred. Upgrade might still go through on server."),
 		); errCond != nil {
 			log.Error(errCond, "Failed to update the conditions status")
@@ -1071,14 +1062,14 @@ func (r *BMCVersionReconciler) issueBMCUpgrade(
 	if errCond = r.Conditions.Update(
 		issuedCondition,
 		conditionutils.UpdateStatus(corev1.ConditionTrue),
-		conditionutils.UpdateReason(bmcUpgradeIssuedReason),
+		conditionutils.UpdateReason(ReasonUpgradeIssued),
 		conditionutils.UpdateMessage(fmt.Sprintf("Task to upgrade has been created %v", taskMonitor)),
 	); errCond != nil {
 		log.Error(errCond, "Failed to update the conditions status, retrying")
 		if errCond = r.Conditions.Update(
 			issuedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(bmcUpgradeIssuedReason),
+			conditionutils.UpdateReason(ReasonUpgradeIssued),
 			conditionutils.UpdateMessage(fmt.Sprintf("Task to upgrade has been created %v", taskMonitor)),
 		); errCond != nil {
 			state = metalv1alpha1.BMCVersionStateFailed

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -31,6 +31,12 @@ const (
 	bmcVersionFinalizer = "metal.ironcore.dev/bmcversion"
 )
 
+// legacyBMCVersionConditionTypes maps old condition type strings to their new values.
+// TODO: Remove this migration in the next release once all CRs have been reconciled.
+var legacyBMCVersionConditionTypes = map[string]string{
+	"BMCResetIssued": ConditionResetIssued,
+}
+
 // BMCVersionReconciler reconciles a BMCVersion object
 type BMCVersionReconciler struct {
 	client.Client
@@ -62,6 +68,14 @@ func (r *BMCVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log := ctrl.LoggerFrom(ctx)
+	// TODO: Remove this migration in the next release once all CRs have been reconciled.
+	bmcVersionBase := bmcVersion.DeepCopy()
+	if migrateConditionTypes(bmcVersion.Status.Conditions, legacyBMCVersionConditionTypes) {
+		log.Info("Migrated legacy condition types on BMCVersion")
+		if err := r.Status().Patch(ctx, bmcVersion, client.MergeFrom(bmcVersionBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
+		}
+	}
 	log.V(1).Info("Reconciling BMCVersion")
 
 	return r.reconcileExists(ctx, bmcVersion)

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -34,7 +34,8 @@ const (
 // legacyBMCVersionConditionTypes maps old condition type strings to their new values.
 // TODO: Remove this migration in the next release once all CRs have been reconciled.
 var legacyBMCVersionConditionTypes = map[string]string{
-	"BMCResetIssued": ConditionResetIssued,
+	"BMCResetIssued":                       ConditionResetIssued,
+	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
 }
 
 // BMCVersionReconciler reconciles a BMCVersion object
@@ -440,14 +441,14 @@ func (r *BMCVersionReconciler) handleFailedState(
 		bmcVersion.Status.ObservedGeneration = bmcVersion.Generation
 		annotations := bmcVersion.GetAnnotations()
 
-		retryCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, RetryOfFailedResourceConditionIssued)
+		retryCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionRetryOfFailedResourceIssued)
 		if err != nil {
 			return fmt.Errorf("failed to get retry condition for BMCVersion: %w", err)
 		}
 		if retryCondition.Status != metav1.ConditionTrue {
 			err := r.Conditions.Update(retryCondition,
 				conditionutils.UpdateStatus(metav1.ConditionTrue),
-				conditionutils.UpdateReason(RetryOfFailedResourceReasonIssued),
+				conditionutils.UpdateReason(ReasonRetryOfFailedResourceIssued),
 				conditionutils.UpdateMessage(annotations[metalv1alpha1.OperationAnnotation]),
 			)
 			if err != nil {
@@ -478,7 +479,7 @@ func (r *BMCVersionReconciler) handleFailedState(
 			bmcVersionBase := bmcVersion.DeepCopy()
 			bmcVersion.Status.State = metalv1alpha1.BMCVersionStatePending
 			bmcVersion.Status.ObservedGeneration = bmcVersion.Generation
-			retryCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, RetryOfFailedResourceConditionIssued)
+			retryCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionRetryOfFailedResourceIssued)
 			if err != nil {
 				return fmt.Errorf("failed to get Retry condition for BMCVersion: %w", err)
 			}
@@ -584,7 +585,7 @@ func (r *BMCVersionReconciler) removeServerMaintenanceRefAndResetConditions(
 		log.V(1).Info("Upgraded BMC version", "BMCVersion", currentBMCVersion, "BMC", BMC.Name)
 		state = metalv1alpha1.BMCVersionStateCompleted
 	}
-	retryFailedCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, RetryOfFailedResourceConditionIssued)
+	retryFailedCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionRetryOfFailedResourceIssued)
 	if err != nil {
 		return fmt.Errorf("failed to get retry condition for BMCVersion: %w", err)
 	}

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -31,6 +31,12 @@ const (
 	bmcVersionFinalizer = "metal.ironcore.dev/bmcversion"
 )
 
+// legacyBMCVersionConditionTypes maps old condition type strings to their new values.
+// TODO: Remove this migration in the next release once all CRs have been reconciled.
+var legacyBMCVersionConditionTypes = map[string]string{
+	"BMCResetIssued": ConditionResetIssued,
+}
+
 // BMCVersionReconciler reconciles a BMCVersion object
 type BMCVersionReconciler struct {
 	client.Client
@@ -61,6 +67,14 @@ func (r *BMCVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log := ctrl.LoggerFrom(ctx)
+	// TODO: Remove this migration in the next release once all CRs have been reconciled.
+	bmcVersionBase := bmcVersion.DeepCopy()
+	if migrateConditionTypes(bmcVersion.Status.Conditions, legacyBMCVersionConditionTypes) {
+		log.Info("Migrated legacy condition types on BMCVersion")
+		if err := r.Status().Patch(ctx, bmcVersion, client.MergeFrom(bmcVersionBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
+		}
+	}
 	log.V(1).Info("Reconciling BMCVersion")
 
 	return r.reconcileExists(ctx, bmcVersion)

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -40,7 +40,10 @@ var legacyBMCVersionConditionTypes = map[string]string{
 
 // legacyBMCVersionConditionReasons maps old condition reason strings to their new values.
 var legacyBMCVersionConditionReasons = map[string]string{
-	"BMCResetIssued": ReasonResetIssued,
+	"BMCResetIssued":           ReasonResetIssued,
+	"IssueBMCUpgradeFailed":    ReasonUpgradeIssueFailed,
+	"TaskCompleted":            ReasonUpgradeTaskCompleted,
+	"VerifiedBMCVersionUpdate": ReasonVersionUpdateVerified,
 }
 
 // BMCVersionReconciler reconciles a BMCVersion object

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -28,16 +28,7 @@ import (
 )
 
 const (
-	bmcVersionFinalizer                    = "metal.ironcore.dev/bmcversion"
-	bmcVersionUpgradeIssued                = "VersionUpgradeIssued"
-	bmcVersionUpgradeCompleted             = "VersionUpgradeCompleted"
-	bmcVersionUpgradeRebootBMC             = "VersionUpgradeReboot"
-	bmcVersionUpgradeVerificationCondition = "VersionUpgradeVerification"
-	bmcUpgradeIssuedReason                 = "UpgradeIssued"
-	bmcFailedUpgradeIssueReason            = "IssueBMCUpgradeFailed"
-	bmcTaskCompletedReason                 = "TaskCompleted"
-	bmcUpgradeTaskFailedReason             = "UpgradeTaskFailed"
-	bmcVerifiedVersionUpdateReason         = "VerifiedBMCVersionUpdate"
+	bmcVersionFinalizer = "metal.ironcore.dev/bmcversion"
 )
 
 // BMCVersionReconciler reconciles a BMCVersion object
@@ -238,7 +229,7 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 				return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
 			}
 		}
-		condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ServerMaintenanceConditionWaiting)
+		condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionServerMaintenanceWaiting)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -248,7 +239,7 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 				if err := r.Conditions.Update(
 					condition,
 					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(ServerMaintenanceReasonWaiting),
+					conditionutils.UpdateReason(ReasonMaintenanceWaiting),
 					conditionutils.UpdateMessage(fmt.Sprintf("Waiting for approval of %v", bmcVersion.Spec.ServerMaintenanceRefs)),
 				); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -261,11 +252,11 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 		}
 
 		// once in maintenance, clear the waiting condition if present
-		if condition.Reason != ServerMaintenanceReasonApproved {
+		if condition.Reason != ReasonMaintenanceApproved {
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(ServerMaintenanceReasonApproved),
+				conditionutils.UpdateReason(ReasonMaintenanceApproved),
 				conditionutils.UpdateMessage("Servers are now in Maintenance mode"),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update ServerMaintenance condition: %w", err)
@@ -277,7 +268,7 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 			return ctrl.Result{}, nil
 		}
 
-		if ok, err := r.resetBMC(ctx, bmcVersion, bmcObj, BMCConditionReset); !ok || err != nil {
+		if ok, err := r.resetBMC(ctx, bmcVersion, bmcObj, ConditionResetIssued); !ok || err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reset bmc %s: %w", client.ObjectKeyFromObject(bmcObj), err)
 		}
 
@@ -299,7 +290,7 @@ func (r *BMCVersionReconciler) handleUpgradeInProgressState(
 	BMC *metalv1alpha1.BMC,
 ) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	issuedCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, bmcVersionUpgradeIssued)
+	issuedCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionVersionUpgradeIssued)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -326,7 +317,7 @@ func (r *BMCVersionReconciler) handleUpgradeInProgressState(
 		return ctrl.Result{}, r.issueBMCUpgrade(ctx, bmcVersion, bmcClient, BMC, issuedCondition)
 	}
 
-	completedCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, bmcVersionUpgradeCompleted)
+	completedCondition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionVersionUpgradeCompleted)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -351,7 +342,7 @@ func (r *BMCVersionReconciler) handleUpgradeInProgressState(
 				if err := r.Conditions.Update(
 					completedCondition,
 					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(bmcTaskCompletedReason),
+					conditionutils.UpdateReason(ReasonUpgradeTaskCompleted),
 					conditionutils.UpdateMessage("Upgrade Task is missing. BMC version successfully upgraded to: "+bmcVersion.Spec.Version),
 				); err != nil {
 					return ctrlResult, fmt.Errorf("failed to update conditions: %w", err)
@@ -364,11 +355,11 @@ func (r *BMCVersionReconciler) handleUpgradeInProgressState(
 		return ctrlResult, err
 	}
 
-	if ok, err := r.resetBMC(ctx, bmcVersion, BMC, bmcVersionUpgradeRebootBMC); !ok || err != nil {
+	if ok, err := r.resetBMC(ctx, bmcVersion, BMC, ConditionVersionUpgradeReboot); !ok || err != nil {
 		return ctrl.Result{}, err
 	}
 
-	condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, bmcVersionUpgradeVerificationCondition)
+	condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionVersionUpgradeVerification)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -401,7 +392,7 @@ func (r *BMCVersionReconciler) handleUpgradeInProgressState(
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(bmcVerifiedVersionUpdateReason),
+			conditionutils.UpdateReason(ReasonVersionUpdateVerified),
 			conditionutils.UpdateMessage("BMC Version updated"),
 		); err != nil {
 			log.Error(err, "Failed to update the conditions status, retrying")
@@ -626,7 +617,7 @@ func (r *BMCVersionReconciler) resetBMC(ctx context.Context, bmcVersion *metalv1
 		annotations := bmcObj.GetAnnotations()
 		// Once the server is powered on, reset the BMC to make sure it is in stable state.
 		// This avoids problems with some BMCs that hang up in subsequent operations.
-		if condition.Reason != BMCReasonReset {
+		if condition.Reason != ReasonResetIssued {
 			if annotations != nil {
 				if op, ok := annotations[metalv1alpha1.OperationAnnotation]; ok {
 					if op == metalv1alpha1.GracefulRestartBMC {
@@ -634,7 +625,7 @@ func (r *BMCVersionReconciler) resetBMC(ctx context.Context, bmcVersion *metalv1
 						if err := r.Conditions.Update(
 							condition,
 							conditionutils.UpdateStatus(corev1.ConditionFalse),
-							conditionutils.UpdateReason(BMCReasonReset),
+							conditionutils.UpdateReason(ReasonResetIssued),
 							conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 						); err != nil {
 							return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -661,7 +652,7 @@ func (r *BMCVersionReconciler) resetBMC(ctx context.Context, bmcVersion *metalv1
 			if err := r.Conditions.Update(
 				condition,
 				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(BMCReasonReset),
+				conditionutils.UpdateReason(ReasonResetIssued),
 				conditionutils.UpdateMessage("Issued BMC reset to stabilize BMC of the server"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update reset BMC condition: %w", err)
@@ -683,7 +674,7 @@ func (r *BMCVersionReconciler) resetBMC(ctx context.Context, bmcVersion *metalv1
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(BMCReasonReset),
+			conditionutils.UpdateReason(ReasonResetIssued),
 			conditionutils.UpdateMessage("BMC reset to stabilize BMC of the server is completed"),
 		); err != nil {
 			return false, fmt.Errorf("failed to update power on server condition: %w", err)
@@ -872,7 +863,7 @@ func (r *BMCVersionReconciler) requestMaintenanceOnServers(ctx context.Context, 
 				return false, fmt.Errorf("failed to verify ServerMaintenance existence: %w", errors.Join(errs...))
 			}
 		}
-		condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ServerMaintenanceConditionCreated)
+		condition, err := GetCondition(r.Conditions, bmcVersion.Status.Conditions, ConditionServerMaintenanceCreated)
 		if err != nil {
 			return false, err
 		}
@@ -884,7 +875,7 @@ func (r *BMCVersionReconciler) requestMaintenanceOnServers(ctx context.Context, 
 		if err := r.Conditions.Update(
 			condition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ServerMaintenanceReasonCreated),
+			conditionutils.UpdateReason(ReasonMaintenanceCreated),
 			conditionutils.UpdateMessage(fmt.Sprintf("Created/present %v at %v", bmcVersion.Spec.ServerMaintenanceRefs, time.Now())),
 		); err != nil {
 			return false, fmt.Errorf("failed to update creating ServerMaintenance condition: %w", err)
@@ -1031,7 +1022,7 @@ func (r *BMCVersionReconciler) checkBMCUpgradeStatus(
 		if err := r.Conditions.Update(
 			completedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(bmcUpgradeTaskFailedReason),
+			conditionutils.UpdateReason(ReasonUpgradeTaskFailed),
 			conditionutils.UpdateMessage(message),
 		); err != nil {
 			log.Error(err, "Failed to update the conditions status, reconciling again")
@@ -1051,7 +1042,7 @@ func (r *BMCVersionReconciler) checkBMCUpgradeStatus(
 		if err := r.Conditions.Update(
 			completedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(bmcTaskCompletedReason),
+			conditionutils.UpdateReason(ReasonUpgradeTaskCompleted),
 			conditionutils.UpdateMessage("BMC successfully upgraded to: "+bmcVersion.Spec.Version),
 		); err != nil {
 			log.Error(err, "Failed to update the conditions status, reconciling again")
@@ -1140,7 +1131,7 @@ func (r *BMCVersionReconciler) issueBMCUpgrade(
 		if errCond = r.Conditions.Update(
 			issuedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason(bmcFailedUpgradeIssueReason),
+			conditionutils.UpdateReason(ReasonUpgradeIssueFailed),
 			conditionutils.UpdateMessage("Fatal error occurred. Upgrade might still go through on server."),
 		); errCond != nil {
 			log.Error(errCond, "Failed to update the conditions status")
@@ -1163,14 +1154,14 @@ func (r *BMCVersionReconciler) issueBMCUpgrade(
 	if errCond = r.Conditions.Update(
 		issuedCondition,
 		conditionutils.UpdateStatus(corev1.ConditionTrue),
-		conditionutils.UpdateReason(bmcUpgradeIssuedReason),
+		conditionutils.UpdateReason(ReasonUpgradeIssued),
 		conditionutils.UpdateMessage(fmt.Sprintf("Task to upgrade has been created %v", taskMonitor)),
 	); errCond != nil {
 		log.Error(errCond, "Failed to update the conditions status, retrying")
 		if errCond = r.Conditions.Update(
 			issuedCondition,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(bmcUpgradeIssuedReason),
+			conditionutils.UpdateReason(ReasonUpgradeIssued),
 			conditionutils.UpdateMessage(fmt.Sprintf("Task to upgrade has been created %v", taskMonitor)),
 		); errCond != nil {
 			state = metalv1alpha1.BMCVersionStateFailed

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -38,6 +38,11 @@ var legacyBMCVersionConditionTypes = map[string]string{
 	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
 }
 
+// legacyBMCVersionConditionReasons maps old condition reason strings to their new values.
+var legacyBMCVersionConditionReasons = map[string]string{
+	"BMCResetIssued": ReasonResetIssued,
+}
+
 // BMCVersionReconciler reconciles a BMCVersion object
 type BMCVersionReconciler struct {
 	client.Client
@@ -71,8 +76,12 @@ func (r *BMCVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	log := ctrl.LoggerFrom(ctx)
 	// TODO: Remove this migration in the next release once all CRs have been reconciled.
 	bmcVersionBase := bmcVersion.DeepCopy()
-	if migrateConditionTypes(bmcVersion.Status.Conditions, legacyBMCVersionConditionTypes) {
-		log.Info("Migrated legacy condition types on BMCVersion")
+	migrated := migrateConditionTypes(bmcVersion.Status.Conditions, legacyBMCVersionConditionTypes)
+	if migrateConditionReasons(bmcVersion.Status.Conditions, legacyBMCVersionConditionReasons) {
+		migrated = true
+	}
+	if migrated {
+		log.Info("Migrated legacy conditions on BMCVersion")
 		if err := r.Status().Patch(ctx, bmcVersion, client.MergeFrom(bmcVersionBase)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
 		}

--- a/internal/controller/bmcversion_controller_test.go
+++ b/internal/controller/bmcversion_controller_test.go
@@ -650,7 +650,7 @@ func ensureBMCVersionConditionTransition(acc *conditionutils.Accessor, bmcVersio
 	}).Should(BeNumerically(">=", 1))
 	Eventually(func(g Gomega) bool {
 		g.Expect(Get(bmcVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, bmcVersionUpgradeIssued, condIssue)).To(BeTrue())
+		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, ConditionVersionUpgradeIssued, condIssue)).To(BeTrue())
 		return condIssue.Status == metav1.ConditionTrue
 	}).Should(BeTrue())
 
@@ -669,7 +669,7 @@ func ensureBMCVersionConditionTransition(acc *conditionutils.Accessor, bmcVersio
 	}).Should(BeNumerically(">=", 2))
 	Eventually(func(g Gomega) bool {
 		g.Expect(Get(bmcVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, bmcVersionUpgradeCompleted, condComplete)).To(BeTrue())
+		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, ConditionVersionUpgradeCompleted, condComplete)).To(BeTrue())
 		return condComplete.Status == metav1.ConditionTrue
 	}).Should(BeTrue())
 
@@ -681,7 +681,7 @@ func ensureBMCVersionConditionTransition(acc *conditionutils.Accessor, bmcVersio
 	}).Should(BeNumerically(">=", 4))
 	Eventually(func(g Gomega) bool {
 		g.Expect(Get(bmcVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, bmcVersionUpgradeVerificationCondition, verificationComplete)).To(BeTrue())
+		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, ConditionVersionUpgradeVerification, verificationComplete)).To(BeTrue())
 		return verificationComplete.Status == metav1.ConditionTrue
 	}).Should(BeTrue())
 }

--- a/internal/controller/bmcversion_controller_test.go
+++ b/internal/controller/bmcversion_controller_test.go
@@ -630,7 +630,7 @@ func ensureBMCVersionConditionTransition(acc *conditionutils.Accessor, bmcVersio
 	}).Should(BeNumerically(">=", 1))
 	Eventually(func(g Gomega) bool {
 		g.Expect(Get(bmcVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, bmcVersionUpgradeIssued, condIssue)).To(BeTrue())
+		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, ConditionVersionUpgradeIssued, condIssue)).To(BeTrue())
 		return condIssue.Status == metav1.ConditionTrue
 	}).Should(BeTrue())
 
@@ -649,7 +649,7 @@ func ensureBMCVersionConditionTransition(acc *conditionutils.Accessor, bmcVersio
 	}).Should(BeNumerically(">=", 2))
 	Eventually(func(g Gomega) bool {
 		g.Expect(Get(bmcVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, bmcVersionUpgradeCompleted, condComplete)).To(BeTrue())
+		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, ConditionVersionUpgradeCompleted, condComplete)).To(BeTrue())
 		return condComplete.Status == metav1.ConditionTrue
 	}).Should(BeTrue())
 
@@ -661,7 +661,7 @@ func ensureBMCVersionConditionTransition(acc *conditionutils.Accessor, bmcVersio
 	}).Should(BeNumerically(">=", 4))
 	Eventually(func(g Gomega) bool {
 		g.Expect(Get(bmcVersion)()).To(Succeed())
-		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, bmcVersionUpgradeVerificationCondition, verificationComplete)).To(BeTrue())
+		g.Expect(acc.FindSlice(bmcVersion.Status.Conditions, ConditionVersionUpgradeVerification, verificationComplete)).To(BeTrue())
 		return verificationComplete.Status == metav1.ConditionTrue
 	}).Should(BeTrue())
 }

--- a/internal/controller/bmcversionset_controller.go
+++ b/internal/controller/bmcversionset_controller.go
@@ -25,14 +25,16 @@ import (
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 )
 
+const (
+	BMCVersionSetFinalizer = "metal.ironcore.dev/bmcversionset"
+)
+
 // BMCVersionSetReconciler reconciles a BMCVersionSet object
 type BMCVersionSetReconciler struct {
 	client.Client
 	Scheme         *runtime.Scheme
 	ResyncInterval time.Duration
 }
-
-const BMCVersionSetFinalizer = "metal.ironcore.dev/bmcversionset"
 
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcversionsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcversionsets/status,verbs=get;update;patch

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+// Shared condition types used across multiple controllers.
+const (
+	// ConditionServerMaintenanceCreated indicates a ServerMaintenance resource has been created.
+	ConditionServerMaintenanceCreated = "ServerMaintenanceCreated"
+	// ConditionServerMaintenanceDeleted indicates a ServerMaintenance resource has been deleted.
+	ConditionServerMaintenanceDeleted = "ServerMaintenanceDeleted"
+	// ConditionServerMaintenanceWaiting indicates waiting for ServerMaintenance approval.
+	ConditionServerMaintenanceWaiting = "ServerMaintenanceWaiting"
+	// ConditionResetIssued indicates a reset has been issued.
+	ConditionResetIssued = "ResetIssued"
+	// ConditionVersionUpgradeIssued indicates a version upgrade has been issued.
+	ConditionVersionUpgradeIssued = "VersionUpgradeIssued"
+	// ConditionVersionUpgradeCompleted indicates a version upgrade has completed.
+	ConditionVersionUpgradeCompleted = "VersionUpgradeCompleted"
+	// ConditionVersionUpgradeVerification indicates version upgrade verification is in progress.
+	ConditionVersionUpgradeVerification = "VersionUpgradeVerification"
+	// ConditionVersionUpgradeReboot indicates a reboot during version upgrade.
+	ConditionVersionUpgradeReboot = "VersionUpgradeReboot"
+	// ConditionVersionUpdatePending indicates a version update is pending.
+	ConditionVersionUpdatePending = "VersionUpdatePending"
+	// ConditionPoweringOn indicates a server is powering on.
+	ConditionPoweringOn = "PoweringOn"
+	// ConditionReset indicates a reset condition.
+	ConditionReset = "Reset"
+	// ConditionReady indicates readiness.
+	ConditionReady = "Ready"
+)
+
+// Shared reason strings used across multiple controllers.
+const (
+	// ReasonUpgradeIssued indicates an upgrade has been issued.
+	ReasonUpgradeIssued = "UpgradeIssued"
+	// ReasonUpgradeTaskFailed indicates an upgrade task has failed.
+	ReasonUpgradeTaskFailed = "UpgradeTaskFailed"
+	// ReasonUpgradeIssueFailed indicates an upgrade failed to be issued.
+	ReasonUpgradeIssueFailed = "UpgradeIssueFailed"
+	// ReasonUpgradeTaskCompleted indicates an upgrade task has completed.
+	ReasonUpgradeTaskCompleted = "UpgradeTaskCompleted"
+	// ReasonVersionUpdateVerified indicates a version update has been verified.
+	ReasonVersionUpdateVerified = "VersionUpdateVerified"
+	// ReasonVersionVerificationFailed indicates version verification has failed.
+	ReasonVersionVerificationFailed = "VersionVerificationFailed"
+	// ReasonVersionUpgradePending indicates a version upgrade is pending.
+	ReasonVersionUpgradePending = "VersionUpgradePending"
+	// ReasonResetIssued indicates a reset has been issued.
+	ReasonResetIssued = "ResetIssued"
+	// ReasonAuthenticationFailed indicates authentication has failed.
+	ReasonAuthenticationFailed = "AuthenticationFailed"
+	// ReasonInternalError indicates an internal server error.
+	ReasonInternalError = "InternalServerError"
+	// ReasonUnknownError indicates an unknown error.
+	ReasonUnknownError = "UnknownError"
+	// ReasonConnectionFailed indicates a connection failure.
+	ReasonConnectionFailed = "ConnectionFailed"
+	// ReasonUserReset indicates a user-requested reset.
+	ReasonUserReset = "UserRequested"
+	// ReasonAutoReset indicates an automatic reset.
+	ReasonAutoReset = "AutoResetting"
+	// ReasonConnected indicates a successful connection.
+	ReasonConnected = "BMCConnected"
+	// ReasonMaintenanceCreated indicates a ServerMaintenance resource has been created.
+	ReasonMaintenanceCreated = "ServerMaintenanceHasBeenCreated"
+	// ReasonMaintenanceDeleted indicates a ServerMaintenance resource has been deleted.
+	ReasonMaintenanceDeleted = "ServerMaintenanceHasBeenDeleted"
+	// ReasonMaintenanceWaiting indicates waiting for ServerMaintenance approval.
+	ReasonMaintenanceWaiting = "ServerMaintenanceWaitingOnApproval"
+	// ReasonMaintenanceApproved indicates ServerMaintenance has been approved.
+	ReasonMaintenanceApproved = "ServerMaintenanceApproval"
+)

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -29,6 +29,8 @@ const (
 	ConditionReset = "Reset"
 	// ConditionReady indicates readiness.
 	ConditionReady = "Ready"
+	// ConditionRetryOfFailedResourceIssued indicates a retry of a failed resource has been issued.
+	ConditionRetryOfFailedResourceIssued = "RetryOfFailedResourceIssued"
 )
 
 // Shared reason strings used across multiple controllers.
@@ -71,4 +73,6 @@ const (
 	ReasonMaintenanceWaiting = "ServerMaintenanceWaitingOnApproval"
 	// ReasonMaintenanceApproved indicates ServerMaintenance has been approved.
 	ReasonMaintenanceApproved = "ServerMaintenanceApproval"
+	// ReasonRetryOfFailedResourceIssued indicates a retry of a failed resource has been issued.
+	ReasonRetryOfFailedResourceIssued = "RetryOfFailedResourceIssued"
 )

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -64,7 +64,7 @@ const (
 	// ReasonAutoReset indicates an automatic reset.
 	ReasonAutoReset = "AutoResetting"
 	// ReasonConnected indicates a successful connection.
-	ReasonConnected = "BMCConnected"
+	ReasonConnected = "Connected"
 	// ReasonMaintenanceCreated indicates a ServerMaintenance resource has been created.
 	ReasonMaintenanceCreated = "ServerMaintenanceHasBeenCreated"
 	// ReasonMaintenanceDeleted indicates a ServerMaintenance resource has been deleted.

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	EndpointFinalizer = "metal.ironcore.dev/endpoint"
+	endpointFinalizer = "metal.ironcore.dev/endpoint"
 )
 
 // EndpointReconciler reconciles a Endpoints object
@@ -61,7 +61,7 @@ func (r *EndpointReconciler) delete(ctx context.Context, endpoint *metalv1alpha1
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Deleting Endpoint")
 	// TODO: cleanup endpoint
-	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, endpoint, EndpointFinalizer); err != nil || modified {
+	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, endpoint, endpointFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}
 	log.V(1).Info("Deleted Endpoint")

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -70,6 +70,7 @@ func GetServerMaintenanceForObjectReference(ctx context.Context, c client.Client
 }
 
 // GetCondition finds a condition in a condition slice.
+// If the condition is not found, a new one with Status=False is returned.
 func GetCondition(acc *conditionutils.Accessor, conditions []metav1.Condition, conditionType string) (*metav1.Condition, error) {
 	condition := &metav1.Condition{}
 	condFound, err := acc.FindSlice(conditions, conditionType, condition)
@@ -88,6 +89,20 @@ func GetCondition(acc *conditionutils.Accessor, conditions []metav1.Condition, c
 	}
 
 	return condition, nil
+}
+
+// migrateConditionTypes renames legacy condition type strings in-place.
+// Returns true if any conditions were migrated.
+// TODO: Remove this function in the next release once all CRs have been reconciled.
+func migrateConditionTypes(conditions []metav1.Condition, migrations map[string]string) bool {
+	migrated := false
+	for i := range conditions {
+		if newType, ok := migrations[conditions[i].Type]; ok {
+			conditions[i].Type = newType
+			migrated = true
+		}
+	}
+	return migrated
 }
 
 // GetServerByName returns a Server object by its name or an error in case the object can not be found.

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -376,6 +376,15 @@ func handleRetryAnnotationPropagation(ctx context.Context, c client.Client, pare
 							// retry was already propagated to child, we can skip re-propagation to avoid infinite loop
 							return nil
 						}
+
+						// Also check legacy condition type for unmigrated CRs.
+						// TODO: Remove this check in the next release once all CRs have been reconciled.
+						legacyCondition, err := GetCondition(acc, conditions, "RetryOfFailedResourceConditionIssued")
+						if err == nil && legacyCondition != nil &&
+							legacyCondition.Status == metav1.ConditionTrue &&
+							legacyCondition.Message == metalv1alpha1.OperationAnnotationRetryFailedPropagated {
+							return nil
+						}
 					}
 				}
 			}

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -32,9 +32,6 @@ import (
 
 const (
 	fieldOwner = client.FieldOwner("metal.ironcore.dev/controller-manager")
-
-	RetryOfFailedResourceConditionIssued = "RetryOfFailedResourceConditionIssued"
-	RetryOfFailedResourceReasonIssued    = "RetryOfFailedResourceReasonIssued"
 )
 
 type BMCTaskFetchFailedError struct {
@@ -357,7 +354,7 @@ func handleRetryAnnotationPropagation(ctx context.Context, c client.Client, pare
 					conditions, ok := conditionsField.Interface().([]metav1.Condition)
 					if ok {
 						acc := conditionutils.NewAccessor(conditionutils.AccessorOptions{})
-						retriedCondition, err := GetCondition(acc, conditions, RetryOfFailedResourceConditionIssued)
+						retriedCondition, err := GetCondition(acc, conditions, ConditionRetryOfFailedResourceIssued)
 
 						if err == nil && retriedCondition != nil &&
 							retriedCondition.Status == metav1.ConditionTrue &&

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -35,14 +35,6 @@ const (
 
 	RetryOfFailedResourceConditionIssued = "RetryOfFailedResourceConditionIssued"
 	RetryOfFailedResourceReasonIssued    = "RetryOfFailedResourceReasonIssued"
-
-	ServerMaintenanceConditionCreated = "ServerMaintenanceCreated"
-	ServerMaintenanceReasonCreated    = "ServerMaintenanceHasBeenCreated"
-	ServerMaintenanceConditionDeleted = "ServerMaintenanceDeleted"
-	ServerMaintenanceReasonDeleted    = "ServerMaintenanceHasBeenDeleted"
-	ServerMaintenanceConditionWaiting = "ServerMaintenanceWaiting"
-	ServerMaintenanceReasonWaiting    = "ServerMaintenanceWaitingOnApproval"
-	ServerMaintenanceReasonApproved   = "ServerMaintenanceApproval"
 )
 
 type BMCTaskFetchFailedError struct {

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -29,14 +29,6 @@ import (
 
 const (
 	fieldOwner = client.FieldOwner("metal.ironcore.dev/controller-manager")
-
-	ServerMaintenanceConditionCreated = "ServerMaintenanceCreated"
-	ServerMaintenanceReasonCreated    = "ServerMaintenanceHasBeenCreated"
-	ServerMaintenanceConditionDeleted = "ServerMaintenanceDeleted"
-	ServerMaintenanceReasonDeleted    = "ServerMaintenanceHasBeenDeleted"
-	ServerMaintenanceConditionWaiting = "ServerMaintenanceWaiting"
-	ServerMaintenanceReasonWaiting    = "ServerMaintenanceWaitingOnApproval"
-	ServerMaintenanceReasonApproved   = "ServerMaintenanceApproval"
 )
 
 type BMCTaskFetchFailedError struct {

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -102,6 +102,20 @@ func migrateConditionTypes(conditions []metav1.Condition, migrations map[string]
 	return migrated
 }
 
+// migrateConditionReasons renames legacy condition reason strings in-place.
+// Returns true if any reasons were migrated.
+// TODO: Remove this function in the next release once all CRs have been reconciled.
+func migrateConditionReasons(conditions []metav1.Condition, migrations map[string]string) bool {
+	migrated := false
+	for i := range conditions {
+		if newReason, ok := migrations[conditions[i].Reason]; ok {
+			conditions[i].Reason = newReason
+			migrated = true
+		}
+	}
+	return migrated
+}
+
 // GetServerByName returns a Server object by its name or an error in case the object can not be found.
 func GetServerByName(ctx context.Context, c client.Client, serverName string) (*metalv1alpha1.Server, error) {
 	server := &metalv1alpha1.Server{}

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -64,6 +64,7 @@ func GetServerMaintenanceForObjectReference(ctx context.Context, c client.Client
 }
 
 // GetCondition finds a condition in a condition slice.
+// If the condition is not found, a new one with Status=False is returned.
 func GetCondition(acc *conditionutils.Accessor, conditions []metav1.Condition, conditionType string) (*metav1.Condition, error) {
 	condition := &metav1.Condition{}
 	condFound, err := acc.FindSlice(conditions, conditionType, condition)
@@ -82,6 +83,20 @@ func GetCondition(acc *conditionutils.Accessor, conditions []metav1.Condition, c
 	}
 
 	return condition, nil
+}
+
+// migrateConditionTypes renames legacy condition type strings in-place.
+// Returns true if any conditions were migrated.
+// TODO: Remove this function in the next release once all CRs have been reconciled.
+func migrateConditionTypes(conditions []metav1.Condition, migrations map[string]string) bool {
+	migrated := false
+	for i := range conditions {
+		if newType, ok := migrations[conditions[i].Type]; ok {
+			conditions[i].Type = newType
+			migrated = true
+		}
+	}
+	return migrated
 }
 
 // GetServerByName returns a Server object by its name or an error in case the object can not be found.

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -65,8 +65,6 @@ const (
 	IsDefaultServerBootConfigOSImageKeyName = "metal.ironcore.dev/is-default-os-image"
 	// InternalAnnotationTypeValue is the value for the internal annotation type
 	InternalAnnotationTypeValue = "Internal"
-	// PoweringOnCondition is the condition type for powering on a server
-	PoweringOnCondition = "PoweringOn"
 )
 
 const (
@@ -1081,7 +1079,7 @@ func (r *ServerReconciler) updatePowerOnCondition(ctx context.Context, server *m
 	original := server.DeepCopy()
 	err := r.Conditions.UpdateSlice(
 		&server.Status.Conditions,
-		PoweringOnCondition,
+		ConditionPoweringOn,
 		conditionutils.UpdateStatus(metav1.ConditionTrue),
 		conditionutils.UpdateReason("ServerPowerOn"),
 		conditionutils.UpdateMessage("Server is powering on"),

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -243,7 +243,7 @@ var _ = Describe("Server Controller", func() {
 			}),
 			HaveField("Status.State", metalv1alpha1.ServerStateDiscovery),
 			HaveField("Status.Conditions", ContainElement(
-				HaveField("Type", PoweringOnCondition),
+				HaveField("Type", ConditionPoweringOn),
 			)),
 		))
 
@@ -439,7 +439,7 @@ var _ = Describe("Server Controller", func() {
 			HaveField("Status.IndicatorLED", metalv1alpha1.OffIndicatorLED),
 			HaveField("Status.State", metalv1alpha1.ServerStateDiscovery),
 			HaveField("Status.Conditions", ContainElement(
-				HaveField("Type", PoweringOnCondition),
+				HaveField("Type", ConditionPoweringOn),
 			)),
 		))
 

--- a/internal/controller/serverclaim_controller.go
+++ b/internal/controller/serverclaim_controller.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	ServerClaimFinalizer = "metal.ironcore.dev/serverclaim"
+	serverClaimFinalizer = "metal.ironcore.dev/serverclaim"
 )
 
 // ServerClaimReconciler reconciles a ServerClaim object
@@ -66,7 +66,7 @@ func (r *ServerClaimReconciler) reconcileExists(ctx context.Context, claim *meta
 func (r *ServerClaimReconciler) delete(ctx context.Context, claim *metalv1alpha1.ServerClaim) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Deleting server claim")
-	if !controllerutil.ContainsFinalizer(claim, ServerClaimFinalizer) {
+	if !controllerutil.ContainsFinalizer(claim, serverClaimFinalizer) {
 		log.V(1).Info("Deleted server claim")
 		return ctrl.Result{}, nil
 	}
@@ -74,7 +74,7 @@ func (r *ServerClaimReconciler) delete(ctx context.Context, claim *metalv1alpha1
 	if err := r.cleanupAndShutdownServer(ctx, claim); err != nil {
 		return ctrl.Result{}, err
 	}
-	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, claim, ServerClaimFinalizer); !apierrors.IsNotFound(err) || modified {
+	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, claim, serverClaimFinalizer); !apierrors.IsNotFound(err) || modified {
 		return ctrl.Result{}, err
 	}
 	log.V(1).Info("Ensured that the finalizer has been removed")
@@ -145,7 +145,7 @@ func (r *ServerClaimReconciler) reconcile(ctx context.Context, claim *metalv1alp
 		}
 	}
 
-	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, claim, ServerClaimFinalizer); err != nil || modified {
+	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, claim, serverClaimFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}
 	log.V(1).Info("Ensured finalizer has been added")

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -108,7 +108,7 @@ var _ = Describe("ServerClaim Controller", func() {
 
 		By("Ensuring that the ServerClaim is bound")
 		Eventually(Object(claim)).Should(SatisfyAll(
-			HaveField("Finalizers", ContainElement(ServerClaimFinalizer)),
+			HaveField("Finalizers", ContainElement(serverClaimFinalizer)),
 			HaveField("Status.Phase", metalv1alpha1.PhaseBound),
 			HaveField("Spec.ServerRef", Not(BeNil())),
 			HaveField("Spec.ServerRef.Name", server.Name),
@@ -207,7 +207,7 @@ var _ = Describe("ServerClaim Controller", func() {
 
 		By("Ensuring that the ServerClaim is bound")
 		Eventually(Object(claim)).Should(SatisfyAll(
-			HaveField("Finalizers", ContainElement(ServerClaimFinalizer)),
+			HaveField("Finalizers", ContainElement(serverClaimFinalizer)),
 			HaveField("Status.Phase", metalv1alpha1.PhaseBound),
 			HaveField("Spec.ServerRef", Not(BeNil())),
 			HaveField("Spec.ServerRef.Name", server.Name),
@@ -260,7 +260,7 @@ var _ = Describe("ServerClaim Controller", func() {
 
 		By("Ensuring that the ServerClaim is bound")
 		Eventually(Object(claim)).Should(SatisfyAll(
-			HaveField("Finalizers", ContainElement(ServerClaimFinalizer)),
+			HaveField("Finalizers", ContainElement(serverClaimFinalizer)),
 			HaveField("Spec.ServerRef", Equal(&v1.LocalObjectReference{Name: server.Name})),
 			HaveField("Status.Phase", metalv1alpha1.PhaseBound),
 		))
@@ -320,7 +320,7 @@ var _ = Describe("ServerClaim Controller", func() {
 
 		By("Ensuring that the ServerClaim is bound")
 		Eventually(Object(claim)).Should(SatisfyAll(
-			HaveField("Finalizers", ContainElement(ServerClaimFinalizer)),
+			HaveField("Finalizers", ContainElement(serverClaimFinalizer)),
 			HaveField("Status.Phase", metalv1alpha1.PhaseUnbound),
 		))
 
@@ -371,7 +371,7 @@ var _ = Describe("ServerClaim Controller", func() {
 
 		By("Ensuring that the ServerClaim is bound")
 		Eventually(Object(claim)).Should(SatisfyAll(
-			HaveField("Finalizers", ContainElement(ServerClaimFinalizer)),
+			HaveField("Finalizers", ContainElement(serverClaimFinalizer)),
 			HaveField("Status.Phase", metalv1alpha1.PhaseBound),
 		))
 
@@ -391,7 +391,7 @@ var _ = Describe("ServerClaim Controller", func() {
 
 		By("Ensuring that the ServerClaim is Unbound")
 		Eventually(Object(claim2)).Should(SatisfyAll(
-			HaveField("Finalizers", ContainElement(ServerClaimFinalizer)),
+			HaveField("Finalizers", ContainElement(serverClaimFinalizer)),
 			HaveField("Status.Phase", metalv1alpha1.PhaseUnbound),
 		))
 
@@ -459,7 +459,7 @@ var _ = Describe("ServerClaim Controller", func() {
 
 		By("Ensuring that the ServerClaim is unbound")
 		Eventually(Object(claim)).Should(SatisfyAll(
-			HaveField("Finalizers", ContainElement(ServerClaimFinalizer)),
+			HaveField("Finalizers", ContainElement(serverClaimFinalizer)),
 			HaveField("Status.Phase", metalv1alpha1.PhaseUnbound),
 		))
 

--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	// ServerMaintenanceFinalizer is the finalizer for the ServerMaintenance resource.
-	ServerMaintenanceFinalizer = "metal.ironcore.dev/servermaintenance"
+	// serverMaintenanceFinalizer is the finalizer for the ServerMaintenance resource.
+	serverMaintenanceFinalizer = "metal.ironcore.dev/servermaintenance"
 
 	// trueValue represents the string value "true" used for labels and annotations
 	trueValue = "true"
@@ -77,7 +77,7 @@ func (r *ServerMaintenanceReconciler) reconcile(ctx context.Context, maintenance
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get Server: %w", err)
 	}
-	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, maintenance, ServerMaintenanceFinalizer); err != nil || modified {
+	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, maintenance, serverMaintenanceFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}
 
@@ -361,7 +361,7 @@ func (r *ServerMaintenanceReconciler) delete(ctx context.Context, maintenance *m
 	log.V(1).Info("Removed dependencies")
 
 	log.V(1).Info("Ensuring that the finalizer is removed")
-	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, maintenance, ServerMaintenanceFinalizer); err != nil || modified {
+	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, maintenance, serverMaintenanceFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}
 	log.V(1).Info("Ensured that the finalizer is removed")


### PR DESCRIPTION
# Proposed Changes

Condition and reason constants were scattered across controller files with inconsistent naming conventions (mixed prefixes, unexported names, BIOS/BMC-specific names for generic concepts) and true duplicates using identical string values. This made it hard to discover existing constants and led to accidental duplication when adding new controllers.

Consolidate shared condition and reason constants into a central conditions.go file and normalize naming to a consistent Condition<Name>/Reason<Name> pattern. Generalize BIOS/BMC-specific names and string values where the concepts are generic (e.g., ConditionBMCResetIssued → ConditionResetIssued,
"BIOSSettingsTimedOut" → "SettingsTimedOut").

Since this change would be breaking, a migration logic has been introduced which migrate the legacy conditions to the new format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized and consolidated status condition and reason identifiers across controllers; introduced shared condition definitions and cleaned up constant declarations.
  * Renamed several finalizer identifiers to unexported names for consistency.

* **Chores / Migration**
  * Added automatic reconciliation-time migration to map legacy condition types and reasons to new identifiers, preserving resource status.

* **Tests**
  * Updated tests to use the renamed condition and reason identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->