### PR TITLE
Improved handling of BMC attribute values by consulting registry type definitions

### DIFF
--- a/bmc/redfish_dell.go
+++ b/bmc/redfish_dell.go
@@ -248,7 +248,8 @@ func (r *DellRedfishBMC) GetBMCAttributeValues(ctx context.Context, bmcUUID stri
 				continue
 			}
 		}
-		if strings.EqualFold(string(entry.Type), string(schemas.EnumerationAttributeType)) {
+		switch entry.Type {
+		case schemas.EnumerationAttributeType:
 			currentVal, hasCurrentVal := mergedBMCAttributes[name]
 			if !hasCurrentVal {
 				errs = append(errs, fmt.Errorf("enum attribute '%v' not found in any DellAttributes endpoint", name))
@@ -269,20 +270,17 @@ func (r *DellRedfishBMC) GetBMCAttributeValues(ctx context.Context, bmcUUID stri
 					fmt.Errorf("current setting '%v' for key '%v' not found in possible values: %v",
 						currentVal, name, entry.Value))
 			}
-		} else {
+		case schemas.IntegerAttributeType:
 			// Convert raw JSON value to the correct Go type based on registry metadata.
 			// JSON numbers unmarshal as float64 into map[string]any; convert to int
 			// for IntegerAttributeType so downstream validation (checkAttributes) passes.
-			switch entry.Type {
-			case schemas.IntegerAttributeType:
-				if f, ok := mergedBMCAttributes[name].(float64); ok {
-					result[name] = int(f)
-				} else {
-					result[name] = mergedBMCAttributes[name]
-				}
-			default:
+			if f, ok := mergedBMCAttributes[name].(float64); ok {
+				result[name] = int(f)
+			} else {
 				result[name] = mergedBMCAttributes[name]
 			}
+		default:
+			result[name] = mergedBMCAttributes[name]
 		}
 	}
 	if len(errs) > 0 {

--- a/bmc/redfish_dell.go
+++ b/bmc/redfish_dell.go
@@ -248,13 +248,14 @@ func (r *DellRedfishBMC) GetBMCAttributeValues(ctx context.Context, bmcUUID stri
 				continue
 			}
 		}
+		currentVal, hasCurrentVal := mergedBMCAttributes[name]
+		if !hasCurrentVal {
+			errs = append(errs, fmt.Errorf("attribute '%v' not found in any DellAttributes endpoint", name))
+			continue
+		}
+
 		switch entry.Type {
 		case schemas.EnumerationAttributeType:
-			currentVal, hasCurrentVal := mergedBMCAttributes[name]
-			if !hasCurrentVal {
-				errs = append(errs, fmt.Errorf("enum attribute '%v' not found in any DellAttributes endpoint", name))
-				continue
-			}
 			// Translate the DisplayName value reported by iDRAC to the canonical
 			// ValueName used by the registry and the PATCH payload.
 			// currentVal may be nil (iDRAC CurrentValue=null for factory-default attributes),
@@ -274,13 +275,13 @@ func (r *DellRedfishBMC) GetBMCAttributeValues(ctx context.Context, bmcUUID stri
 			// Convert raw JSON value to the correct Go type based on registry metadata.
 			// JSON numbers unmarshal as float64 into map[string]any; convert to int
 			// for IntegerAttributeType so downstream validation (checkAttributes) passes.
-			if f, ok := mergedBMCAttributes[name].(float64); ok {
+			if f, ok := currentVal.(float64); ok {
 				result[name] = int(f)
 			} else {
-				result[name] = mergedBMCAttributes[name]
+				result[name] = currentVal
 			}
 		default:
-			result[name] = mergedBMCAttributes[name]
+			result[name] = currentVal
 		}
 	}
 	if len(errs) > 0 {

--- a/bmc/redfish_dell.go
+++ b/bmc/redfish_dell.go
@@ -270,7 +270,19 @@ func (r *DellRedfishBMC) GetBMCAttributeValues(ctx context.Context, bmcUUID stri
 						currentVal, name, entry.Value))
 			}
 		} else {
-			result[name] = mergedBMCAttributes[name]
+			// Convert raw JSON value to the correct Go type based on registry metadata.
+			// JSON numbers unmarshal as float64 into map[string]any; convert to int
+			// for IntegerAttributeType so downstream validation (checkAttributes) passes.
+			switch entry.Type {
+			case schemas.IntegerAttributeType:
+				if f, ok := mergedBMCAttributes[name].(float64); ok {
+					result[name] = int(f)
+				} else {
+					result[name] = mergedBMCAttributes[name]
+				}
+			default:
+				result[name] = mergedBMCAttributes[name]
+			}
 		}
 	}
 	if len(errs) > 0 {


### PR DESCRIPTION
Fix Dell GetBMCAttributeValues: convert Integer attributes from float64 to int

JSON numbers unmarshaled into map[string]any always produce float64 in Go.
When the registry declares an attribute as IntegerAttributeType, convert
the float64 value to int so downstream checkAttributes validation passes.

# Proposed Changes

- Convert value type to match Dell Registry Attribute type

Fixes #847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribute handling: integer attributes from BMC responses are now normalized to proper integer types, enumeration attributes continue to map correctly, and attribute-type branching is more robust—reducing misinterpreted values and improving configuration accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->