### PR TITLE
Move BMC User Account Unit tests to go mock server

### DIFF
--- a/bmc/mock/server/data/AccountService/Accounts/1/index.json
+++ b/bmc/mock/server/data/AccountService/Accounts/1/index.json
@@ -4,16 +4,13 @@
     "Name": "User Account",
     "Description": "User Account",
     "Enabled": true,
-    "Password": null,
+    "Password": "adminpass",
     "PasswordChangeRequired": false,
     "PasswordExpiration": "2026-12-31T23:59:59Z",
     "AccountTypes": [
         "Redfish"
     ],
-    "UserName": "Administrator",
-    "EmailAddress": "Tiffany@contoso.com",
-    "PhoneNumber": "312-555-1212",
-    "OneTimePasscodeDeliveryAddress": "3125551212@smsrelay.contoso.com",
+    "UserName": "admin",
     "RoleId": "Administrator",
     "Locked": false,
     "Certificates": {

--- a/bmc/mock/server/data/AccountService/Accounts/2/index.json
+++ b/bmc/mock/server/data/AccountService/Accounts/2/index.json
@@ -1,28 +1,18 @@
 {
     "@odata.type": "#ManagerAccount.v1_12_0.ManagerAccount",
     "Id": "2",
-    "Name": "Employee #457",
-    "Description": "This user is both a Redfish administrator and a SNMPv3 user.",
+    "Name": "Test User",
+    "Description": "Default test account used by controller tests.",
     "Enabled": true,
-    "Password": null,
-    "UserName": "contoso_employee457",
-    "MFABypass": {
-        "BypassTypes": [
-            "All"
-        ]
-    },
+    "Password": "bar",
+    "PasswordChangeRequired": false,
+    "PasswordExpiration": "2026-12-31T23:59:59Z",
+    "UserName": "foo",
     "RoleId": "Administrator",
     "Locked": false,
     "AccountTypes": [
-        "Redfish",
-        "SNMP"
+        "Redfish"
     ],
-    "SNMP": {
-        "AuthenticationKey": null,
-        "AuthenticationProtocol": "None",
-        "EncryptionKey": null,
-        "EncryptionProtocol": "CFB128_AES128"
-    },
     "Links": {
         "Role": {
             "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"

--- a/bmc/mock/server/data/AccountService/Accounts/index.json
+++ b/bmc/mock/server/data/AccountService/Accounts/index.json
@@ -1,10 +1,13 @@
 {
     "@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
     "Name": "Accounts Collection",
-    "Members@odata.count": 1,
+    "Members@odata.count": 2,
     "Members": [
         {
             "@odata.id": "/redfish/v1/AccountService/Accounts/1"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/2"
         }
     ],
     "@odata.id": "/redfish/v1/AccountService/Accounts",

--- a/bmc/mock/server/server.go
+++ b/bmc/mock/server/server.go
@@ -117,22 +117,164 @@ var (
 	errBadReset    = errors.New("unknown reset type")
 )
 
+// memberHook is invoked when a collection member is created (onCreate) or
+// deleted (onDelete). data holds the member resource's JSON fields.
+// Hooks are keyed by collection URL suffix (e.g. "/AccountService/Accounts");
+// register a new entry in NewMockServer to handle additional collection types.
+type memberHook func(s *MockServer, data map[string]any)
+
+// actionHandler pairs a URL path predicate with a POST action handler.
+// Handlers are tested in order; the first match wins and the default
+// collection-creation logic is skipped. Add entries to MockServer.actionHandlers
+// in NewMockServer to support new Redfish action endpoints without touching
+// handlePost.
+type actionHandler struct {
+	matches func(path string) bool
+	handle  func(w http.ResponseWriter, r *http.Request, body []byte)
+}
+
+// Option is a functional option for configuring a MockServer.
+type Option func(*MockServer)
+
+// WithAuth enables HTTP Basic Auth enforcement on all non-service-root endpoints.
+// By default the mock server accepts all requests without credentials, which is
+// convenient for local development. Pass WithAuth() in unit-test suites to
+// exercise the authentication path.
+func WithAuth() Option {
+	return func(s *MockServer) { s.authEnabled = true }
+}
+
 type MockServer struct {
 	log               logr.Logger
 	addr              string
 	handler           http.Handler
 	mu                sync.RWMutex
 	overrides         map[string]any
-	upgradeGen        int64             // incremented on each SimpleUpdate to cancel stale goroutines
-	upgradedResources map[string]string // odata.id URI → file path for resources updated by the last upgrade
+	upgradeGen        int64                 // incremented on each SimpleUpdate to cancel stale goroutines
+	upgradedResources map[string]string     // odata.id URI → file path for resources updated by the last upgrade
+	accounts          map[string]string     // username → password (authentication store)
+	authEnabled       bool                  // when true, all non-service-root requests require Basic Auth
+	unavailable       bool                  // when true, all requests return 503 Service Unavailable
+	actionHandlers    []actionHandler       // ordered POST action dispatch table (first match wins)
+	onCreate          map[string]memberHook // collection URL suffix → hook called after a member is added
+	onDelete          map[string]memberHook // collection URL suffix → hook called before a member is removed
 }
 
-func NewMockServer(log logr.Logger, addr string) *MockServer {
+// loadAccountsFromEmbedded seeds the authentication store by reading the
+// embedded AccountService/Accounts collection and extracting UserName/Password
+// pairs. This keeps the initial credentials in sync with the data files rather
+// than duplicating them in Go code.
+func loadAccountsFromEmbedded() map[string]string {
+	result := make(map[string]string)
+	data, err := dataFS.ReadFile("data/AccountService/Accounts/index.json")
+	if err != nil {
+		return result
+	}
+	var collection Collection
+	if err := json.Unmarshal(data, &collection); err != nil {
+		return result
+	}
+	for _, member := range collection.Members {
+		memberData, err := dataFS.ReadFile(resolvePath(member.OdataID))
+		if err != nil {
+			continue
+		}
+		var account struct {
+			UserName string `json:"UserName"`
+			Password string `json:"Password"`
+		}
+		if err := json.Unmarshal(memberData, &account); err != nil {
+			continue
+		}
+		if account.UserName != "" && account.Password != "" {
+			result[account.UserName] = account.Password
+		}
+	}
+	return result
+}
+
+func NewMockServer(log logr.Logger, addr string, opts ...Option) *MockServer {
 	s := &MockServer{
 		addr:              addr,
 		log:               log,
 		overrides:         make(map[string]any),
 		upgradedResources: make(map[string]string),
+		accounts:          loadAccountsFromEmbedded(),
+		// onCreate hooks run after a new collection member is stored.
+		// Add an entry here to handle side-effects for additional collection types.
+		onCreate: map[string]memberHook{
+			"/AccountService/Accounts": func(s *MockServer, data map[string]any) {
+				// Seed missing fields from the embedded account template so that the
+				// new account has the full Redfish structure (Actions, PasswordExpiration,
+				// AccountTypes, Links, etc.) without enumerating individual fields here.
+				if raw, err := dataFS.ReadFile("data/AccountService/Accounts/2/index.json"); err == nil {
+					var tmpl map[string]any
+					if json.Unmarshal(raw, &tmpl) == nil {
+						for k, v := range tmpl {
+							if _, exists := data[k]; !exists {
+								data[k] = deepCopyAny(v)
+							}
+						}
+					}
+				}
+				// Always overwrite Actions with the correct target for this account's
+				// @odata.id (the template value would point to account 2).
+				if odataID, ok := data["@odata.id"].(string); ok && odataID != "" {
+					data["Actions"] = map[string]any{
+						"#ManagerAccount.ChangePassword": map[string]any{
+							"target": odataID + "/Actions/ManagerAccount.ChangePassword",
+						},
+					}
+					// PasswordExpiration: use template value if present, else one year from now.
+					if exp, ok := data["PasswordExpiration"].(string); !ok || exp == "" {
+						data["PasswordExpiration"] = time.Now().AddDate(1, 0, 0).UTC().Format(time.RFC3339)
+					}
+				}
+				// Update the authentication store with the new account's credentials.
+				if username, ok := data["UserName"].(string); ok && username != "" {
+					password, _ := data["Password"].(string)
+					s.accounts[username] = password
+				}
+			},
+		},
+		// onDelete hooks run before a collection member override is erased.
+		// data is the full member resource loaded prior to deletion.
+		onDelete: map[string]memberHook{
+			"/AccountService/Accounts": func(s *MockServer, data map[string]any) {
+				if username, ok := data["UserName"].(string); ok && username != "" {
+					delete(s.accounts, username)
+				}
+			},
+		},
+	}
+
+	// actionHandlers is the ordered POST dispatch table.
+	// Add a new actionHandler entry here to support additional Redfish action
+	// endpoints — no changes to handlePost are needed.
+	s.actionHandlers = []actionHandler{
+		{
+			matches: hasSuffix("/Actions/ComputerSystem.Reset"),
+			handle:  s.handleSystemReset,
+		},
+		{
+			matches: hasSuffix("/Actions/Manager.Reset"),
+			handle:  s.handleBMCReset,
+		},
+		{
+			matches: func(path string) bool {
+				return strings.Contains(path, "UpdateService/Actions/SimpleUpdate") ||
+					strings.Contains(path, "UpdateService/Actions/UpdateService.SimpleUpdate")
+			},
+			handle: s.handleSimpleUpdate,
+		},
+		{
+			matches: hasSuffix("/Actions/ManagerAccount.ChangePassword"),
+			handle:  s.handleChangePassword,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(s)
 	}
 
 	mux := http.NewServeMux()
@@ -142,8 +284,34 @@ func NewMockServer(log logr.Logger, addr string) *MockServer {
 	return s
 }
 
+// hasSuffix returns a path predicate that checks for a fixed URL suffix.
+// Use this as a shorthand when registering actionHandlers.
+func hasSuffix(suffix string) func(string) bool {
+	return func(path string) bool { return strings.HasSuffix(path, suffix) }
+}
+
 func (s *MockServer) redfishHandler(w http.ResponseWriter, r *http.Request) {
 	s.log.Info("Received request", "method", r.Method, "path", r.URL.Path)
+
+	s.mu.RLock()
+	unavailable := s.unavailable
+	s.mu.RUnlock()
+	if unavailable {
+		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	// When auth is enabled, the Redfish service root is the only publicly
+	// accessible endpoint (gofish fetches it without credentials during
+	// ConnectContext). All other requests require valid Basic Auth credentials.
+	if s.authEnabled && r.URL.Path != "/redfish/v1/" && r.URL.Path != "/redfish/v1" {
+		username, password, ok := r.BasicAuth()
+		if !ok || !s.Authenticate(username, password) {
+			w.Header().Set("WWW-Authenticate", `Basic realm="redfish"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
 
 	switch r.Method {
 	case http.MethodGet:
@@ -196,77 +364,96 @@ func (s *MockServer) handlePost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	urlPath := r.URL.Path
-	switch {
-	case strings.HasSuffix(urlPath, "/Actions/ComputerSystem.Reset"):
-		s.handleSystemReset(w, r, body)
-	case strings.HasSuffix(urlPath, "/Actions/Manager.Reset"):
-		s.handleBMCReset(w, r, body)
-	case strings.Contains(urlPath, "UpdateService/Actions/SimpleUpdate") ||
-		strings.Contains(urlPath, "UpdateService/Actions/UpdateService.SimpleUpdate"):
-		s.handleSimpleUpdate(w, r, body)
-	default:
-		//
-		urlPath := resolvePath(r.URL.Path)
-		var update map[string]any
-		if err := json.Unmarshal(body, &update); err != nil {
-			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+	for _, a := range s.actionHandlers {
+		if a.matches(urlPath) {
+			a.handle(w, r, body)
 			return
 		}
-		// Handle resource creation in collections
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		cached, hasOverride := s.overrides[urlPath]
-		var base Collection
-		if hasOverride {
-			s.log.Info("Using overridden data for POST", "path", urlPath)
-			var ok bool
-			base, ok = cached.(Collection)
-			if !ok {
+	}
+	s.handleCollectionPost(w, r, body)
+}
+
+func (s *MockServer) handleCollectionPost(w http.ResponseWriter, r *http.Request, body []byte) {
+	var update map[string]any
+	if err := json.Unmarshal(body, &update); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	urlPath := resolvePath(r.URL.Path)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cached, hasOverride := s.overrides[urlPath]
+	var base Collection
+	if hasOverride {
+		s.log.Info("Using overridden data for POST", "path", urlPath)
+		switch v := cached.(type) {
+		case Collection:
+			base = v
+		case map[string]any:
+			// Normalise an override stored as map[string]any (e.g. after ResetAccounts).
+			b, err := json.Marshal(v)
+			if err != nil {
 				http.Error(w, "Corrupt overridden JSON", http.StatusInternalServerError)
 				return
 			}
-		} else {
-			s.log.Info("Using embedded data for POST", "path", urlPath)
-			data, err := dataFS.ReadFile(urlPath)
-			if err != nil {
-				s.log.Error(err, "Failed to read embedded data for POST", "path", urlPath)
-				http.NotFound(w, r)
+			if err := json.Unmarshal(b, &base); err != nil {
+				http.Error(w, "Corrupt overridden JSON", http.StatusInternalServerError)
 				return
 			}
-			if err := json.Unmarshal(data, &base); err != nil {
-				http.Error(w, "Corrupt embedded JSON", http.StatusInternalServerError)
-				return
-			}
+		default:
+			http.Error(w, "Corrupt overridden JSON", http.StatusInternalServerError)
+			return
 		}
-		// If resource collection (has "Members"), add a new member
-		if len(base.Members) > 0 {
-			newID := fmt.Sprintf("%d", len(base.Members)+1)
-			location := path.Join(r.URL.Path, newID)
-			newMemberPath := resolvePath(location)
-			base.Members = append(base.Members, Member{
-				OdataID: location,
-			})
-			s.log.Info("Adding new member", "id", newID, "location", location, "memberPath", newMemberPath)
-			if strings.HasSuffix(r.URL.Path, "/Subscriptions") {
-				w.Header().Set("Location", location)
-			}
-			s.overrides[urlPath] = base
-			s.overrides[newMemberPath] = update
-		} else {
-			base.Members = make([]Member, 0)
-			location := r.URL.JoinPath("1").String()
-			base.Members = []Member{
-				{
-					OdataID: r.URL.JoinPath("1").String(),
-				},
-			}
-			s.overrides[urlPath] = base
-			if strings.HasSuffix(r.URL.Path, "/Subscriptions") {
-				w.Header().Set("Location", location)
-			}
+	} else {
+		s.log.Info("Using embedded data for POST", "path", urlPath)
+		data, err := dataFS.ReadFile(urlPath)
+		if err != nil {
+			s.log.Error(err, "Failed to read embedded data for POST", "path", urlPath)
+			http.NotFound(w, r)
+			return
 		}
-		s.writeJSON(w, http.StatusCreated, map[string]string{"status": "created"})
+		if err := json.Unmarshal(data, &base); err != nil {
+			http.Error(w, "Corrupt embedded JSON", http.StatusInternalServerError)
+			return
+		}
 	}
+
+	// Derive the next ID from the maximum numeric ID already in the collection
+	// rather than from len(Members). Using len() causes collisions after a
+	// non-trailing delete (e.g. deleting member 2 from [1,2,3] leaves len=2,
+	// so the next POST computes newID=3 which already exists).
+	maxID := 0
+	for _, m := range base.Members {
+		// member OdataID is e.g. "/redfish/v1/AccountService/Accounts/3"
+		segment := path.Base(m.OdataID)
+		var n int
+		if _, err := fmt.Sscanf(segment, "%d", &n); err == nil && n > maxID {
+			maxID = n
+		}
+	}
+	newID := fmt.Sprintf("%d", maxID+1)
+	location := path.Join(r.URL.Path, newID)
+	newMemberPath := resolvePath(location)
+	base.Members = append(base.Members, Member{OdataID: location})
+	s.log.Info("Adding new member", "id", newID, "location", location, "memberPath", newMemberPath)
+	if strings.HasSuffix(r.URL.Path, "/Subscriptions") {
+		w.Header().Set("Location", location)
+	}
+	// Inject standard Redfish identity fields so gofish can parse Id and ODataID.
+	update["Id"] = newID
+	update["@odata.id"] = location
+	s.overrides[urlPath] = base
+	s.overrides[newMemberPath] = update
+	// Dispatch create hooks for this collection (e.g. credential tracking).
+	for suffix, hook := range s.onCreate {
+		if strings.HasSuffix(r.URL.Path, suffix) {
+			hook(s, update)
+			break
+		}
+	}
+	s.writeJSON(w, http.StatusCreated, map[string]string{"status": "created"})
 }
 
 func (s *MockServer) handlePatch(w http.ResponseWriter, r *http.Request) {
@@ -325,6 +512,14 @@ func (s *MockServer) handleDelete(w http.ResponseWriter, r *http.Request) {
 	// Hold a single lock for the entire delete + collection update to avoid
 	// unsynchronised reads of s.overrides between the two operations.
 	s.mu.Lock()
+	// Dispatch delete hooks for this resource (e.g. credential cleanup).
+	// base was loaded before the lock and covers both overridden and embedded resources.
+	for suffix, hook := range s.onDelete {
+		if strings.Contains(r.URL.Path, suffix+"/") {
+			hook(s, base)
+			break
+		}
+	}
 	delete(s.overrides, filePath)
 
 	// get collection of the resource
@@ -537,6 +732,40 @@ func (s *MockServer) handleSystemReset(w http.ResponseWriter, r *http.Request, b
 	}
 
 	s.writeJSON(w, http.StatusAccepted, map[string]string{"status": "Accepted"})
+}
+
+func (s *MockServer) handleChangePassword(w http.ResponseWriter, r *http.Request, body []byte) {
+	var req struct {
+		NewPassword string `json:"NewPassword"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if req.NewPassword == "" {
+		http.Error(w, "NewPassword must not be empty", http.StatusBadRequest)
+		return
+	}
+	accountPath := strings.TrimSuffix(r.URL.Path, "/Actions/ManagerAccount.ChangePassword")
+	filePath := resolvePath(accountPath)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	account, err := s.loadResourceLocked(filePath)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	username, ok := account["UserName"].(string)
+	if !ok || username == "" {
+		http.Error(w, "account has no UserName", http.StatusBadRequest)
+		return
+	}
+	// Update both the auth store and the persisted resource so that a
+	// subsequent GET returns the current password.
+	s.accounts[username] = req.NewPassword
+	account["Password"] = req.NewPassword
+	s.overrides[filePath] = account
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *MockServer) handleBMCReset(w http.ResponseWriter, r *http.Request, body []byte) {
@@ -930,6 +1159,19 @@ func (s *MockServer) loadResourceLocked(filePath string) (map[string]any, error)
 	if cached, ok := s.overrides[filePath].(map[string]any); ok {
 		return deepCopy(cached), nil
 	}
+	// Collection overrides are stored as Collection structs by handleCollectionPost/handleDelete.
+	// Marshal to map[string]any so this path is uniform with the embedded-data path.
+	if col, ok := s.overrides[filePath].(Collection); ok {
+		b, err := json.Marshal(col)
+		if err != nil {
+			return nil, fmt.Errorf("%w: marshal collection: %w", errCorruptJSON, err)
+		}
+		var result map[string]any
+		if err := json.Unmarshal(b, &result); err != nil {
+			return nil, fmt.Errorf("%w: unmarshal collection: %w", errCorruptJSON, err)
+		}
+		return result, nil
+	}
 
 	data, err := dataFS.ReadFile(filePath)
 	if err != nil {
@@ -985,6 +1227,68 @@ func (s *MockServer) writeJSON(w http.ResponseWriter, status int, data any) {
 	if _, err := w.Write(resp); err != nil {
 		s.log.Error(err, "Failed to write response")
 	}
+}
+
+// SetUnavailable toggles the simulated-unavailable mode. When true every request
+// returns 503 Service Unavailable, allowing tests to verify BMC connection-error
+// handling without touching UnitTestMockUps.
+func (s *MockServer) SetUnavailable(unavailable bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unavailable = unavailable
+}
+
+// Authenticate returns true if username/password match the stored account credentials.
+func (s *MockServer) Authenticate(username, password string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	stored, ok := s.accounts[username]
+	return ok && stored == password
+}
+
+// GetAccountNames returns the set of UserName values currently in the account
+// collection (including any created by tests). Suitable for gomega HaveKey assertions.
+func (s *MockServer) GetAccountNames() map[string]struct{} {
+	collection, err := s.loadResource("data/AccountService/Accounts/index.json")
+	if err != nil {
+		return map[string]struct{}{}
+	}
+	members, _ := collection["Members"].([]any)
+	result := make(map[string]struct{}, len(members))
+	for _, m := range members {
+		mMap, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		odataID, _ := mMap["@odata.id"].(string)
+		if odataID == "" {
+			continue
+		}
+		member, err := s.loadResource(resolvePath(odataID))
+		if err != nil {
+			continue
+		}
+		if uname, ok := member["UserName"].(string); ok && uname != "" {
+			result[uname] = struct{}{}
+		}
+	}
+	return result
+}
+
+// ResetAccounts clears all account-collection overrides (restoring the embedded
+// default collection) and resets the password store to defaults. Call this in
+// AfterEach to ensure a clean slate between account-related tests.
+func (s *MockServer) ResetAccounts() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resetResourceFromEmbeddedLocked("data/AccountService/Accounts/index.json")
+	for key := range s.overrides {
+		if strings.HasPrefix(key, "data/AccountService/Accounts/") &&
+			key != "data/AccountService/Accounts/index.json" {
+			delete(s.overrides, key)
+		}
+	}
+	s.accounts = loadAccountsFromEmbedded()
 }
 
 // Start starts the mock server and stops on ctx cancellation.

--- a/bmc/redfish_local.go
+++ b/bmc/redfish_local.go
@@ -26,72 +26,13 @@ type RedfishLocalBMC struct {
 }
 
 // NewRedfishLocalBMCClient creates a new RedfishLocalBMC with the given connection details.
+// Authentication is validated by the mock HTTP server via the standard Basic Auth header.
 func NewRedfishLocalBMCClient(ctx context.Context, options Options) (BMC, error) {
-	if UnitTestMockUps == nil {
-		InitMockUp()
-	}
-	if UnitTestMockUps.SimulateUnvailableBMC {
-		err := &schemas.Error{
-			HTTPReturnedStatusCode: 503,
-		}
-		return nil, err
-	}
 	bmc, err := newRedfishBaseBMCClient(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	if acc, ok := UnitTestMockUps.Accounts[options.Username]; ok {
-		if acc.Password == options.Password {
-			// authenticated
-			return &RedfishLocalBMC{RedfishBaseBMC: bmc}, nil
-		}
-	}
-	return nil, &schemas.Error{
-		HTTPReturnedStatusCode: 401,
-	}
-}
-
-// GetAccounts retrieves all user accounts from the BMC.
-func (r *RedfishLocalBMC) GetAccounts() ([]*schemas.ManagerAccount, error) {
-	accounts := make([]*schemas.ManagerAccount, 0, len(UnitTestMockUps.Accounts))
-	for _, a := range UnitTestMockUps.Accounts {
-		accounts = append(accounts, a)
-	}
-	return accounts, nil
-}
-
-// CreateOrUpdateAccount creates or updates a user account on the BMC.
-func (r *RedfishLocalBMC) CreateOrUpdateAccount(
-	ctx context.Context, userName, role, password string, enabled bool,
-) error {
-	for _, a := range UnitTestMockUps.Accounts {
-		if a.UserName == userName {
-			a.RoleID = role
-			a.UserName = userName
-			a.Enabled = enabled
-			a.Password = password
-			return nil
-		}
-	}
-	newAccount := schemas.ManagerAccount{
-		Entity: schemas.Entity{
-			ID: fmt.Sprintf("%d", len(UnitTestMockUps.Accounts)+1),
-		},
-		UserName: userName,
-		RoleID:   role,
-		Enabled:  enabled,
-		Password: password,
-	}
-	UnitTestMockUps.Accounts[userName] = &newAccount
-	return nil
-}
-
-func (r *RedfishLocalBMC) DeleteAccount(ctx context.Context, userName, id string) error {
-	if _, ok := UnitTestMockUps.Accounts[userName]; ok {
-		delete(UnitTestMockUps.Accounts, userName)
-		return nil
-	}
-	return fmt.Errorf("account %s not found", userName)
+	return &RedfishLocalBMC{RedfishBaseBMC: bmc}, nil
 }
 
 // UpgradeBiosVersion initiates a BIOS upgrade.

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -1258,6 +1258,7 @@ var _ = Describe("BIOSSettings Controller with BMCRef BMC", func() {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, pendingSettingsURL, bytes.NewReader(pendingBody))
 		Expect(err).NotTo(HaveOccurred())
 		req.Header.Set("Content-Type", "application/json")
+		req.SetBasicAuth(string(bmcSecret.Data[metalv1alpha1.BMCSecretUsernameKeyName]), string(bmcSecret.Data[metalv1alpha1.BMCSecretPasswordKeyName]))
 
 		client := &http.Client{
 			Timeout: 5 * time.Second,
@@ -1310,6 +1311,7 @@ var _ = Describe("BIOSSettings Controller with BMCRef BMC", func() {
 		clearPendingURL := fmt.Sprintf("http://%s:%d/redfish/v1/Systems/437XR1138R2/Bios/Settings", MockServerIP, MockServerPort)
 		clearReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, clearPendingURL, nil)
 		Expect(err).NotTo(HaveOccurred())
+		clearReq.SetBasicAuth(string(bmcSecret.Data[metalv1alpha1.BMCSecretUsernameKeyName]), string(bmcSecret.Data[metalv1alpha1.BMCSecretPasswordKeyName]))
 
 		clearResp, err := client.Do(clearReq)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
-	metalBmc "github.com/ironcore-dev/metal-operator/bmc"
 	"github.com/ironcore-dev/metal-operator/internal/bmcutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -584,7 +583,7 @@ var _ = Describe("BMC Conditions", func() {
 	})
 
 	It("should create ready conditions when there are BMC connection errors", func(ctx SpecContext) {
-		metalBmc.UnitTestMockUps.SimulateUnvailableBMC = true
+		mockServers[0].SetUnavailable(true)
 		By("Creating a BMCSecret")
 		bmcSecret := &metalv1alpha1.BMCSecret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -631,7 +630,7 @@ var _ = Describe("BMC Conditions", func() {
 			)),
 		)
 
-		metalBmc.UnitTestMockUps.SimulateUnvailableBMC = false
+		mockServers[0].SetUnavailable(false)
 
 		By("Ensuring right conditions are present, after bmc becomes responsive again")
 		Eventually(Object(bmc)).Should(

--- a/internal/controller/bmcuser_controller.go
+++ b/internal/controller/bmcuser_controller.go
@@ -368,6 +368,18 @@ func (r *BMCUserReconciler) bmcConnectionTest(ctx context.Context, secret *metal
 		return false, fmt.Errorf("failed to create BMC client: %w", err)
 	}
 	defer bmcClient.Logout()
+	// With BasicAuth, ConnectContext only stores credentials without making an
+	// authenticated request (it skips CreateSession). Probe an authenticated
+	// endpoint here so that invalid/rotated credentials are detected.
+	if r.BMCOptions.BasicAuth {
+		if _, err := bmcClient.GetAccountService(); err != nil {
+			var httpErr *schemas.Error
+			if errors.As(err, &httpErr) && (httpErr.HTTPReturnedStatusCode == 401 || httpErr.HTTPReturnedStatusCode == 403) {
+				return true, nil
+			}
+			return false, fmt.Errorf("failed to verify BMC credentials: %w", err)
+		}
+	}
 	return false, nil
 }
 

--- a/internal/controller/bmcuser_controller_test.go
+++ b/internal/controller/bmcuser_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
-	metalBMC "github.com/ironcore-dev/metal-operator/bmc"
 	"github.com/ironcore-dev/metal-operator/internal/bmcutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -294,7 +293,7 @@ var _ = Describe("BMCUser Controller", func() {
 	})
 
 	It("should delete BMC user and secret on User deletion", func(ctx SpecContext) {
-		metalBMC.UnitTestMockUps.InitializeDefaults()
+		mockServers[0].ResetAccounts()
 		By("Creating a User resource")
 		user := &metalv1alpha1.BMCUser{
 			ObjectMeta: metav1.ObjectMeta{
@@ -311,7 +310,7 @@ var _ = Describe("BMCUser Controller", func() {
 		Expect(k8sClient.Create(ctx, user)).To(Succeed())
 		By("Ensuring that the User resource has been created")
 		Eventually(Get(user)).Should(Succeed())
-		Eventually(metalBMC.UnitTestMockUps.Accounts).Should(HaveKey("deleteUser"))
+		Eventually(mockServers[0].GetAccountNames).Should(HaveKey("deleteUser"))
 
 		By("Ensuring that the User resource has been patched with the BMC secret reference")
 		Eventually(Object(user)).Should(SatisfyAll(
@@ -333,7 +332,7 @@ var _ = Describe("BMCUser Controller", func() {
 		Eventually(Get(user)).ShouldNot(Succeed())
 
 		By("Ensuring that the BMC user has been deleted")
-		Eventually(metalBMC.UnitTestMockUps.Accounts).ShouldNot(HaveKey("deleteUser"))
+		Eventually(mockServers[0].GetAccountNames).ShouldNot(HaveKey("deleteUser"))
 
 		By("Ensuring that the effective BMCSecret has been deleted")
 		Expect(k8sClient.Delete(ctx, effectiveSecret)).To(Succeed())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -189,6 +189,11 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			EventURL:               "http://localhost:8008",
 			DNSRecordTemplate:      dnsTemplate,
 			Conditions:             accessor,
+			BMCOptions: bmc.Options{
+				PowerPollingInterval: 50 * time.Millisecond,
+				PowerPollingTimeout:  200 * time.Millisecond,
+				BasicAuth:            true,
+			},
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
 		Expect((&ServerReconciler{
@@ -346,7 +351,7 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			mockServers = make([]*server.MockServer, 0, len(redfishMockServers))
 			for _, serverAddr := range redfishMockServers {
 				By(fmt.Sprintf("Starting the mock Redfish servers %v", serverAddr))
-				ms := server.NewMockServer(GinkgoLogr, serverAddr.String())
+				ms := server.NewMockServer(GinkgoLogr, serverAddr.String(), server.WithAuth())
 				mockServers = append(mockServers, ms)
 				Expect(k8sManager.Add(manager.RunnableFunc(func(ctx context.Context) error {
 					if err := ms.Start(ctx); err != nil {
@@ -358,7 +363,7 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			}
 		} else {
 			By("Starting the default mock Redfish server")
-			ms := server.NewMockServer(GinkgoLogr, fmt.Sprintf(":%d", MockServerPort))
+			ms := server.NewMockServer(GinkgoLogr, fmt.Sprintf(":%d", MockServerPort), server.WithAuth())
 			mockServers = []*server.MockServer{ms}
 			Expect(k8sManager.Add(manager.RunnableFunc(func(ctx context.Context) error {
 				if err := ms.Start(ctx); err != nil {


### PR DESCRIPTION
Fixes #840 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mock Redfish server now supports configurable Basic Authentication and an "unavailable" mode (returns 503).

* **Chores**
  * Tests and test framework updated to use per-server authentication controls and server-level credential APIs.

* **Data**
  * Mock account data updated (usernames, passwords, account types) and account collection membership adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->