### PR TITLE
Fix manager reset to use UUID instead of ID

### DIFF
--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -252,7 +252,7 @@ func resetBMCOfServer(ctx context.Context, kClient client.Client, server *metalv
 			return fmt.Errorf("failed to get manager to reset BMC: %w", err)
 		}
 		log.V(1).Info("Resetting through redfish to stabilize BMC of the server")
-		err = bmcClient.ResetManager(ctx, bmcManager.ID, schemas.GracefulRestartResetType)
+		err = bmcClient.ResetManager(ctx, bmcManager.UUID, schemas.GracefulRestartResetType)
 		if err != nil {
 			return fmt.Errorf("failed to get manager to reset BMC: %w", err)
 		}


### PR DESCRIPTION
The resetBMCOfServer function was incorrectly passing bmcManager.ID to ResetManager. The GetManager function expects UUID for comparison, so we must pass bmcManager.UUID instead.

Fixes #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected BMC manager reset operation to use the proper identifier for Redfish graceful reset, improving system reliability during maintenance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->