### PR TITLE
Implement webhook validation to reject ServerClaim deprecated updates

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -650,6 +650,13 @@ func main() { // nolint: gocyclo
 	}
 	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err := webhookv1alpha1.SetupServerClaimWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "Failed to create webhook", "webhook", "ServerClaim")
+			os.Exit(1)
+		}
+	}
+	// nolint:goconst
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err := webhookv1alpha1.SetupBIOSSettingsWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "Failed to create webhook", "webhook", "BIOSSettings")
 			os.Exit(1)

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -148,3 +148,23 @@ webhooks:
     resources:
     - servers
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-metal-ironcore-dev-v1alpha1-serverclaim
+  failurePolicy: Fail
+  name: vserverclaim-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - metal.ironcore.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - serverclaims
+  sideEffects: None

--- a/dist/chart/templates/webhook/webhooks.yaml
+++ b/dist/chart/templates/webhook/webhooks.yaml
@@ -155,4 +155,24 @@ webhooks:
           - v1alpha1
         resources:
           - servers
+  - name: vserverclaim-v1alpha1.kb.io
+    clientConfig:
+      service:
+        name: metal-operator-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-metal-ironcore-dev-v1alpha1-serverclaim
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - metal.ironcore.dev
+        apiVersions:
+          - v1alpha1
+        resources:
+          - serverclaims
 {{- end }}

--- a/internal/webhook/v1alpha1/serverclaim_webhook.go
+++ b/internal/webhook/v1alpha1/serverclaim_webhook.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+)
+
+var serverclaimlog = logf.Log.WithName("serverclaim-resource")
+
+// SetupServerClaimWebhookWithManager registers the webhook for ServerClaim in the manager.
+func SetupServerClaimWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &metalv1alpha1.ServerClaim{}).
+		WithValidator(&ServerClaimCustomValidator{Client: mgr.GetClient()}).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-metal-ironcore-dev-v1alpha1-serverclaim,mutating=false,failurePolicy=fail,sideEffects=None,groups=metal.ironcore.dev,resources=serverclaims,verbs=create;update,versions=v1alpha1,name=vserverclaim-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// ServerClaimCustomValidator validates ServerClaim resources on create and update.
+type ServerClaimCustomValidator struct {
+	Client client.Client
+}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type ServerClaim.
+func (v *ServerClaimCustomValidator) ValidateCreate(ctx context.Context, obj *metalv1alpha1.ServerClaim) (admission.Warnings, error) {
+	serverclaimlog.Info("Validation for ServerClaim upon creation", "name", obj.GetName())
+	return nil, validateNoDeprecatedApprovalKey(obj)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type ServerClaim.
+func (v *ServerClaimCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *metalv1alpha1.ServerClaim) (admission.Warnings, error) {
+	serverclaimlog.Info("Validation for ServerClaim upon update", "name", newObj.GetName())
+	return nil, validateNoDeprecatedApprovalKey(newObj)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type ServerClaim.
+func (v *ServerClaimCustomValidator) ValidateDelete(_ context.Context, _ *metalv1alpha1.ServerClaim) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validateNoDeprecatedApprovalKey rejects any ServerClaim that carries the deprecated
+// maintenance-approval key in its annotations or labels. Consumers must use
+// ServerMaintenanceApprovedLabelKey ("metal.ironcore.dev/maintenance-approved") instead.
+func validateNoDeprecatedApprovalKey(obj *metalv1alpha1.ServerClaim) error {
+	deprecatedMsg := fmt.Sprintf(
+		"deprecated maintenance approval key %q; please migrate to %q",
+		metalv1alpha1.ServerMaintenanceApprovalKey,
+		metalv1alpha1.ServerMaintenanceApprovedLabelKey,
+	)
+
+	var errs field.ErrorList
+	if _, ok := obj.Annotations[metalv1alpha1.ServerMaintenanceApprovalKey]; ok {
+		errs = append(errs, field.Forbidden(
+			field.NewPath("metadata", "annotations").Key(metalv1alpha1.ServerMaintenanceApprovalKey),
+			deprecatedMsg,
+		))
+	}
+	if _, ok := obj.Labels[metalv1alpha1.ServerMaintenanceApprovalKey]; ok {
+		errs = append(errs, field.Forbidden(
+			field.NewPath("metadata", "labels").Key(metalv1alpha1.ServerMaintenanceApprovalKey),
+			deprecatedMsg,
+		))
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind},
+		obj.GetName(),
+		errs,
+	)
+}

--- a/internal/webhook/v1alpha1/serverclaim_webhook_test.go
+++ b/internal/webhook/v1alpha1/serverclaim_webhook_test.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+)
+
+var _ = Describe("ServerClaim Webhook", func() {
+	var (
+		serverClaim *metalv1alpha1.ServerClaim
+		validator   ServerClaimCustomValidator
+	)
+
+	BeforeEach(func() {
+		serverClaim = &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    "default",
+				GenerateName: "test-claim-",
+			},
+			Spec: metalv1alpha1.ServerClaimSpec{
+				Power: metalv1alpha1.PowerOff,
+				ServerRef: &corev1.LocalObjectReference{
+					Name: "test-server",
+				},
+				Image: "foo:latest",
+			},
+		}
+		validator = ServerClaimCustomValidator{Client: k8sClient}
+	})
+
+	Context("When creating a ServerClaim under Validating Webhook", func() {
+		It("should reject a ServerClaim with the deprecated approval annotation", func() {
+			serverClaim.Annotations = map[string]string{
+				metalv1alpha1.ServerMaintenanceApprovalKey: "true",
+			}
+			Expect(validator.ValidateCreate(ctx, serverClaim)).Error().To(HaveOccurred())
+		})
+
+		It("should reject a ServerClaim with the deprecated approval label", func() {
+			serverClaim.Labels = map[string]string{
+				metalv1alpha1.ServerMaintenanceApprovalKey: "true",
+			}
+			Expect(validator.ValidateCreate(ctx, serverClaim)).Error().To(HaveOccurred())
+		})
+
+		It("should reject a ServerClaim with the deprecated key in both annotations and labels", func() {
+			serverClaim.Annotations = map[string]string{
+				metalv1alpha1.ServerMaintenanceApprovalKey: "true",
+			}
+			serverClaim.Labels = map[string]string{
+				metalv1alpha1.ServerMaintenanceApprovalKey: "true",
+			}
+			_, err := validator.ValidateCreate(ctx, serverClaim)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(metalv1alpha1.ServerMaintenanceApprovalKey))
+			Expect(err.Error()).To(ContainSubstring(metalv1alpha1.ServerMaintenanceApprovedLabelKey))
+		})
+
+		It("should allow a ServerClaim with the current approved annotation", func() {
+			serverClaim.Annotations = map[string]string{
+				metalv1alpha1.ServerMaintenanceApprovedLabelKey: "true",
+			}
+			Expect(validator.ValidateCreate(ctx, serverClaim)).Error().NotTo(HaveOccurred())
+		})
+
+		It("should allow a ServerClaim with no approval keys", func() {
+			Expect(validator.ValidateCreate(ctx, serverClaim)).Error().NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When updating a ServerClaim under Validating Webhook", func() {
+		It("should reject an update that adds the deprecated approval annotation", func() {
+			updated := serverClaim.DeepCopy()
+			updated.Annotations = map[string]string{
+				metalv1alpha1.ServerMaintenanceApprovalKey: "true",
+			}
+			Expect(validator.ValidateUpdate(ctx, serverClaim, updated)).Error().To(HaveOccurred())
+		})
+
+		It("should reject an update that adds the deprecated approval label", func() {
+			updated := serverClaim.DeepCopy()
+			updated.Labels = map[string]string{
+				metalv1alpha1.ServerMaintenanceApprovalKey: "true",
+			}
+			Expect(validator.ValidateUpdate(ctx, serverClaim, updated)).Error().To(HaveOccurred())
+		})
+
+		It("should allow an update that uses the current approved label", func() {
+			updated := serverClaim.DeepCopy()
+			updated.Labels = map[string]string{
+				metalv1alpha1.ServerMaintenanceApprovedLabelKey: "true",
+			}
+			Expect(validator.ValidateUpdate(ctx, serverClaim, updated)).Error().NotTo(HaveOccurred())
+		})
+
+		It("should allow an update with no approval keys", func() {
+			updated := serverClaim.DeepCopy()
+			Expect(validator.ValidateUpdate(ctx, serverClaim, updated)).Error().NotTo(HaveOccurred())
+		})
+	})
+})

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -135,6 +135,9 @@ var _ = BeforeSuite(func() {
 	err = SetupServerWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = SetupServerClaimWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	// +kubebuilder:scaffold:webhook
 
 	go func() {


### PR DESCRIPTION
# Proposed Changes

- Created a new webhook that detects the presence of metal.ironcore.dev/maintenance-approval in annotations and labels
- Returned a clear validation error directing users to migrate to metal.ironcore.dev/maintenance-approved
- Added unit/integration tests for the webhook validation

Fixes #838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ServerClaim resources now validate and reject deprecated approval keys during creation and updates.

* **Tests**
  * Added comprehensive test coverage for ServerClaim webhook validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->