### PR TITLE
ci: skip long-running checks on docs-only PRs via noop companion workflows

### DIFF
--- a/.github/workflows/check-codegen-noop.yml
+++ b/.github/workflows/check-codegen-noop.yml
@@ -1,0 +1,19 @@
+name: Check Codegen
+
+# Noop companion to check-codegen.yml. Fires when a PR only touches
+# docs / markdown files, declaring the same job name so the required
+# "Run code generation checks" status check is satisfied without running
+# the real codegen diff. See
+# https://github.com/ironcore-dev/metal-operator/issues/824.
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '**/*.md'
+
+jobs:
+  check-codegen:
+    name: Run code generation checks
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change, skipping code generation checks"

--- a/.github/workflows/check-codegen.yml
+++ b/.github/workflows/check-codegen.yml
@@ -2,6 +2,9 @@ name: Check Codegen
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
 
 jobs:
   check-codegen:

--- a/.github/workflows/lint-noop.yml
+++ b/.github/workflows/lint-noop.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+# Noop companion to lint.yml. Fires when a PR only touches docs / markdown
+# files, declaring the same job name so the required "Run linter" status
+# check is satisfied without running the real linter. See
+# https://github.com/ironcore-dev/metal-operator/issues/824.
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '**/*.md'
+
+jobs:
+  lint:
+    name: Run linter
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change, skipping linter"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
 
 jobs:
   lint:

--- a/.github/workflows/test-noop.yml
+++ b/.github/workflows/test-noop.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+# Noop companion to test.yml. Fires when a PR only touches docs / markdown
+# files, declaring the same job name so the required "Run tests" status
+# check is satisfied without running the real long-running test job. See
+# https://github.com/ironcore-dev/metal-operator/issues/824.
+on:
+  pull_request:
+    types: [ assigned, opened, synchronize, reopened ]
+    paths:
+      - 'docs/**'
+      - '**/*.md'
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change, skipping tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Tests
 on:
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
 
 jobs:
   test:


### PR DESCRIPTION
Closes #824.

## Change

Implements the pattern @afritzler / @damyan / @stefanhipfel sketched on #818: use same-name noop workflows so docs-only PRs skip the real `test` / `lint` / `check-codegen` jobs while still satisfying the required status checks (GitHub matches status by job name, not file).

- `test.yml` / `lint.yml` / `check-codegen.yml`: add \`paths-ignore: ['docs/**', '**/*.md']\` so the real jobs no longer run on docs-only changes.
- `test-noop.yml` / `lint-noop.yml` / `check-codegen-noop.yml`: new files, trigger on the opposite path set with the same job names (\`test\` / \`lint\` / \`check-codegen\`) and the same display names (\`Run tests\` / \`Run linter\` / \`Run code generation checks\`). Each job runs a single \`echo\` step and exits cleanly.

Net effect: a PR that only changes docs/markdown reports the three required checks green in seconds; a PR that touches any code file goes through the existing jobs unchanged. Both paths always report a status under the expected names, so branch protection doesn't need to be touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized pull request workflows to skip code generation, linting, and testing checks when changes are limited to documentation or Markdown files.
  * Added fallback workflow variants to provide required status checks for documentation-only changes without running unnecessary code quality verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->