### PR TITLE
Rework condition handling during settings application and BMC reset

### DIFF
--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -423,13 +423,15 @@ func (r *BMCSettingsReconciler) handleSettingInProgressState(ctx context.Context
 
 func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, settings *metalv1alpha1.BMCSettings, bmcObj *metalv1alpha1.BMC, settingsDiff schemas.SettingsAttributes, bmcClient bmc.BMC) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	resetBMC, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
+
+	// Phase 1: Issue settings to the BMC (gated by ConditionBMCSettingsChangesIssued)
+	changesIssued, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesIssued)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get condition for reset of BMC of server: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to get condition for settings changes issued: %w", err)
 	}
 
-	if resetBMC.Reason != ReasonResetIssued {
-		// apply the BMC Settings if not done.
+	if changesIssued.Reason != ReasonBMCSettingsChangesIssued {
+		// Settings not yet issued — apply them now.
 		if ok, err := r.handleBMCPowerState(ctx, bmcObj, settings); err != nil || ok {
 			return ctrl.Result{}, err
 		}
@@ -469,34 +471,54 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 			}
 			log.V(1).Info("BMC settings issued successfully", "SettingKeys", settingKeys(settingsDiff))
 
-			BMCSettingsAppliedCondition, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesIssued)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to get Condition for Successful issue of BMC Settings: %w", err)
-			}
 			if err := r.Conditions.Update(
-				BMCSettingsAppliedCondition,
+				changesIssued,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
 				conditionutils.UpdateReason(ReasonBMCSettingsChangesIssued),
 				conditionutils.UpdateMessage("BMC settings have been issued on the server's BMC"),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings Applied condition: %w", err)
 			}
-			if err := r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, BMCSettingsAppliedCondition); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to update Condition for Successful issue of BMC Settings: %w", err)
-			}
+
+			// Mark whether a post-apply reset is needed for Phase 2
 			if resetBMCReq {
-				if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionBMCResetPostSettingApply); !ok || err != nil {
-					return ctrl.Result{}, err
+				resetCond, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
+				if errCond != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to get condition for reset of BMC: %w", errCond)
 				}
+				if err := r.Conditions.Update(
+					resetCond,
+					conditionutils.UpdateStatus(corev1.ConditionFalse),
+					conditionutils.UpdateReason(ReasonResetRequired),
+					conditionutils.UpdateMessage("BMC reset required after settings apply"),
+				); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to update reset required condition: %w", err)
+				}
+				if err := r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, changesIssued); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to persist settings changes issued condition: %w", err)
+				}
+				return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, resetCond)
 			}
+
+			return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, changesIssued)
 		}
-	} else {
-		log.V(1).Info("Waiting for BMC reset post applying BMC settings")
+
+		return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
+	}
+
+	// Phase 2: Handle BMC reset if required
+	resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get condition for reset of BMC: %w", err)
+	}
+	if resetCond.Reason == ReasonResetRequired || resetCond.Reason == ReasonResetIssued {
+		log.V(1).Info("Handling BMC reset post applying BMC settings")
 		if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionBMCResetPostSettingApply); !ok || err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
+	// Phase 3: Verify settings
 	settingsDiff, err = r.getBMCSettingsDifference(ctx, settings, bmcObj, bmcClient)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get BMC settings: %w", err)
@@ -544,7 +566,21 @@ func (r *BMCSettingsReconciler) handleSettingAppliedState(ctx context.Context, s
 		return fmt.Errorf("failed to fetch and check BMCSettings: %w", err)
 	}
 	if len(settingsDiff) > 0 {
-		return r.updateBMCSettingsStatus(ctx, settings, "", nil)
+		// Drift detected — clear the "changes issued" gate so the next InProgress
+		// reconcile will re-enter the apply phase.
+		changesIssued, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesIssued)
+		if errCond != nil {
+			return fmt.Errorf("failed to get condition for settings changes issued: %w", errCond)
+		}
+		if err := r.Conditions.Update(
+			changesIssued,
+			conditionutils.UpdateStatus(corev1.ConditionFalse),
+			conditionutils.UpdateReason("DriftDetected"),
+			conditionutils.UpdateMessage("Settings drift detected, re-apply needed"),
+		); err != nil {
+			return fmt.Errorf("failed to clear settings changes issued condition: %w", err)
+		}
+		return r.updateBMCSettingsStatus(ctx, settings, "", changesIssued)
 	}
 
 	log.V(1).Info("Done with BMC setting update", "BMCSetting", settings.Name, "BMC", bmcObj.Name)

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -481,50 +481,10 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 				return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings Applied condition: %w", err)
 			}
 
-			// Reset later-phase conditions to prevent stale state from a previous generation
-			// leaking into this apply cycle.
-			resetCond, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
-			if errCond != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to get condition for reset of BMC: %w", errCond)
+			if err := r.persistApplyCycleConditions(ctx, settings, changesIssued, resetBMCReq); err != nil {
+				return ctrl.Result{}, err
 			}
-			verifiedCond, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesVerified)
-			if errCond != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to get condition for settings changes verified: %w", errCond)
-			}
-			if err := r.Conditions.Update(
-				verifiedCond,
-				conditionutils.UpdateStatus(corev1.ConditionFalse),
-				conditionutils.UpdateReason(ReasonBMCSettingsVerificationPending),
-				conditionutils.UpdateMessage("Verification pending for new apply cycle"),
-			); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to reset settings changes verified condition: %w", err)
-			}
-
-			// Mark whether a post-apply reset is needed for Phase 2
-			if resetBMCReq {
-				if err := r.Conditions.Update(
-					resetCond,
-					conditionutils.UpdateStatus(corev1.ConditionFalse),
-					conditionutils.UpdateReason(ReasonResetRequired),
-					conditionutils.UpdateMessage("BMC reset required after settings apply"),
-				); err != nil {
-					return ctrl.Result{}, fmt.Errorf("failed to update reset required condition: %w", err)
-				}
-			} else {
-				if err := r.Conditions.Update(
-					resetCond,
-					conditionutils.UpdateStatus(corev1.ConditionTrue),
-					conditionutils.UpdateReason(ReasonResetIssued),
-					conditionutils.UpdateMessage("No BMC reset required for this apply cycle"),
-				); err != nil {
-					return ctrl.Result{}, fmt.Errorf("failed to update reset not required condition: %w", err)
-				}
-			}
-
-			if err := r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, changesIssued); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to persist settings changes issued condition: %w", err)
-			}
-			return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, resetCond)
+			return ctrl.Result{}, nil
 		}
 
 		return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
@@ -570,6 +530,55 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 	}
 
 	return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
+}
+
+// persistApplyCycleConditions resets later-phase conditions (verified, reset) and
+// persists all phase conditions after a successful settings apply in Phase 1.
+func (r *BMCSettingsReconciler) persistApplyCycleConditions(ctx context.Context, settings *metalv1alpha1.BMCSettings, changesIssued *metav1.Condition, resetBMCReq bool) error {
+	resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
+	if err != nil {
+		return fmt.Errorf("failed to get condition for reset of BMC: %w", err)
+	}
+	verifiedCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesVerified)
+	if err != nil {
+		return fmt.Errorf("failed to get condition for settings changes verified: %w", err)
+	}
+	if err := r.Conditions.Update(
+		verifiedCond,
+		conditionutils.UpdateStatus(corev1.ConditionFalse),
+		conditionutils.UpdateReason(ReasonBMCSettingsVerificationPending),
+		conditionutils.UpdateMessage("Verification pending for new apply cycle"),
+	); err != nil {
+		return fmt.Errorf("failed to reset settings changes verified condition: %w", err)
+	}
+
+	if resetBMCReq {
+		if err := r.Conditions.Update(
+			resetCond,
+			conditionutils.UpdateStatus(corev1.ConditionFalse),
+			conditionutils.UpdateReason(ReasonResetRequired),
+			conditionutils.UpdateMessage("BMC reset required after settings apply"),
+		); err != nil {
+			return fmt.Errorf("failed to update reset required condition: %w", err)
+		}
+	} else {
+		if err := r.Conditions.Update(
+			resetCond,
+			conditionutils.UpdateStatus(corev1.ConditionTrue),
+			conditionutils.UpdateReason(ReasonResetIssued),
+			conditionutils.UpdateMessage("No BMC reset required for this apply cycle"),
+		); err != nil {
+			return fmt.Errorf("failed to update reset not required condition: %w", err)
+		}
+	}
+
+	if err := r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, changesIssued); err != nil {
+		return fmt.Errorf("failed to persist settings changes issued condition: %w", err)
+	}
+	if err := r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, verifiedCond); err != nil {
+		return fmt.Errorf("failed to persist settings changes verified condition: %w", err)
+	}
+	return r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, resetCond)
 }
 
 func (r *BMCSettingsReconciler) handleSettingAppliedState(ctx context.Context, settings *metalv1alpha1.BMCSettings, bmcObj *metalv1alpha1.BMC, bmcClient bmc.BMC) error {

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -533,8 +533,10 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 }
 
 // persistApplyCycleConditions resets later-phase conditions (verified, reset) and
-// persists all phase conditions after a successful settings apply in Phase 1.
+// persists all phase conditions atomically after a successful settings apply in Phase 1.
 func (r *BMCSettingsReconciler) persistApplyCycleConditions(ctx context.Context, settings *metalv1alpha1.BMCSettings, changesIssued *metav1.Condition, resetBMCReq bool) error {
+	log := ctrl.LoggerFrom(ctx)
+
 	resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
 	if err != nil {
 		return fmt.Errorf("failed to get condition for reset of BMC: %w", err)
@@ -565,20 +567,37 @@ func (r *BMCSettingsReconciler) persistApplyCycleConditions(ctx context.Context,
 		if err := r.Conditions.Update(
 			resetCond,
 			conditionutils.UpdateStatus(corev1.ConditionTrue),
-			conditionutils.UpdateReason(ReasonResetIssued),
+			conditionutils.UpdateReason(ReasonNoResetRequired),
 			conditionutils.UpdateMessage("No BMC reset required for this apply cycle"),
 		); err != nil {
 			return fmt.Errorf("failed to update reset not required condition: %w", err)
 		}
 	}
 
-	if err := r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, changesIssued); err != nil {
-		return fmt.Errorf("failed to persist settings changes issued condition: %w", err)
+	// Persist all three conditions in a single atomic status patch.
+	BMCSettingsBase := settings.DeepCopy()
+	for _, cond := range []*metav1.Condition{changesIssued, verifiedCond, resetCond} {
+		updateOpts := []conditionutils.UpdateOption{
+			conditionutils.UpdateStatus(cond.Status),
+			conditionutils.UpdateReason(cond.Reason),
+			conditionutils.UpdateMessage(cond.Message),
+		}
+		if cond.ObservedGeneration > 0 {
+			updateOpts = append(updateOpts, conditionutils.UpdateObservedGeneration(cond.ObservedGeneration))
+		}
+		if err := r.Conditions.UpdateSlice(
+			&settings.Status.Conditions,
+			cond.Type,
+			updateOpts...,
+		); err != nil {
+			return fmt.Errorf("failed to update condition %s in slice: %w", cond.Type, err)
+		}
 	}
-	if err := r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, verifiedCond); err != nil {
-		return fmt.Errorf("failed to persist settings changes verified condition: %w", err)
+	if err := r.Status().Patch(ctx, settings, client.MergeFrom(BMCSettingsBase)); err != nil {
+		return fmt.Errorf("failed to patch settings status: %w", err)
 	}
-	return r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, resetCond)
+	log.V(1).Info("Persisted apply-cycle conditions atomically")
+	return nil
 }
 
 func (r *BMCSettingsReconciler) handleSettingAppliedState(ctx context.Context, settings *metalv1alpha1.BMCSettings, bmcObj *metalv1alpha1.BMC, bmcClient bmc.BMC) error {
@@ -661,8 +680,8 @@ func (r *BMCSettingsReconciler) handleBMCReset(
 		return false, fmt.Errorf("failed to get condition for reset of BMC of server %v", err)
 	}
 
-	// No reset requested — nothing to do
-	if resetBMC.Reason != ReasonResetRequired && resetBMC.Reason != ReasonResetIssued {
+	// The post-apply reset phase can be skipped explicitly when no reset was needed.
+	if conditionType == ConditionBMCResetPostSettingApply && resetBMC.Status == metav1.ConditionTrue && resetBMC.Reason == ReasonNoResetRequired {
 		return true, nil
 	}
 

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -508,15 +508,9 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 	}
 
 	// Phase 2: Handle BMC reset if required
-	resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get condition for reset of BMC: %w", err)
-	}
-	if resetCond.Reason == ReasonResetRequired || resetCond.Reason == ReasonResetIssued {
-		log.V(1).Info("Handling BMC reset post applying BMC settings")
-		if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionBMCResetPostSettingApply); !ok || err != nil {
-			return ctrl.Result{}, err
-		}
+	log.V(1).Info("Handling BMC reset post applying BMC settings")
+	if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionBMCResetPostSettingApply); !ok || err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Phase 3: Verify settings
@@ -567,36 +561,10 @@ func (r *BMCSettingsReconciler) handleSettingAppliedState(ctx context.Context, s
 		return fmt.Errorf("failed to fetch and check BMCSettings: %w", err)
 	}
 	if len(settingsDiff) > 0 {
-		// Drift detected — clear the "changes issued" and "changes verified" gates
-		// so the next InProgress reconcile will re-enter the apply phase.
-		changesIssued, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesIssued)
-		if errCond != nil {
-			return fmt.Errorf("failed to get condition for settings changes issued: %w", errCond)
-		}
-		if err := r.Conditions.Update(
-			changesIssued,
-			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason("DriftDetected"),
-			conditionutils.UpdateMessage("Settings drift detected, re-apply needed"),
-		); err != nil {
-			return fmt.Errorf("failed to clear settings changes issued condition: %w", err)
-		}
-		changesVerified, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesVerified)
-		if errCond != nil {
-			return fmt.Errorf("failed to get condition for settings changes verified: %w", errCond)
-		}
-		if err := r.Conditions.Update(
-			changesVerified,
-			conditionutils.UpdateStatus(corev1.ConditionFalse),
-			conditionutils.UpdateReason("DriftDetected"),
-			conditionutils.UpdateMessage("Settings drift detected, re-apply needed"),
-		); err != nil {
-			return fmt.Errorf("failed to clear settings changes verified condition: %w", err)
-		}
-		if err := r.updateBMCSettingsStatus(ctx, settings, "", changesIssued); err != nil {
-			return fmt.Errorf("failed to persist settings changes issued condition: %w", err)
-		}
-		return r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, changesVerified)
+		// Drift detected — reset all conditions and state so the next reconcile
+		// re-enters the apply phase from scratch.
+		log.V(1).Info("Settings drift detected, resetting state for re-apply")
+		return r.updateBMCSettingsStatus(ctx, settings, "", nil)
 	}
 
 	log.V(1).Info("Done with BMC setting update", "BMCSetting", settings.Name, "BMC", bmcObj.Name)
@@ -659,6 +627,11 @@ func (r *BMCSettingsReconciler) handleBMCReset(
 	resetBMC, err := GetCondition(r.Conditions, settings.Status.Conditions, conditionType)
 	if err != nil {
 		return false, fmt.Errorf("failed to get condition for reset of BMC of server %v", err)
+	}
+
+	// No reset requested — nothing to do
+	if resetBMC.Reason != ReasonResetRequired && resetBMC.Reason != ReasonResetIssued {
+		return true, nil
 	}
 
 	if resetBMC.Status != metav1.ConditionTrue {

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -481,12 +481,27 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 				return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings Applied condition: %w", err)
 			}
 
+			// Reset later-phase conditions to prevent stale state from a previous generation
+			// leaking into this apply cycle.
+			resetCond, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
+			if errCond != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to get condition for reset of BMC: %w", errCond)
+			}
+			verifiedCond, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesVerified)
+			if errCond != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to get condition for settings changes verified: %w", errCond)
+			}
+			if err := r.Conditions.Update(
+				verifiedCond,
+				conditionutils.UpdateStatus(corev1.ConditionFalse),
+				conditionutils.UpdateReason(ReasonBMCSettingsVerificationPending),
+				conditionutils.UpdateMessage("Verification pending for new apply cycle"),
+			); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to reset settings changes verified condition: %w", err)
+			}
+
 			// Mark whether a post-apply reset is needed for Phase 2
 			if resetBMCReq {
-				resetCond, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCResetPostSettingApply)
-				if errCond != nil {
-					return ctrl.Result{}, fmt.Errorf("failed to get condition for reset of BMC: %w", errCond)
-				}
 				if err := r.Conditions.Update(
 					resetCond,
 					conditionutils.UpdateStatus(corev1.ConditionFalse),
@@ -495,13 +510,21 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 				); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update reset required condition: %w", err)
 				}
-				if err := r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, changesIssued); err != nil {
-					return ctrl.Result{}, fmt.Errorf("failed to persist settings changes issued condition: %w", err)
+			} else {
+				if err := r.Conditions.Update(
+					resetCond,
+					conditionutils.UpdateStatus(corev1.ConditionTrue),
+					conditionutils.UpdateReason(ReasonResetIssued),
+					conditionutils.UpdateMessage("No BMC reset required for this apply cycle"),
+				); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to update reset not required condition: %w", err)
 				}
-				return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, resetCond)
 			}
 
-			return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, changesIssued)
+			if err := r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, changesIssued); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to persist settings changes issued condition: %w", err)
+			}
+			return ctrl.Result{}, r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, resetCond)
 		}
 
 		return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -487,11 +487,11 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 			return ctrl.Result{}, nil
 		}
 
+		log.V(1).Info("Pending BMC attributes exist, waiting for them to clear before applying settings")
 		return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
 	}
 
 	// Phase 2: Handle BMC reset if required
-	log.V(1).Info("Handling BMC reset post applying BMC settings")
 	if ok, err := r.handleBMCReset(ctx, settings, bmcObj, ConditionBMCResetPostSettingApply); !ok || err != nil {
 		return ctrl.Result{}, err
 	}
@@ -684,6 +684,8 @@ func (r *BMCSettingsReconciler) handleBMCReset(
 	if conditionType == ConditionBMCResetPostSettingApply && resetBMC.Status == metav1.ConditionTrue && resetBMC.Reason == ReasonNoResetRequired {
 		return true, nil
 	}
+
+	log.V(1).Info("Handling BMC reset", "conditionType", conditionType)
 
 	if resetBMC.Status != metav1.ConditionTrue {
 		annotations := bmcObj.GetAnnotations()

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -430,8 +430,8 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 		return ctrl.Result{}, fmt.Errorf("failed to get condition for settings changes issued: %w", err)
 	}
 
-	if changesIssued.Reason != ReasonBMCSettingsChangesIssued {
-		// Settings not yet issued — apply them now.
+	if changesIssued.Reason != ReasonBMCSettingsChangesIssued || changesIssued.ObservedGeneration < settings.Generation {
+		// Settings not yet issued, or spec changed since last apply — (re-)apply them now.
 		if ok, err := r.handleBMCPowerState(ctx, bmcObj, settings); err != nil || ok {
 			return ctrl.Result{}, err
 		}
@@ -476,6 +476,7 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
 				conditionutils.UpdateReason(ReasonBMCSettingsChangesIssued),
 				conditionutils.UpdateMessage("BMC settings have been issued on the server's BMC"),
+				conditionutils.UpdateObserved(settings),
 			); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update BMCSettings Applied condition: %w", err)
 			}
@@ -566,8 +567,8 @@ func (r *BMCSettingsReconciler) handleSettingAppliedState(ctx context.Context, s
 		return fmt.Errorf("failed to fetch and check BMCSettings: %w", err)
 	}
 	if len(settingsDiff) > 0 {
-		// Drift detected — clear the "changes issued" gate so the next InProgress
-		// reconcile will re-enter the apply phase.
+		// Drift detected — clear the "changes issued" and "changes verified" gates
+		// so the next InProgress reconcile will re-enter the apply phase.
 		changesIssued, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesIssued)
 		if errCond != nil {
 			return fmt.Errorf("failed to get condition for settings changes issued: %w", errCond)
@@ -580,7 +581,22 @@ func (r *BMCSettingsReconciler) handleSettingAppliedState(ctx context.Context, s
 		); err != nil {
 			return fmt.Errorf("failed to clear settings changes issued condition: %w", err)
 		}
-		return r.updateBMCSettingsStatus(ctx, settings, "", changesIssued)
+		changesVerified, errCond := GetCondition(r.Conditions, settings.Status.Conditions, ConditionBMCSettingsChangesVerified)
+		if errCond != nil {
+			return fmt.Errorf("failed to get condition for settings changes verified: %w", errCond)
+		}
+		if err := r.Conditions.Update(
+			changesVerified,
+			conditionutils.UpdateStatus(corev1.ConditionFalse),
+			conditionutils.UpdateReason("DriftDetected"),
+			conditionutils.UpdateMessage("Settings drift detected, re-apply needed"),
+		); err != nil {
+			return fmt.Errorf("failed to clear settings changes verified condition: %w", err)
+		}
+		if err := r.updateBMCSettingsStatus(ctx, settings, "", changesIssued); err != nil {
+			return fmt.Errorf("failed to persist settings changes issued condition: %w", err)
+		}
+		return r.updateBMCSettingsStatus(ctx, settings, settings.Status.State, changesVerified)
 	}
 
 	log.V(1).Info("Done with BMC setting update", "BMCSetting", settings.Name, "BMC", bmcObj.Name)
@@ -1178,12 +1194,18 @@ func (r *BMCSettingsReconciler) updateBMCSettingsStatus(ctx context.Context, set
 	settings.Status.State = state
 
 	if condition != nil {
-		if err := r.Conditions.UpdateSlice(
-			&settings.Status.Conditions,
-			condition.Type,
+		updateOpts := []conditionutils.UpdateOption{
 			conditionutils.UpdateStatus(condition.Status),
 			conditionutils.UpdateReason(condition.Reason),
 			conditionutils.UpdateMessage(condition.Message),
+		}
+		if condition.ObservedGeneration > 0 {
+			updateOpts = append(updateOpts, conditionutils.UpdateObservedGeneration(condition.ObservedGeneration))
+		}
+		if err := r.Conditions.UpdateSlice(
+			&settings.Status.Conditions,
+			condition.Type,
+			updateOpts...,
 		); err != nil {
 			return fmt.Errorf("failed to patch BMCSettings condition: %w", err)
 		}

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -51,6 +51,8 @@ const (
 	ReasonVersionUpgradePending = "VersionUpgradePending"
 	// ReasonResetIssued indicates a reset has been issued.
 	ReasonResetIssued = "ResetIssued"
+	// ReasonResetRequired indicates a BMC reset is needed but not yet issued.
+	ReasonResetRequired = "ResetRequired"
 	// ReasonAuthenticationFailed indicates authentication has failed.
 	ReasonAuthenticationFailed = "AuthenticationFailed"
 	// ReasonInternalError indicates an internal server error.

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -53,6 +53,8 @@ const (
 	ReasonResetIssued = "ResetIssued"
 	// ReasonResetRequired indicates a BMC reset is needed but not yet issued.
 	ReasonResetRequired = "ResetRequired"
+	// ReasonNoResetRequired indicates no BMC reset is needed for this apply cycle.
+	ReasonNoResetRequired = "NoResetRequired"
 	// ReasonAuthenticationFailed indicates authentication has failed.
 	ReasonAuthenticationFailed = "AuthenticationFailed"
 	// ReasonInternalError indicates an internal server error.


### PR DESCRIPTION
# Proposed Changes

- Change condition handling to prevent apply loop

Fixes #857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better drift detection: when settings diverge, prior apply state is cleared so reconciliation reliably retries.
  * Improved reset handling: post-apply reset needs are recorded and unnecessary reset attempts are avoided.

* **Improvements**
  * Phased apply-and-verify flow with clearer verification-pending transitions.
  * Status updates now include generation info when applicable.
  * Added a distinct reset-required reason for clearer reset state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/metal-operator/pull/861)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->