### PR TITLE
Add Server Label to metrics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    types: [ assigned, opened, synchronize, reopened ]
+    types: [assigned, opened, synchronize, reopened]
 
 jobs:
   test:
@@ -30,3 +30,21 @@ jobs:
         run: |
           sudo --preserve-env=GOROOT,GOPATH,PATH go mod tidy
           sudo --preserve-env=GOROOT,GOPATH,PATH make test-only
+
+  test-alerts:
+    name: Test Prometheus alert rules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Check alert rules syntax
+        run: make check-alerts
+
+      - name: Run alert rule tests
+        run: make test-alerts

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docs/.vitepress/cache/*
 docs/.vitepress/dist/*
 .vitepress/
 .cache
+config/prometheus/server_alerts_rules.yaml

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,16 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 lint-config: golangci-lint ## Verify golangci-lint linter configuration
 	"$(GOLANGCI_LINT)" config verify
 
+.PHONY: test-alerts
+test-alerts: promtool yq ## Run Prometheus alert rule tests.
+	@"$(YQ)" '.spec' config/prometheus/server_alerts.yaml > config/prometheus/server_alerts_rules.yaml
+	"$(PROMTOOL)" test rules config/prometheus/server_alerts_test.yaml
+
+.PHONY: check-alerts
+check-alerts: promtool yq ## Validate Prometheus alert rules syntax.
+	@"$(YQ)" '.spec' config/prometheus/server_alerts.yaml > config/prometheus/server_alerts_rules.yaml
+	"$(PROMTOOL)" check rules config/prometheus/server_alerts_rules.yaml
+
 .PHONY: startdocs
 startdocs: ## Start the local mkdocs based development environment.
 	docker build -t $(IMAGE) -f docs/Dockerfile . --load
@@ -270,6 +280,8 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GOIMPORTS ?= $(LOCALBIN)/goimports
 METALCTL ?= $(LOCALBIN)/metalctl
 GINKGO ?= $(LOCALBIN)/ginkgo
+PROMTOOL ?= $(LOCALBIN)/promtool
+YQ ?= $(LOCALBIN)/yq
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.8.1
@@ -285,6 +297,8 @@ CRD_REF_DOCS_VERSION ?= v0.2.0
 KUBEBUILDER_VERSION ?= v4.13.0
 ADDLICENSE_VERSION ?= v1.1.1
 GINKGO_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
+PROMTOOL_VERSION ?= 3.11.3
+YQ_VERSION ?= v4.44.3
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.
@@ -359,6 +373,16 @@ $(MOCKSERVER_BIN): $(LOCALBIN)
 .PHONY: metalctl
 metalctl: $(METALCTL) ## Build metalctl locally if necessary.
 	go build -o $(METALCTL) ./cmd/metalctl
+
+.PHONY: promtool
+promtool: $(PROMTOOL) ## Download promtool locally if necessary.
+$(PROMTOOL): $(LOCALBIN)
+	@hack/install-promtool.sh "$(PROMTOOL_VERSION)" "$(LOCALBIN)"
+
+.PHONY: yq
+yq: $(YQ) ## Download yq locally if necessary.
+$(YQ): $(LOCALBIN)
+	$(call go-install-tool,$(YQ),github.com/mikefarah/yq/v4,$(YQ_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # Note: All paths are quoted to work in directories containing spaces or parentheses.

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -9,6 +9,7 @@ metadata:
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
+  jobLabel: app.kubernetes.io/name
   endpoints:
     - path: /metrics
       port: https # Ensure this is the name of the port that exposes HTTPS metrics
@@ -25,4 +26,3 @@ spec:
     matchLabels:
       control-plane: controller-manager
       app.kubernetes.io/name: metal-operator
-

--- a/config/prometheus/server_alerts.yaml
+++ b/config/prometheus/server_alerts.yaml
@@ -7,82 +7,82 @@ metadata:
     control-plane: controller-manager
 spec:
   groups:
-  - name: metal_operator_servers
-    interval: 30s
-    rules:
-    - alert: NoAvailableServers
-      expr: sum(metal_server_state{state="Available"} or on() vector(0)) < 1 AND sum(metal_server_state{state="Reserved"} or on() vector(0)) == 0
-      for: 5m
-      annotations:
-        summary: "No available or reserved servers in the fleet"
-        description: "The fleet is completely idle with no servers in Available or Reserved state"
-      labels:
-        severity: warning
+    - name: metal_operator_servers
+      interval: 30s
+      rules:
+        - alert: NoAvailableServers
+          expr: (count(metal_server_state{state="Available"}) or vector(0)) < 1 and (count(metal_server_state{state="Reserved"}) or vector(0)) < 1
+          for: 5m
+          annotations:
+            summary: "No available or reserved servers in the fleet"
+            description: "The fleet is completely idle with no servers in Available or Reserved state"
+          labels:
+            severity: warning
 
-    - alert: ServersInErrorState
-      expr: metal_server_state{state="Error"} > 0
-      for: 2m
-      annotations:
-        summary: "Servers are in Error state"
-        description: "{{ $value }} server(s) are in Error state and require attention"
-      labels:
-        severity: critical
+        - alert: ServersInErrorState
+          expr: metal_server_state{state="Error"} == 1
+          for: 2m
+          annotations:
+            summary: "Server {{ $labels.server }} is in Error state"
+            description: "Server {{ $labels.server }} is in Error state and requires attention"
+          labels:
+            severity: critical
 
-    - alert: ServersPoweringOnTooLong
-      expr: metal_server_power_state{power_state="PoweringOn"} > 0
-      for: 10m
-      annotations:
-        summary: "Servers stuck in PoweringOn state"
-        description: "{{ $value }} server(s) have been in PoweringOn state for over 10 minutes"
-      labels:
-        severity: warning
+        - alert: ServersPoweringOnTooLong
+          expr: metal_server_power_state{power_state="PoweringOn"} == 1
+          for: 10m
+          annotations:
+            summary: "Server {{ $labels.server }} stuck in PoweringOn state"
+            description: "Server {{ $labels.server }} has been in PoweringOn state for over 10 minutes"
+          labels:
+            severity: warning
 
-    - alert: ServersPoweringOffTooLong
-      expr: metal_server_power_state{power_state="PoweringOff"} > 0
-      for: 10m
-      annotations:
-        summary: "Servers stuck in PoweringOff state"
-        description: "{{ $value }} server(s) have been in PoweringOff state for over 10 minutes"
-      labels:
-        severity: warning
+        - alert: ServersPoweringOffTooLong
+          expr: metal_server_power_state{power_state="PoweringOff"} == 1
+          for: 10m
+          annotations:
+            summary: "Server {{ $labels.server }} stuck in PoweringOff state"
+            description: "Server {{ $labels.server }} has been in PoweringOff state for over 10 minutes"
+          labels:
+            severity: warning
 
-    - alert: HighReconciliationErrorRate
-      expr: rate(metal_server_reconciliation_total{result=~"error_.*"}[5m]) > 0.1
-      for: 5m
-      annotations:
-        summary: "High server reconciliation error rate"
-        description: "Server reconciliation errors are occurring at {{ $value | humanize }} per second"
-      labels:
-        severity: warning
+        - alert: HighReconciliationErrorRate
+          expr: rate(metal_server_reconciliation_total{result=~"error_.*"}[5m]) > 0.1
+          for: 5m
+          annotations:
+            summary: "High server reconciliation error rate"
+            description: "Server reconciliation errors are occurring at {{ $value | humanize }} per second"
+          labels:
+            severity: warning
 
-    - alert: LowAvailableServerCapacity
-      expr: sum(metal_server_state{state="Available"} or on() vector(0)) < 2
-      for: 5m
-      annotations:
-        summary: "Low available server capacity"
-        description: "Only {{ $value }} server(s) are available"
-      labels:
-        severity: warning
+        - alert: LowAvailableServerCapacity
+          expr: (count(metal_server_state{state="Available"}) or vector(0)) < 2
+          for: 5m
+          annotations:
+            summary: "Low available server capacity"
+            description: "Only {{ $value }} server(s) are available"
+          labels:
+            severity: warning
 
-    - alert: ServerMetricsMissing
-      expr: absent(metal_server_state)
-      for: 5m
-      annotations:
-        summary: "Server metrics are not being collected"
-        description: "The metal-operator metrics endpoint is not reporting server state metrics"
-      labels:
-        severity: critical
+        - alert: ServerMetricsMissing
+          expr: up{job="metal-operator"} == 0
+          for: 5m
+          annotations:
+            summary: "Metal-operator scrape is failing"
+            description: "Prometheus cannot scrape the metal-operator metrics endpoint - check operator health and network connectivity"
+          labels:
+            severity: critical
 
-    - alert: ServerReconciliationFailureSpike
-      expr: |
-        (
-          sum(rate(metal_server_reconciliation_total{result=~"error_.*"}[5m]))
-          /
-          sum(rate(metal_server_reconciliation_total[5m]))
-        ) > 0.5
-      for: 10m
-      annotations:
-        summary: "High rate of server reconciliation failures"
-        description: "More than 50% of server reconciliations are failing"
-      labels:
-        severity: critical
+        - alert: ServerReconciliationFailureSpike
+          expr: |
+            (
+              sum(rate(metal_server_reconciliation_total{result=~"error_.*"}[5m]))
+              /
+              sum(rate(metal_server_reconciliation_total[5m]))
+            ) > 0.5
+          for: 10m
+          annotations:
+            summary: "High rate of server reconciliation failures"
+            description: "More than 50% of server reconciliations are failing"
+          labels:
+            severity: critical

--- a/config/prometheus/server_alerts_test.yaml
+++ b/config/prometheus/server_alerts_test.yaml
@@ -1,0 +1,164 @@
+# promtool test rules config/prometheus/server_alerts_test.yaml
+# Rules are extracted from server_alerts.yaml (PrometheusRule CRD) at test time
+rule_files:
+  - server_alerts_rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+  # Test: ServersInErrorState fires for specific server
+  - interval: 1m
+    input_series:
+      - series: 'metal_server_state{server="srv-error-01", state="Error"}'
+        values: "1 1 1 1 1"
+      - series: 'metal_server_state{server="srv-ok-01", state="Available"}'
+        values: "1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: ServersInErrorState
+        exp_alerts:
+          - exp_labels:
+              server: srv-error-01
+              state: Error
+              severity: critical
+            exp_annotations:
+              summary: "Server srv-error-01 is in Error state"
+              description: "Server srv-error-01 is in Error state and requires attention"
+
+  # Test: ServersPoweringOnTooLong fires for specific server
+  - interval: 1m
+    input_series:
+      - series: 'metal_server_power_state{server="srv-stuck-01", power_state="PoweringOn"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ServersPoweringOnTooLong
+        exp_alerts:
+          - exp_labels:
+              server: srv-stuck-01
+              power_state: PoweringOn
+              severity: warning
+            exp_annotations:
+              summary: "Server srv-stuck-01 stuck in PoweringOn state"
+              description: "Server srv-stuck-01 has been in PoweringOn state for over 10 minutes"
+
+  # Test: ServersPoweringOffTooLong fires for specific server
+  - interval: 1m
+    input_series:
+      - series: 'metal_server_power_state{server="srv-stuck-02", power_state="PoweringOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ServersPoweringOffTooLong
+        exp_alerts:
+          - exp_labels:
+              server: srv-stuck-02
+              power_state: PoweringOff
+              severity: warning
+            exp_annotations:
+              summary: "Server srv-stuck-02 stuck in PoweringOff state"
+              description: "Server srv-stuck-02 has been in PoweringOff state for over 10 minutes"
+
+  # Test: NoAvailableServers fires when no Available or Reserved servers
+  - interval: 1m
+    input_series:
+      - series: 'metal_server_state{server="srv-01", state="Error"}'
+        values: "1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NoAvailableServers
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "No available or reserved servers in the fleet"
+              description: "The fleet is completely idle with no servers in Available or Reserved state"
+
+  # Test: NoAvailableServers does NOT fire when Available servers exist
+  - interval: 1m
+    input_series:
+      - series: 'metal_server_state{server="srv-01", state="Available"}'
+        values: "1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NoAvailableServers
+        exp_alerts: []
+
+  # Test: NoAvailableServers does NOT fire when Reserved servers exist
+  - interval: 1m
+    input_series:
+      - series: 'metal_server_state{server="srv-01", state="Reserved"}'
+        values: "1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NoAvailableServers
+        exp_alerts: []
+
+  # Test: LowAvailableServerCapacity fires when only 1 server available
+  - interval: 1m
+    input_series:
+      - series: 'metal_server_state{server="srv-01", state="Available"}'
+        values: "1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: LowAvailableServerCapacity
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "Low available server capacity"
+              description: "Only 1 server(s) are available"
+
+  # Test: LowAvailableServerCapacity does NOT fire when 2+ servers available
+  - interval: 1m
+    input_series:
+      - series: 'metal_server_state{server="srv-01", state="Available"}'
+        values: "1 1 1 1 1 1 1"
+      - series: 'metal_server_state{server="srv-02", state="Available"}'
+        values: "1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: LowAvailableServerCapacity
+        exp_alerts: []
+
+  # Test: ServerMetricsMissing fires when scrape is down
+  - interval: 1m
+    input_series:
+      - series: 'up{job="metal-operator"}'
+        values: "0 0 0 0 0 0 0"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: ServerMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              job: metal-operator
+              severity: critical
+            exp_annotations:
+              summary: "Metal-operator scrape is failing"
+              description: "Prometheus cannot scrape the metal-operator metrics endpoint - check operator health and network connectivity"
+
+  # Test: Multiple servers in Error state fire separate alerts
+  - interval: 1m
+    input_series:
+      - series: 'metal_server_state{server="srv-error-01", state="Error"}'
+        values: "1 1 1 1 1"
+      - series: 'metal_server_state{server="srv-error-02", state="Error"}'
+        values: "1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: ServersInErrorState
+        exp_alerts:
+          - exp_labels:
+              server: srv-error-01
+              state: Error
+              severity: critical
+            exp_annotations:
+              summary: "Server srv-error-01 is in Error state"
+              description: "Server srv-error-01 is in Error state and requires attention"
+          - exp_labels:
+              server: srv-error-02
+              state: Error
+              severity: critical
+            exp_annotations:
+              summary: "Server srv-error-02 is in Error state"
+              description: "Server srv-error-02 is in Error state and requires attention"

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -42,61 +42,70 @@ spec:
 
 ### Server State Distribution (`metal_server_state`)
 
-**Type:** Gauge
-**Description:** Current count of servers in each state
+**Type:** Gauge (enum pattern)
+**Description:** Server state as enum metric — emits all possible states for each server with value 1 for the current state and 0 for all others. This pattern prevents series churn when servers change state.
 **Labels:**
+- `server`: Server resource name
 - `state`: ServerState value (Initial, Discovery, Available, Reserved, Error, Maintenance)
 
 **Example values:**
 ```text
-metal_server_state{state="Available"} 5
-metal_server_state{state="Reserved"} 2
-metal_server_state{state="Error"} 0
-metal_server_state{state="Maintenance"} 1
+# Server srv-001 is currently in Available state
+metal_server_state{server="srv-001", state="Initial"} 0
+metal_server_state{server="srv-001", state="Discovery"} 0
+metal_server_state{server="srv-001", state="Available"} 1
+metal_server_state{server="srv-001", state="Reserved"} 0
+metal_server_state{server="srv-001", state="Error"} 0
+metal_server_state{server="srv-001", state="Maintenance"} 0
 ```
 
 **Use cases:**
-- Monitor available server capacity
-- Alert on servers in error states
-- Track server lifecycle distribution
+- Monitor available server capacity: `count(metal_server_state{state="Available"} == 1)`
+- Alert on specific servers in error states: `metal_server_state{state="Error"} == 1`
+- Track server lifecycle distribution: `count by (state) (metal_server_state == 1)`
 
 ### Server Power State Distribution (`metal_server_power_state`)
 
-**Type:** Gauge
-**Description:** Current count of servers in each power state
+**Type:** Gauge (enum pattern)
+**Description:** Server power state as enum metric — emits all possible power states for each server with value 1 for the current state and 0 for all others.
 **Labels:**
+- `server`: Server resource name
 - `power_state`: ServerPowerState value (On, Off, PoweringOn, PoweringOff, Paused)
 
 **Example values:**
 ```text
-metal_server_power_state{power_state="On"} 7
-metal_server_power_state{power_state="Off"} 1
-metal_server_power_state{power_state="PoweringOn"} 0
+# Server srv-001 is currently powered On
+metal_server_power_state{server="srv-001", power_state="On"} 1
+metal_server_power_state{server="srv-001", power_state="Off"} 0
+metal_server_power_state{server="srv-001", power_state="Paused"} 0
+metal_server_power_state{server="srv-001", power_state="PoweringOn"} 0
+metal_server_power_state{server="srv-001", power_state="PoweringOff"} 0
 ```
 
 **Use cases:**
 - Track power operations in progress
-- Identify stuck power transitions
+- Identify specific servers with stuck power transitions
 - Energy consumption estimation
 
 ### Server Condition Status (`metal_server_condition_status`)
 
 **Type:** Gauge
-**Description:** Count of servers with each condition status
+**Description:** Current condition status of each server (value is always 1)
 **Labels:**
+- `server`: Server resource name
 - `condition_type`: Condition type (e.g., "Ready", "PoweringOn", "Discovered")
 - `status`: Condition status (True, False, Unknown)
 
 **Example values:**
 ```text
-metal_server_condition_status{condition_type="Ready",status="True"} 1
-metal_server_condition_status{condition_type="Discovered",status="True"} 1
-metal_server_condition_status{condition_type="PoweringOn",status="False"} 0
+metal_server_condition_status{server="srv-001", condition_type="Ready", status="True"} 1
+metal_server_condition_status{server="srv-001", condition_type="Discovered", status="True"} 1
+metal_server_condition_status{server="srv-002", condition_type="Ready", status="False"} 1
 ```
 
 **Use cases:**
-- Track server health conditions
-- Alert on specific condition failures
+- Track individual server health conditions
+- Alert on specific servers with condition failures
 - Monitor discovery and power operation progress
 
 ### Server Reconciliation Total (`metal_server_reconciliation_total`)
@@ -123,40 +132,49 @@ metal_server_reconciliation_total{result="error_reconcile"} 15
 ### Server Inventory
 
 ```promql
-# Total servers by state
-sum by (state) (metal_server_state)
+# Count of servers by state
+count by (state) (metal_server_state == 1)
 
-# Available server capacity
-metal_server_state{state="Available"}
+# Number of available servers
+count(metal_server_state{state="Available"} == 1)
 
-# Servers requiring attention
-metal_server_state{state="Error"} + metal_server_state{state="Maintenance"}
+# List servers in error state
+metal_server_state{state="Error"} == 1
+
+# Count of servers requiring attention (Error or Maintenance)
+count(metal_server_state{state=~"Error|Maintenance"} == 1)
 
 # Percentage of servers in error state
-metal_server_state{state="Error"} / sum(metal_server_state) * 100
+count(metal_server_state{state="Error"} == 1) / count(metal_server_state == 1) * 100
 ```
 
 ### Power Operations
 
 ```promql
-# Servers currently powered on
-metal_server_power_state{power_state="On"}
+# Count of servers currently powered on
+count(metal_server_power_state{power_state="On"} == 1)
 
-# Servers in transition states (possibly stuck)
-metal_server_power_state{power_state="PoweringOn"} + metal_server_power_state{power_state="PoweringOff"}
+# List servers in transition states (possibly stuck)
+metal_server_power_state{power_state=~"PoweringOn|PoweringOff"} == 1
+
+# Count servers in transition states
+count(metal_server_power_state{power_state=~"PoweringOn|PoweringOff"} == 1)
 
 # Power state distribution
-sum by (power_state) (metal_server_power_state)
+count by (power_state) (metal_server_power_state == 1)
 ```
 
 ### Health and Conditions
 
 ```promql
 # Count of servers with Ready=True
-sum(metal_server_condition_status{condition_type="Ready",status="True"})
+count(metal_server_condition_status{condition_type="Ready", status="True"})
+
+# List servers with Ready=False
+metal_server_condition_status{condition_type="Ready", status="False"}
 
 # Servers with failed power operations
-metal_server_condition_status{condition_type="PoweringOn",status="False"}
+metal_server_condition_status{condition_type="PoweringOn", status="False"}
 ```
 
 ### Reconciliation Performance
@@ -175,7 +193,7 @@ sum(rate(metal_server_reconciliation_total[5m]))
 
 ## Alerting Rules
 
-Example PrometheusRule resource:
+Example PrometheusRule resource (see `config/prometheus/server_alerts.yaml` for the full version):
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -189,29 +207,29 @@ spec:
     interval: 30s
     rules:
     - alert: NoAvailableServers
-      expr: metal_server_state{state="Available"} == 0
+      expr: (count(metal_server_state{state="Available"} == 1) or vector(0)) < 1 and (count(metal_server_state{state="Reserved"} == 1) or vector(0)) < 1
       for: 5m
       annotations:
-        summary: "No available servers in the fleet"
-        description: "All servers are either Reserved, in Maintenance, or in Error state"
+        summary: "No available or reserved servers in the fleet"
+        description: "The fleet is completely idle with no servers in Available or Reserved state"
       labels:
         severity: warning
 
     - alert: ServersInErrorState
-      expr: metal_server_state{state="Error"} > 0
+      expr: metal_server_state{state="Error"} == 1
       for: 2m
       annotations:
-        summary: "Servers are in Error state"
-        description: "{{ $value }} server(s) are in Error state and require attention"
+        summary: "Server {{ $labels.server }} is in Error state"
+        description: "Server {{ $labels.server }} is in Error state and requires attention"
       labels:
         severity: critical
 
     - alert: ServersPoweringOnTooLong
-      expr: metal_server_power_state{power_state="PoweringOn"} > 0
+      expr: metal_server_power_state{power_state="PoweringOn"} == 1
       for: 10m
       annotations:
-        summary: "Servers stuck in PoweringOn state"
-        description: "{{ $value }} server(s) have been in PoweringOn state for over 10 minutes"
+        summary: "Server {{ $labels.server }} stuck in PoweringOn state"
+        description: "Server {{ $labels.server }} has been in PoweringOn state for over 10 minutes"
       labels:
         severity: warning
 
@@ -225,7 +243,7 @@ spec:
         severity: warning
 
     - alert: LowAvailableServerCapacity
-      expr: metal_server_state{state="Available"} < 2
+      expr: (count(metal_server_state{state="Available"} == 1) or vector(0)) < 2
       for: 5m
       annotations:
         summary: "Low available server capacity"
@@ -241,13 +259,13 @@ Example dashboard queries for visualization:
 ### Server State Distribution Panel (Pie Chart)
 
 ```promql
-sum by (state) (metal_server_state)
+count by (state) (metal_server_state == 1)
 ```
 
 ### Server Power State Timeline (Graph)
 
 ```promql
-metal_server_power_state
+count by (power_state) (metal_server_power_state == 1)
 ```
 
 ### Reconciliation Error Rate (Graph)
@@ -260,44 +278,48 @@ rate(metal_server_reconciliation_total{result=~"error_.*"}[5m])
 ### Available Server Capacity (Gauge)
 
 ```promql
-metal_server_state{state="Available"}
+count(metal_server_state{state="Available"} == 1)
 ```
 
 ## Implementation Details
 
 ### Metric Collection Strategy
 
-The operator uses a **custom Collector pattern** to ensure accurate metric counts:
+The operator uses a **custom Collector pattern** with **enum metrics** to emit per-server state information:
 
 1. On each Prometheus scrape (default: 30s interval), the collector lists all Server resources
-2. Counts are computed in-memory and emitted as gauge metrics
-3. This ensures metrics always reflect current cluster state, not accumulated values
+2. For each server, it emits enum metrics for all possible states (value=1 for current state, value=0 for others)
+3. This **enum pattern** prevents series churn when servers change state — values flip but all series remain active
 
 **Benefits:**
-- Accurate counts even if reconciliation loop misses updates
-- No metric staleness from deleted servers
+- Per-server visibility enables targeted alerting (e.g., \"Server X is in Error state\")
+- Accurate counts via `count(metric == 1)` aggregation
+- No stale series when state changes (unlike single-value-per-state approaches)
+- Works with `changes()` and other gauge-appropriate Prometheus functions (do not use `rate()` on enum gauges)
 - Resilient to operator restarts
 
 **Performance considerations:**
 - ServerList operation uses watch cache (fast)
 - Default scrape interval is 30s (adjustable)
+- Cardinality: (servers × 6 states) + (servers × 5 power states) + conditions
 - For very large clusters (>1000 servers), consider increasing scrape interval
 
 ### Cardinality Control
 
-All metrics use **bounded label value sets** to prevent cardinality explosion:
+Metrics include the `server` label to enable per-server alerting and filtering. Label cardinality is controlled by using **bounded label value sets** for state-related labels:
 
+- `server`: One value per Server resource (scales with fleet size)
 - `state`: 6 possible values
 - `power_state`: 5 possible values
 - `condition_type`: ~10 typical values
 - `result`: 3 values
 
 **Never used as labels:**
-- Server names, UUIDs, or namespaces
+- Server UUIDs
 - IP addresses or MAC addresses
 - Timestamps
 
-This ensures Prometheus performance remains optimal even with large server fleets.
+For very large server fleets (>1000 servers), monitor Prometheus memory usage and consider increasing the scrape interval if needed.
 
 ## Troubleshooting
 

--- a/hack/install-promtool.sh
+++ b/hack/install-promtool.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# install-promtool.sh downloads a pre-built promtool binary from the
+# Prometheus GitHub release artifacts with checksum verification.
+#
+# Usage: install-promtool.sh <version> <output-dir>
+#   version    - Prometheus release version (e.g. 2.54.0, without leading 'v')
+#   output-dir - Directory to place the promtool binary in
+
+set -euo pipefail
+
+VERSION="${1:?Usage: install-promtool.sh <version> <output-dir>}"
+OUTPUT_DIR="${2:?Usage: install-promtool.sh <version> <output-dir>}"
+
+# Strip leading 'v' if present
+VERSION="${VERSION#v}"
+
+BINARY="${OUTPUT_DIR}/promtool"
+
+if [[ -f "${BINARY}" ]] && "${BINARY}" --version 2>&1 | grep -q "${VERSION}"; then
+    echo "promtool ${VERSION} already installed at ${BINARY}"
+    exit 0
+fi
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "${ARCH}" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+esac
+
+TARBALL="prometheus-${VERSION}.${OS}-${ARCH}.tar.gz"
+RELEASE_URL="https://github.com/prometheus/prometheus/releases/download/v${VERSION}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+echo "Downloading promtool ${VERSION} for ${OS}/${ARCH}..."
+curl -sSfL "${RELEASE_URL}/${TARBALL}" -o "${TMP_DIR}/${TARBALL}"
+curl -sSfL "${RELEASE_URL}/sha256sums.txt" -o "${TMP_DIR}/sha256sums.txt"
+
+cd "${TMP_DIR}"
+if ! grep -F "${TARBALL}" sha256sums.txt | sha256sum -c -; then
+    echo "ERROR: SHA256 checksum verification failed for ${TARBALL}" >&2
+    exit 1
+fi
+
+tar -xzf "${TARBALL}" -C "${TMP_DIR}"
+mv "prometheus-${VERSION}.${OS}-${ARCH}/promtool" "${BINARY}"
+chmod +x "${BINARY}"
+echo "Installed promtool ${VERSION} at ${BINARY}"

--- a/internal/metrics/server_metrics.go
+++ b/internal/metrics/server_metrics.go
@@ -13,6 +13,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+// AllServerStates defines all possible server states for enum metrics
+var AllServerStates = []metalv1alpha1.ServerState{
+	metalv1alpha1.ServerStateInitial,
+	metalv1alpha1.ServerStateDiscovery,
+	metalv1alpha1.ServerStateAvailable,
+	metalv1alpha1.ServerStateReserved,
+	metalv1alpha1.ServerStateError,
+	metalv1alpha1.ServerStateMaintenance,
+}
+
+// AllServerPowerStates defines all possible server power states for enum metrics
+var AllServerPowerStates = []metalv1alpha1.ServerPowerState{
+	metalv1alpha1.ServerOnPowerState,
+	metalv1alpha1.ServerOffPowerState,
+	metalv1alpha1.ServerPausedPowerState,
+	metalv1alpha1.ServerPoweringOnPowerState,
+	metalv1alpha1.ServerPoweringOffPowerState,
+}
+
 var (
 	// ServerReconciliationTotal tracks reconciliation operations by result
 	ServerReconciliationTotal = prometheus.NewCounterVec(
@@ -47,20 +66,20 @@ func NewServerStateCollector(c client.Client) *ServerStateCollector {
 		Client: c,
 		stateDesc: prometheus.NewDesc(
 			"metal_server_state",
-			"Current count of servers in each state",
-			[]string{"state"},
+			"Server state as enum metric (1 for current state, 0 for others)",
+			[]string{"server", "state"},
 			nil,
 		),
 		powerStateDesc: prometheus.NewDesc(
 			"metal_server_power_state",
-			"Current count of servers in each power state",
-			[]string{"power_state"},
+			"Server power state as enum metric (1 for current state, 0 for others)",
+			[]string{"server", "power_state"},
 			nil,
 		),
 		conditionDesc: prometheus.NewDesc(
 			"metal_server_condition_status",
-			"Count of servers with each condition status",
-			[]string{"condition_type", "status"},
+			"Current condition status of a server (value is always 1)",
+			[]string{"server", "condition_type", "status"},
 			nil,
 		),
 	}
@@ -74,8 +93,9 @@ func (c *ServerStateCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.conditionDesc
 }
 
-// Collect is called by Prometheus when collecting metrics.
-// It queries all servers and emits aggregated metrics.
+// Collect is called by Prometheus when scraping metrics.
+// It queries all Server resources and emits enum metrics for state and power state
+// (1 for current state, 0 for all other states), plus condition metrics.
 func (c *ServerStateCollector) Collect(ch chan<- prometheus.Metric) {
 	// Add 5-second timeout for metrics collection to prevent hanging scrapes
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -90,63 +110,48 @@ func (c *ServerStateCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	// Count servers by state
-	stateCounts := make(map[string]float64)
-	powerStateCounts := make(map[string]float64)
-	conditionCounts := make(map[string]map[string]float64)
-
 	for _, server := range servers.Items {
-		// Count by server state
-		if server.Status.State != "" {
-			stateCounts[string(server.Status.State)]++
-		}
+		serverName := server.Name
 
-		// Count by power state
-		if server.Status.PowerState != "" {
-			powerStateCounts[string(server.Status.PowerState)]++
-		}
-
-		// Count by condition status
-		for _, condition := range server.Status.Conditions {
-			conditionType := condition.Type
-			status := string(condition.Status)
-
-			if conditionCounts[conditionType] == nil {
-				conditionCounts[conditionType] = make(map[string]float64)
+		// Emit enum metrics for all possible states (1 for current, 0 for others)
+		for _, state := range AllServerStates {
+			value := 0.0
+			if server.Status.State == state {
+				value = 1.0
 			}
-			conditionCounts[conditionType][status]++
+			ch <- prometheus.MustNewConstMetric(
+				c.stateDesc,
+				prometheus.GaugeValue,
+				value,
+				serverName,
+				string(state),
+			)
 		}
-	}
 
-	// Emit state metrics
-	for state, count := range stateCounts {
-		ch <- prometheus.MustNewConstMetric(
-			c.stateDesc,
-			prometheus.GaugeValue,
-			count,
-			state,
-		)
-	}
+		// Emit enum metrics for all possible power states (1 for current, 0 for others)
+		for _, powerState := range AllServerPowerStates {
+			value := 0.0
+			if server.Status.PowerState == powerState {
+				value = 1.0
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.powerStateDesc,
+				prometheus.GaugeValue,
+				value,
+				serverName,
+				string(powerState),
+			)
+		}
 
-	// Emit power state metrics
-	for powerState, count := range powerStateCounts {
-		ch <- prometheus.MustNewConstMetric(
-			c.powerStateDesc,
-			prometheus.GaugeValue,
-			count,
-			powerState,
-		)
-	}
-
-	// Emit condition metrics with server counts
-	for conditionType, statusMap := range conditionCounts {
-		for status, count := range statusMap {
+		// Emit per-server condition metrics
+		for _, condition := range server.Status.Conditions {
 			ch <- prometheus.MustNewConstMetric(
 				c.conditionDesc,
 				prometheus.GaugeValue,
-				count,
-				conditionType,
-				status,
+				1,
+				serverName,
+				condition.Type,
+				string(condition.Status),
 			)
 		}
 	}

--- a/internal/metrics/server_metrics_test.go
+++ b/internal/metrics/server_metrics_test.go
@@ -19,6 +19,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const (
+	labelServer = "server"
+)
+
 func TestMetrics(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Metrics Suite")
@@ -90,7 +94,7 @@ var _ = Describe("ServerStateCollector", func() {
 		Expect(count).To(Equal(0))
 	})
 
-	It("should count servers by state", func(ctx SpecContext) {
+	It("should emit enum metrics for all states per server", func(ctx SpecContext) {
 		// Create servers in different states
 		servers := []metalv1alpha1.Server{
 			{
@@ -119,27 +123,54 @@ var _ = Describe("ServerStateCollector", func() {
 		collector.Collect(ch)
 		close(ch)
 
-		// Parse metrics and verify exact counts
-		metrics := make(map[string]float64)
+		// Parse metrics and verify enum pattern: all states emitted per server
+		type stateKey struct {
+			server, state string
+		}
+		stateMetrics := make(map[stateKey]float64)
 		for metric := range ch {
 			var m = metric
 			dto := &prometheus_io.Metric{}
 			Expect(m.Write(dto)).To(Succeed())
 
-			if dto.GetGauge() != nil && len(dto.GetLabel()) > 0 {
-				label := dto.GetLabel()[0]
-				if label.GetName() == "state" {
-					metrics[label.GetValue()] = dto.GetGauge().GetValue()
+			if dto.GetGauge() != nil {
+				var key stateKey
+				for _, label := range dto.GetLabel() {
+					switch label.GetName() {
+					case labelServer:
+						key.server = label.GetValue()
+					case "state":
+						key.state = label.GetValue()
+					}
+				}
+				if key.state != "" {
+					stateMetrics[key] = dto.GetGauge().GetValue()
 				}
 			}
 		}
 
-		// Assert exact label/value pairs
-		Expect(metrics["Available"]).To(Equal(2.0), "Expected 2 Available servers")
-		Expect(metrics["Reserved"]).To(Equal(1.0), "Expected 1 Reserved server")
+		// Assert enum pattern: all 6 states emitted per server with 1 for current, 0 for others
+		// server1 is Available
+		Expect(stateMetrics[stateKey{server: "server1", state: "Initial"}]).To(Equal(0.0))
+		Expect(stateMetrics[stateKey{server: "server1", state: "Discovery"}]).To(Equal(0.0))
+		Expect(stateMetrics[stateKey{server: "server1", state: "Available"}]).To(Equal(1.0))
+		Expect(stateMetrics[stateKey{server: "server1", state: "Reserved"}]).To(Equal(0.0))
+		Expect(stateMetrics[stateKey{server: "server1", state: "Error"}]).To(Equal(0.0))
+		Expect(stateMetrics[stateKey{server: "server1", state: "Maintenance"}]).To(Equal(0.0))
+
+		// server2 is Available
+		Expect(stateMetrics[stateKey{server: "server2", state: "Available"}]).To(Equal(1.0))
+		Expect(stateMetrics[stateKey{server: "server2", state: "Reserved"}]).To(Equal(0.0))
+
+		// server3 is Reserved
+		Expect(stateMetrics[stateKey{server: "server3", state: "Available"}]).To(Equal(0.0))
+		Expect(stateMetrics[stateKey{server: "server3", state: "Reserved"}]).To(Equal(1.0))
+
+		// Total: 3 servers × 6 states = 18 state metrics
+		Expect(stateMetrics).To(HaveLen(18))
 	})
 
-	It("should count servers by power state", func(ctx SpecContext) {
+	It("should emit enum metrics for all power states per server", func(ctx SpecContext) {
 		// Create servers with different power states
 		servers := []metalv1alpha1.Server{
 			{
@@ -177,24 +208,50 @@ var _ = Describe("ServerStateCollector", func() {
 		collector.Collect(ch)
 		close(ch)
 
-		// Parse metrics and verify exact counts
-		metrics := make(map[string]float64)
+		// Parse metrics and verify enum pattern: all power states emitted per server
+		type powerKey struct {
+			server, powerState string
+		}
+		powerMetrics := make(map[powerKey]float64)
 		for metric := range ch {
 			var m = metric
 			dto := &prometheus_io.Metric{}
 			Expect(m.Write(dto)).To(Succeed())
 
-			if dto.GetGauge() != nil && len(dto.GetLabel()) > 0 {
-				label := dto.GetLabel()[0]
-				if label.GetName() == "power_state" {
-					metrics[label.GetValue()] = dto.GetGauge().GetValue()
+			if dto.GetGauge() != nil {
+				var key powerKey
+				for _, label := range dto.GetLabel() {
+					switch label.GetName() {
+					case labelServer:
+						key.server = label.GetValue()
+					case "power_state":
+						key.powerState = label.GetValue()
+					}
+				}
+				if key.powerState != "" {
+					powerMetrics[key] = dto.GetGauge().GetValue()
 				}
 			}
 		}
 
-		// Assert exact label/value pairs
-		Expect(metrics["On"]).To(Equal(2.0), "Expected 2 On servers")
-		Expect(metrics["Off"]).To(Equal(1.0), "Expected 1 Off server")
+		// Assert enum pattern: all 5 power states emitted per server with 1 for current, 0 for others
+		// server1 is On
+		Expect(powerMetrics[powerKey{server: "server1", powerState: "On"}]).To(Equal(1.0))
+		Expect(powerMetrics[powerKey{server: "server1", powerState: "Off"}]).To(Equal(0.0))
+		Expect(powerMetrics[powerKey{server: "server1", powerState: "Paused"}]).To(Equal(0.0))
+		Expect(powerMetrics[powerKey{server: "server1", powerState: "PoweringOn"}]).To(Equal(0.0))
+		Expect(powerMetrics[powerKey{server: "server1", powerState: "PoweringOff"}]).To(Equal(0.0))
+
+		// server2 is On
+		Expect(powerMetrics[powerKey{server: "server2", powerState: "On"}]).To(Equal(1.0))
+		Expect(powerMetrics[powerKey{server: "server2", powerState: "Off"}]).To(Equal(0.0))
+
+		// server3 is Off
+		Expect(powerMetrics[powerKey{server: "server3", powerState: "On"}]).To(Equal(0.0))
+		Expect(powerMetrics[powerKey{server: "server3", powerState: "Off"}]).To(Equal(1.0))
+
+		// Total: 3 servers × 5 power states = 15 power state metrics
+		Expect(powerMetrics).To(HaveLen(15))
 	})
 
 	It("should emit condition metrics", func(ctx SpecContext) {
@@ -225,38 +282,44 @@ var _ = Describe("ServerStateCollector", func() {
 		collector.Collect(ch)
 		close(ch)
 
-		// Parse metrics and verify exact counts
-		conditionMetrics := make(map[string]map[string]float64)
+		// Parse metrics and verify per-server condition metrics with all labels
+		type conditionKey struct {
+			server, conditionType, status string
+		}
+		conditionMetrics := make(map[conditionKey]int)
 		for metric := range ch {
 			var m = metric
 			dto := &prometheus_io.Metric{}
 			Expect(m.Write(dto)).To(Succeed())
 
-			if dto.GetGauge() != nil && len(dto.GetLabel()) >= 2 {
-				var condType, status string
+			if dto.GetGauge() != nil {
+				var key conditionKey
 				for _, label := range dto.GetLabel() {
-					if label.GetName() == "condition_type" {
-						condType = label.GetValue()
-					}
-					if label.GetName() == "status" {
-						status = label.GetValue()
+					switch label.GetName() {
+					case labelServer:
+						key.server = label.GetValue()
+					case "condition_type":
+						key.conditionType = label.GetValue()
+					case "status":
+						key.status = label.GetValue()
 					}
 				}
-				if condType != "" && status != "" {
-					if conditionMetrics[condType] == nil {
-						conditionMetrics[condType] = make(map[string]float64)
-					}
-					conditionMetrics[condType][status] = dto.GetGauge().GetValue()
+				if key.conditionType != "" && key.status != "" {
+					// Each per-server metric has value 1
+					Expect(dto.GetGauge().GetValue()).To(Equal(1.0))
+					conditionMetrics[key]++
 				}
 			}
 		}
 
-		// Assert exact label/value pairs
-		Expect(conditionMetrics["Ready"]["True"]).To(Equal(1.0), "Expected 1 Ready=True condition")
-		Expect(conditionMetrics["Discovered"]["True"]).To(Equal(1.0), "Expected 1 Discovered=True condition")
+		// Assert exact per-server condition metrics
+		Expect(conditionMetrics).To(Equal(map[conditionKey]int{
+			{server: "server1", conditionType: "Ready", status: "True"}:      1,
+			{server: "server1", conditionType: "Discovered", status: "True"}: 1,
+		}))
 	})
 
-	It("should handle servers without state gracefully", func(ctx SpecContext) {
+	It("should emit all enum states with value 0 when server has no state set", func(ctx SpecContext) {
 		// Create server without state set
 		server := metalv1alpha1.Server{
 			ObjectMeta: metav1.ObjectMeta{Name: "server1"},
@@ -266,11 +329,42 @@ var _ = Describe("ServerStateCollector", func() {
 
 		Expect(fakeClient.Create(ctx, &server)).To(Succeed())
 
-		// Collect metrics - should not panic
+		// Collect metrics - should not panic and should emit all states with value 0
 		ch := make(chan prometheus.Metric, 100)
 		Expect(func() {
 			collector.Collect(ch)
 			close(ch)
 		}).NotTo(Panic())
+
+		// Parse metrics and verify all states are emitted with value 0
+		type stateKey struct {
+			server, state string
+		}
+		stateMetrics := make(map[stateKey]float64)
+		for metric := range ch {
+			var m = metric
+			dto := &prometheus_io.Metric{}
+			Expect(m.Write(dto)).To(Succeed())
+
+			if dto.GetGauge() != nil {
+				var key stateKey
+				for _, label := range dto.GetLabel() {
+					switch label.GetName() {
+					case labelServer:
+						key.server = label.GetValue()
+					case "state":
+						key.state = label.GetValue()
+					}
+				}
+				if key.state != "" {
+					stateMetrics[key] = dto.GetGauge().GetValue()
+				}
+			}
+		}
+
+		// All states should be 0 since no state is set
+		Expect(stateMetrics[stateKey{server: "server1", state: "Initial"}]).To(Equal(0.0))
+		Expect(stateMetrics[stateKey{server: "server1", state: "Available"}]).To(Equal(0.0))
+		Expect(stateMetrics).To(HaveLen(6)) // All 6 states emitted
 	})
 })


### PR DESCRIPTION
# Proposed Changes

Update Metal Operator metrics to have server label. 

e.g. 

from:

`metal_server_power_state{endpoint="https", instance="127.0.0.1:8443", job="metal-operator-controller-manager-metrics-service", namespace="my-namespace", pod="metal-operator-controller-manager-5fff57cd7c-nqhwq", power_state="Off", service="metal-operator-controller-manager-metrics-service"}
`

to:

`metal_server_power_state{endpoint="https", instance="127.0.0.1:8443", job="metal-operator-controller-manager-metrics-service", namespace="my-namespace", pod="metal-operator-controller-manager-5fff57cd7c-nqhwq", power_state="Off", server="my-server-1",service="metal-operator-controller-manager-metrics-service"}
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-server metrics: state, power state, and condition gauges that emit enum-style series with a server label.
  * Added alert rule test/check targets and local promtool/yq install support.
* **Bug Fixes**
  * Fixed PrometheusRule nesting and revised alert expressions/annotations; replaced metric-absence alert with scrape-health check.
* **Tests**
  * Updated unit tests for per-server metrics and added Prometheus alert rule tests.
* **Documentation**
  * Updated metrics docs, PromQL/Grafana examples, and cardinality guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->