### PR TITLE
Add BMC manager discovery and non-bootable system filtering

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -57,6 +57,9 @@ type BMC interface {
 	// GetManager returns the manager
 	GetManager(UUID string) (*schemas.Manager, error)
 
+	// DiscoverManager returns the first manager that exposes graphical console capabilities.
+	DiscoverManager(ctx context.Context) (*schemas.Manager, error)
+
 	// ResetManager performs a reset on the Manager.
 	ResetManager(ctx context.Context, UUID string, resetType schemas.ResetType) error
 

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -215,6 +215,9 @@ func (r *RedfishBaseBMC) GetSystems(ctx context.Context) ([]Server, error) {
 	}
 	servers := make([]Server, 0, len(systems))
 	for _, s := range systems {
+		if s.Boot.BootSourceOverrideTarget == "" {
+			continue
+		}
 		servers = append(servers, Server{
 			UUID:         s.UUID,
 			URI:          s.ODataID,
@@ -274,6 +277,28 @@ func (r *RedfishBaseBMC) GetManager(bmcUUID string) (*schemas.Manager, error) {
 		}
 	}
 	return nil, fmt.Errorf("matching managers not found for UUID %v", bmcUUID)
+}
+
+// DiscoverManager queries the BMC for available managers and returns the first
+// one that exposes graphical console capabilities (non-zero MaxConcurrentSessions
+// or non-empty ConnectTypesSupported).
+func (r *RedfishBaseBMC) DiscoverManager(_ context.Context) (*schemas.Manager, error) {
+	if r.client == nil {
+		return nil, fmt.Errorf("no client found")
+	}
+	managers, err := r.client.Service.Managers()
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range managers {
+		if m.GraphicalConsole.MaxConcurrentSessions != 0 {
+			return m, nil
+		}
+		if len(m.GraphicalConsole.ConnectTypesSupported) != 0 {
+			return m, nil
+		}
+	}
+	return nil, fmt.Errorf("no manager found with graphical console capabilities")
 }
 
 func (r *RedfishBaseBMC) ResetManager(ctx context.Context, bmcUUID string, resetType schemas.ResetType) error {

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -279,9 +279,10 @@ func (r *RedfishBaseBMC) GetManager(bmcUUID string) (*schemas.Manager, error) {
 	return nil, fmt.Errorf("matching managers not found for UUID %v", bmcUUID)
 }
 
-// DiscoverManager queries the BMC for available managers and returns the first
-// one that exposes graphical console capabilities (non-zero MaxConcurrentSessions
-// or non-empty ConnectTypesSupported).
+// DiscoverManager queries the BMC for available managers and returns the one
+// with graphical console capabilities (non-zero MaxConcurrentSessions or
+// non-empty ConnectTypesSupported). When multiple candidates match, the manager
+// with the lexicographically smallest ODataID is returned for determinism.
 func (r *RedfishBaseBMC) DiscoverManager(_ context.Context) (*schemas.Manager, error) {
 	if r.client == nil {
 		return nil, fmt.Errorf("no client found")
@@ -290,15 +291,20 @@ func (r *RedfishBaseBMC) DiscoverManager(_ context.Context) (*schemas.Manager, e
 	if err != nil {
 		return nil, err
 	}
+	var candidates []*schemas.Manager
 	for _, m := range managers {
-		if m.GraphicalConsole.MaxConcurrentSessions != 0 {
-			return m, nil
-		}
-		if len(m.GraphicalConsole.ConnectTypesSupported) != 0 {
-			return m, nil
+		if m.GraphicalConsole.MaxConcurrentSessions != 0 ||
+			len(m.GraphicalConsole.ConnectTypesSupported) != 0 {
+			candidates = append(candidates, m)
 		}
 	}
-	return nil, fmt.Errorf("no manager found with graphical console capabilities")
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no manager found with graphical console capabilities")
+	}
+	slices.SortFunc(candidates, func(a, b *schemas.Manager) int {
+		return strings.Compare(a.ODataID, b.ODataID)
+	})
+	return candidates[0], nil
 }
 
 func (r *RedfishBaseBMC) ResetManager(ctx context.Context, bmcUUID string, resetType schemas.ResetType) error {

--- a/bmc/redfish_dell_test.go
+++ b/bmc/redfish_dell_test.go
@@ -7,17 +7,11 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stmcginnis/gofish/schemas"
 )
-
-func TestDellOEM(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Dell OEM Suite")
-}
 
 var _ = Describe("Dell OEM", func() {
 	var dell *DellRedfishBMC

--- a/bmc/redfish_test.go
+++ b/bmc/redfish_test.go
@@ -5,70 +5,224 @@ package bmc
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/stmcginnis/gofish"
+	"github.com/stmcginnis/gofish/schemas"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stmcginnis/gofish/schemas"
 )
 
-// fakeBMCClient is a minimal stub implementing BMC for unit testing DiscoverManager.
-type fakeBMCClient struct {
-	BMC
-	manager    *schemas.Manager
-	managerErr error
+// newTestRedfishBMC creates a RedfishBaseBMC backed by the given httptest server.
+// It connects using basic auth to avoid session creation requests.
+func newTestRedfishBMC(server *httptest.Server) *RedfishBaseBMC {
+	client, err := gofish.ConnectContext(context.Background(),
+		gofish.ClientConfig{
+			Endpoint:   server.URL,
+			Username:   "admin",
+			Password:   "admin",
+			BasicAuth:  true,
+			HTTPClient: server.Client(),
+		})
+	Expect(err).NotTo(HaveOccurred())
+	return &RedfishBaseBMC{client: client}
 }
 
-func (f *fakeBMCClient) DiscoverManager(_ context.Context) (*schemas.Manager, error) {
-	return f.manager, f.managerErr
+// managerJSON returns JSON bytes for a Manager with the given fields.
+func managerJSON(id string, maxSessions uint, connectTypes []string) []byte {
+	type graphicalConsole struct {
+		MaxConcurrentSessions uint     `json:"MaxConcurrentSessions"`
+		ConnectTypesSupported []string `json:"ConnectTypesSupported"`
+		ServiceEnabled        bool     `json:"ServiceEnabled"`
+	}
+	m := struct {
+		ODataID          string           `json:"@odata.id"`
+		ID               string           `json:"Id"`
+		Name             string           `json:"Name"`
+		GraphicalConsole graphicalConsole `json:"GraphicalConsole"`
+	}{
+		ODataID: "/redfish/v1/Managers/" + id,
+		ID:      id,
+		Name:    "Manager " + id,
+		GraphicalConsole: graphicalConsole{
+			MaxConcurrentSessions: maxSessions,
+			ConnectTypesSupported: connectTypes,
+			ServiceEnabled:        true,
+		},
+	}
+	b, _ := json.Marshal(m)
+	return b
 }
 
-var _ = Describe("DiscoverManager", func() {
-	It("should return a manager with GraphicalConsole.MaxConcurrentSessions set", func(ctx SpecContext) {
-		fake := &fakeBMCClient{
-			manager: &schemas.Manager{
-				GraphicalConsole: schemas.GraphicalConsole{
-					MaxConcurrentSessions: 2,
-				},
-			},
-		}
-		manager, err := fake.DiscoverManager(ctx)
+// serviceRootJSON returns JSON for a minimal Redfish service root.
+func serviceRootJSON() []byte {
+	root := map[string]any{
+		"@odata.id":      "/redfish/v1/",
+		"Id":             "ServiceRoot",
+		"Name":           "Service Root",
+		"RedfishVersion": "1.0.0",
+		"Managers":       map[string]string{"@odata.id": "/redfish/v1/Managers"},
+	}
+	b, _ := json.Marshal(root)
+	return b
+}
+
+// managersCollectionJSON returns JSON for a managers collection with the given member links.
+func managersCollectionJSON(memberLinks []string) []byte {
+	type member struct {
+		ODataID string `json:"@odata.id"`
+	}
+	members := make([]member, len(memberLinks))
+	for i, link := range memberLinks {
+		members[i] = member{ODataID: link}
+	}
+	col := map[string]any{
+		"@odata.id":           "/redfish/v1/Managers",
+		"Name":                "Manager Collection",
+		"Members@odata.count": len(memberLinks),
+		"Members":             members,
+	}
+	b, _ := json.Marshal(col)
+	return b
+}
+
+var _ = Describe("RedfishBaseBMC DiscoverManager", func() {
+	ctx := context.Background()
+
+	It("should return the first manager with MaxConcurrentSessions set", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managersCollectionJSON([]string{"/redfish/v1/Managers/BMC1"})) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers/BMC1", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managerJSON("BMC1", 2, nil)) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		manager, err := bmc.DiscoverManager(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 		Expect(manager.GraphicalConsole.MaxConcurrentSessions).To(Equal(uint(2)))
 	})
 
-	It("should return a manager with GraphicalConsole.ConnectTypesSupported set", func(ctx SpecContext) {
-		fake := &fakeBMCClient{
-			manager: &schemas.Manager{
-				GraphicalConsole: schemas.GraphicalConsole{
-					ConnectTypesSupported: []schemas.GraphicalConnectTypesSupported{"KVMIP"},
-				},
-			},
-		}
-		manager, err := fake.DiscoverManager(ctx)
+	It("should return the first manager with ConnectTypesSupported set", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managersCollectionJSON([]string{"/redfish/v1/Managers/BMC1"})) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers/BMC1", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managerJSON("BMC1", 0, []string{"KVMIP"})) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		manager, err := bmc.DiscoverManager(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 		Expect(manager.GraphicalConsole.ConnectTypesSupported).To(HaveLen(1))
+		Expect(manager.GraphicalConsole.ConnectTypesSupported[0]).To(Equal(schemas.GraphicalConnectTypesSupported("KVMIP")))
 	})
 
-	It("should return an error when no suitable manager is found", func(ctx SpecContext) {
-		fake := &fakeBMCClient{
-			managerErr: fmt.Errorf("no manager found with graphical console capabilities"),
-		}
-		manager, err := fake.DiscoverManager(ctx)
+	It("should skip managers without graphical console and return a suitable one", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managersCollectionJSON([]string{"/redfish/v1/Managers/NoConsole", "/redfish/v1/Managers/WithConsole"})) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers/NoConsole", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managerJSON("NoConsole", 0, nil)) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers/WithConsole", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managerJSON("WithConsole", 4, []string{"KVMIP"})) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		manager, err := bmc.DiscoverManager(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(manager).NotTo(BeNil())
+		// Should have found the one with graphical console capabilities
+		Expect(manager.GraphicalConsole.MaxConcurrentSessions).To(BeNumerically(">", 0))
+	})
+
+	It("should return an error when no managers have graphical console capabilities", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managersCollectionJSON([]string{"/redfish/v1/Managers/Plain"})) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers/Plain", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managerJSON("Plain", 0, nil)) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		manager, err := bmc.DiscoverManager(ctx)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("no manager found"))
+		Expect(err.Error()).To(ContainSubstring("no manager found with graphical console capabilities"))
 		Expect(manager).To(BeNil())
 	})
 
-	It("should return an error when the BMC connection fails", func(ctx SpecContext) {
-		fake := &fakeBMCClient{
-			managerErr: fmt.Errorf("connection refused"),
-		}
-		manager, err := fake.DiscoverManager(ctx)
+	It("should return an error when the managers endpoint fails", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error": {"message": "internal error"}}`)) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		manager, err := bmc.DiscoverManager(ctx)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("connection refused"))
+		Expect(manager).To(BeNil())
+	})
+
+	It("should return an error when the client is nil", func() {
+		bmc := &RedfishBaseBMC{client: nil}
+		manager, err := bmc.DiscoverManager(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no client found"))
 		Expect(manager).To(BeNil())
 	})
 })

--- a/bmc/redfish_test.go
+++ b/bmc/redfish_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package bmc
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+// fakeBMCClient is a minimal stub implementing BMC for unit testing DiscoverManager.
+type fakeBMCClient struct {
+	BMC
+	manager    *schemas.Manager
+	managerErr error
+}
+
+func (f *fakeBMCClient) DiscoverManager(_ context.Context) (*schemas.Manager, error) {
+	return f.manager, f.managerErr
+}
+
+var _ = Describe("DiscoverManager", func() {
+	It("should return a manager with GraphicalConsole.MaxConcurrentSessions set", func(ctx SpecContext) {
+		fake := &fakeBMCClient{
+			manager: &schemas.Manager{
+				GraphicalConsole: schemas.GraphicalConsole{
+					MaxConcurrentSessions: 2,
+				},
+			},
+		}
+		manager, err := fake.DiscoverManager(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(manager).NotTo(BeNil())
+		Expect(manager.GraphicalConsole.MaxConcurrentSessions).To(Equal(uint(2)))
+	})
+
+	It("should return a manager with GraphicalConsole.ConnectTypesSupported set", func(ctx SpecContext) {
+		fake := &fakeBMCClient{
+			manager: &schemas.Manager{
+				GraphicalConsole: schemas.GraphicalConsole{
+					ConnectTypesSupported: []schemas.GraphicalConnectTypesSupported{"KVMIP"},
+				},
+			},
+		}
+		manager, err := fake.DiscoverManager(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(manager).NotTo(BeNil())
+		Expect(manager.GraphicalConsole.ConnectTypesSupported).To(HaveLen(1))
+	})
+
+	It("should return an error when no suitable manager is found", func(ctx SpecContext) {
+		fake := &fakeBMCClient{
+			managerErr: fmt.Errorf("no manager found with graphical console capabilities"),
+		}
+		manager, err := fake.DiscoverManager(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no manager found"))
+		Expect(manager).To(BeNil())
+	})
+
+	It("should return an error when the BMC connection fails", func(ctx SpecContext) {
+		fake := &fakeBMCClient{
+			managerErr: fmt.Errorf("connection refused"),
+		}
+		manager, err := fake.DiscoverManager(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("connection refused"))
+		Expect(manager).To(BeNil())
+	})
+})

--- a/bmc/redfish_test.go
+++ b/bmc/redfish_test.go
@@ -173,6 +173,37 @@ var _ = Describe("RedfishBaseBMC DiscoverManager", func() {
 		Expect(manager.GraphicalConsole.MaxConcurrentSessions).To(BeNumerically(">", 0))
 	})
 
+	It("should deterministically select the manager with the smallest ODataID when multiple candidates match", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootJSON()) //nolint:errcheck
+		})
+		// List managers in reverse alphabetical order to verify sorting
+		mux.HandleFunc("/redfish/v1/Managers", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managersCollectionJSON([]string{"/redfish/v1/Managers/Z-BMC", "/redfish/v1/Managers/A-BMC"})) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers/Z-BMC", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managerJSON("Z-BMC", 4, []string{"KVMIP"})) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/Managers/A-BMC", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(managerJSON("A-BMC", 2, []string{"KVMIP"})) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		manager, err := bmc.DiscoverManager(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(manager).NotTo(BeNil())
+		// Should select A-BMC (lexicographically smallest ODataID) despite Z-BMC being listed first
+		Expect(manager.ID).To(Equal("A-BMC"))
+	})
+
 	It("should return an error when no managers have graphical console capabilities", func() {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {

--- a/bmc/suite_test.go
+++ b/bmc/suite_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package bmc
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBMC(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BMC Suite")
+}

--- a/docs/concepts/bmcs.md
+++ b/docs/concepts/bmcs.md
@@ -92,7 +92,11 @@ power state.
 
 3. **Update BMCStatus**: Populates the `status` field of the BMC resource with the retrieved information.
 
-4. **Detect Managed Systems**: Identifies all systems (servers) that the BMC manages.
+4. **Detect Managed Systems**: Identifies all systems (servers) that the BMC manages. During detection, systems are 
+filtered to exclude non-bootable entries: any system that does not report a `BootSourceOverrideTarget` in its Redfish 
+Boot configuration is considered non-bootable and is skipped. This filters out auxiliary system entries (e.g. virtual 
+or management subsystems) that appear in the Redfish system collection but do not represent physical servers capable 
+of booting an operating system.
 
 5. **Create Server Resources**: For each detected system, the `BMCReconciler` creates a corresponding [`Server`](servers.md)
 resource to represent the physical server.

--- a/docs/concepts/endpoints.md
+++ b/docs/concepts/endpoints.md
@@ -87,5 +87,13 @@ the device.
 Controller (`type: "bmc"`), it automatically creates a [`BMC`](bmcs.md) and a [`BMCSecret`](bmcsecrets.md)
 object using the data from the MAC Prefix Database. These objects are used to manage and authenticate with the BMC device.
 
-6. **Configuration Application**: Additional settings such as console access and communication ports are applied based 
+6. **Manager Discovery**: During BMC creation, the `EndpointReconciler` queries the BMC for available Redfish managers 
+and attempts to identify the primary management controller. A manager is considered a valid BMC manager if it exposes 
+graphical console capabilities (non-zero `MaxConcurrentSessions` or non-empty `ConnectTypesSupported`). This heuristic 
+distinguishes actual BMC managers from auxiliary controllers (e.g. network switches or storage controllers) that may 
+also appear in the Redfish manager collection. If a matching manager is found, its UUID is stored in the `BMC` 
+resource's `spec.bmcUUID` field. If no suitable manager can be determined, the `BMC` resource is still created without 
+a UUID since the field is optional.
+
+7. **Configuration Application**: Additional settings such as console access and communication ports are applied based 
 on the database entries.

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -188,7 +188,9 @@ func (r *EndpointReconciler) applyBMC(ctx context.Context, bmcClient bmc.BMC, en
 			Name: metalv1alpha1.ConsoleProtocolName(m.Console.Type),
 			Port: m.Console.Port,
 		}
-		spec.BMCUUID = bmcUUID
+		if bmcUUID != "" {
+			spec.BMCUUID = bmcUUID
+		}
 		return controllerutil.SetControllerReference(endpoint, bmcObj, r.Client.Scheme())
 	})
 	if err != nil {

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -111,7 +111,7 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, endpoint *metalv1alp
 				}
 				log.V(1).Info("Applied BMC secret for Endpoint")
 
-				if err := r.applyBMC(ctx, endpoint, bmcSecret, m); err != nil {
+				if err := r.applyBMC(ctx, bmcClient, endpoint, bmcSecret, m); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to apply BMC object: %w", err)
 				}
 				log.V(1).Info("Applied BMC object for Endpoint")
@@ -129,7 +129,7 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, endpoint *metalv1alp
 				}
 				log.V(1).Info("Applied local test BMC secret for Endpoint")
 
-				if err := r.applyBMC(ctx, endpoint, bmcSecret, m); err != nil {
+				if err := r.applyBMC(ctx, bmcClient, endpoint, bmcSecret, m); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to apply BMC object: %w", err)
 				}
 				log.V(1).Info("Applied BMC object for Endpoint")
@@ -147,7 +147,7 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, endpoint *metalv1alp
 				}
 				log.V(1).Info("Applied kube test BMC secret for Endpoint")
 
-				if err := r.applyBMC(ctx, endpoint, bmcSecret, m); err != nil {
+				if err := r.applyBMC(ctx, bmcClient, endpoint, bmcSecret, m); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to apply BMC object: %w", err)
 				}
 				log.V(1).Info("Applied BMC object for Endpoint")
@@ -162,8 +162,17 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, endpoint *metalv1alp
 	return ctrl.Result{}, nil
 }
 
-func (r *EndpointReconciler) applyBMC(ctx context.Context, endpoint *metalv1alpha1.Endpoint, secret *metalv1alpha1.BMCSecret, m macdb.MacPrefix) error {
+func (r *EndpointReconciler) applyBMC(ctx context.Context, bmcClient bmc.BMC, endpoint *metalv1alpha1.Endpoint, secret *metalv1alpha1.BMCSecret, m macdb.MacPrefix) error {
 	log := ctrl.LoggerFrom(ctx)
+	var bmcUUID string
+	manager, err := bmcClient.DiscoverManager(ctx)
+	if err != nil {
+		log.V(1).Info("Could not determine manager UUID, proceeding without it", "error", err)
+	} else {
+		bmcUUID = manager.UUID
+		log.V(1).Info("Got manager from BMC client", "ManagerUUID", bmcUUID)
+	}
+
 	bmcObj := &metalv1alpha1.BMC{}
 	bmcObj.Name = endpoint.Name
 	opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, bmcObj, func() error {
@@ -179,6 +188,7 @@ func (r *EndpointReconciler) applyBMC(ctx context.Context, endpoint *metalv1alph
 			Name: metalv1alpha1.ConsoleProtocolName(m.Console.Type),
 			Port: m.Console.Port,
 		}
+		spec.BMCUUID = bmcUUID
 		return controllerutil.SetControllerReference(endpoint, bmcObj, r.Client.Scheme())
 	})
 	if err != nil {

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -15,7 +15,9 @@ import (
 	"github.com/ironcore-dev/metal-operator/internal/api/macdb"
 	"github.com/ironcore-dev/metal-operator/internal/bmcutils"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -164,13 +166,27 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, endpoint *metalv1alp
 
 func (r *EndpointReconciler) applyBMC(ctx context.Context, bmcClient bmc.BMC, endpoint *metalv1alpha1.Endpoint, secret *metalv1alpha1.BMCSecret, m macdb.MacPrefix) error {
 	log := ctrl.LoggerFrom(ctx)
+
+	// Check whether the existing BMC object already has a UUID persisted.
 	var bmcUUID string
-	manager, err := bmcClient.DiscoverManager(ctx)
-	if err != nil {
-		log.V(1).Info("Could not determine manager UUID, proceeding without it", "error", err)
+	existingBMC := &metalv1alpha1.BMC{}
+	if err := r.Get(ctx, types.NamespacedName{Name: endpoint.Name}, existingBMC); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get existing BMC: %w", err)
+		}
 	} else {
-		bmcUUID = manager.UUID
-		log.V(1).Info("Got manager from BMC client", "ManagerUUID", bmcUUID)
+		bmcUUID = existingBMC.Spec.BMCUUID
+	}
+
+	// Only call DiscoverManager when UUID is not yet known.
+	if bmcUUID == "" {
+		manager, err := bmcClient.DiscoverManager(ctx)
+		if err != nil {
+			log.V(1).Info("Could not determine manager UUID, proceeding without it", "error", err)
+		} else {
+			bmcUUID = manager.UUID
+			log.V(1).Info("Got manager from BMC client", "ManagerUUID", bmcUUID)
+		}
 	}
 
 	bmcObj := &metalv1alpha1.BMC{}

--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -55,13 +55,13 @@ var _ = Describe("Endpoints Controller", func() {
 				metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
 			}))))
 
-		By("Ensuring that the BMC object has been created")
-		bmc := &metalv1alpha1.BMC{
+		By("Ensuring that the BMC object has been created with BMCUUID set")
+		bmcObj := &metalv1alpha1.BMC{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: endpoint.Name,
 			},
 		}
-		Eventually(Object(bmc)).Should(SatisfyAll(
+		Eventually(Object(bmcObj)).Should(SatisfyAll(
 			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
 				APIVersion:         "metal.ironcore.dev/v1alpha1",
 				Kind:               "Endpoint",
@@ -71,7 +71,7 @@ var _ = Describe("Endpoints Controller", func() {
 				BlockOwnerDeletion: ptr.To(true),
 			})),
 			HaveField("Spec.EndpointRef.Name", Equal(endpoint.Name)),
-			HaveField("Spec.BMCSecretRef.Name", Equal(bmc.Name)),
+			HaveField("Spec.BMCSecretRef.Name", Equal(bmcObj.Name)),
 			HaveField("Spec.Protocol", metalv1alpha1.Protocol{
 				Name: metalv1alpha1.ProtocolRedfishLocal,
 				Port: MockServerPort,
@@ -79,12 +79,14 @@ var _ = Describe("Endpoints Controller", func() {
 			HaveField("Spec.ConsoleProtocol", &metalv1alpha1.ConsoleProtocol{
 				Name: metalv1alpha1.ConsoleProtocolNameSSH,
 				Port: 22,
-			})))
+			}),
+			HaveField("Spec.BMCUUID", Not(BeEmpty())),
+		))
 
 		By("Ensuring that the server object has been created")
 		server := &metalv1alpha1.Server{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: bmcutils.GetServerNameFromBMCandIndex(0, bmc),
+				Name: bmcutils.GetServerNameFromBMCandIndex(0, bmcObj),
 			},
 		}
 		Eventually(Get(server)).Should(Succeed())
@@ -94,7 +96,7 @@ var _ = Describe("Endpoints Controller", func() {
 
 		By("Ensuring that all subsequent objects have been removed")
 		Eventually(Get(endpoint)).Should(Satisfy(apierrors.IsNotFound))
-		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmc))).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcObj))).To(Succeed())
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcSecret))).To(Succeed())
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, server))).To(Succeed())
 	})


### PR DESCRIPTION
# Proposed Changes

Introduce manager discovery during endpoint reconciliation to identify the primary BMC manager by graphical console capabilities and store its UUID in the BMC spec. Filter out non-bootable systems (missing BootSourceOverrideTarget) from the Redfish system collection. The BMCUUID field remains optional to avoid breaking existing BMC resources when manager discovery fails.

Fixes #823 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic manager discovery to identify the primary management controller (graphical-console capable); discovered manager UUID is recorded on BMC resources when found.
  * Public BMC interface extended to expose manager discovery.

* **Improvements**
  * System detection now filters out non-bootable/auxiliary systems lacking boot-source reporting.
  * Manager selection is deterministic (consistent tie-breaking); discovery failures are logged and do not block BMC creation.

* **Documentation**
  * Added Manager Discovery stage and clarified system-detection behavior.

* **Tests**
  * Added comprehensive tests for discovery, selection, and error scenarios; adjusted test suite entrypoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->