### PR TITLE
Fix BMC subscription duplicate handling by matching on Context instead of EventFormatType

### DIFF
--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -1093,7 +1093,7 @@ func (r *RedfishBaseBMC) CreateEventSubscription(
 				if strings.Contains(info.MessageId, "ResourceAlreadyExists") ||
 					strings.Contains(info.MessageId, "PropertyValueModified") {
 					// Handle duplicate subscription - try to find existing one
-					if existingLink, findErr := r.findExistingSubscription(destination, eventFormatType); findErr == nil {
+					if existingLink, findErr := r.findExistingSubscription(destination); findErr == nil {
 						// Successfully found existing subscription
 						return existingLink, nil
 					}
@@ -1121,10 +1121,9 @@ func (r *RedfishBaseBMC) CreateEventSubscription(
 
 // findExistingSubscription queries the BMC for an existing subscription with the given destination.
 // Returns the subscription URI if found, error otherwise.
-func (r *RedfishBaseBMC) findExistingSubscription(
-	destination string,
-	eventFormatType schemas.EventFormatType,
-) (string, error) {
+// Matches by Destination + Context ("metal-operator") rather than EventFormatType,
+// because many BMCs do not return EventFormatType in subscription responses.
+func (r *RedfishBaseBMC) findExistingSubscription(destination string) (string, error) {
 	service := r.client.GetService()
 	ev, err := service.EventService()
 	if err != nil {
@@ -1137,9 +1136,9 @@ func (r *RedfishBaseBMC) findExistingSubscription(
 		return "", fmt.Errorf("failed to list subscriptions: %w", err)
 	}
 
-	// Find subscription matching our destination and event format
+	// Find subscription matching our destination and context
 	for _, sub := range subscriptions {
-		if sub.Destination == destination && sub.EventFormatType == eventFormatType {
+		if sub.Destination == destination && sub.Context == "metal-operator" {
 			// Extract URI from OData ID
 			if sub.ODataID != "" {
 				return sub.ODataID, nil

--- a/bmc/redfish_hpe.go
+++ b/bmc/redfish_hpe.go
@@ -110,7 +110,7 @@ func (r *HPERedfishBMC) CreateEventSubscription(
 				if strings.Contains(info.MessageID, "ResourceAlreadyExists") ||
 					strings.Contains(info.MessageID, "PropertyValueModified") {
 					// Handle duplicate subscription - try to find existing one
-					if existingLink, findErr := r.findExistingSubscription(destination, eventFormatType); findErr == nil {
+					if existingLink, findErr := r.findExistingSubscription(destination); findErr == nil {
 						// Successfully found existing subscription
 						return existingLink, nil
 					}

--- a/bmc/redfish_test.go
+++ b/bmc/redfish_test.go
@@ -257,3 +257,193 @@ var _ = Describe("RedfishBaseBMC DiscoverManager", func() {
 		Expect(manager).To(BeNil())
 	})
 })
+
+// eventServiceJSON returns JSON for an EventService with subscriptions link.
+func eventServiceJSON() []byte {
+	svc := map[string]any{
+		"@odata.id":             "/redfish/v1/EventService",
+		"Id":                    "EventService",
+		"Name":                  "Event Service",
+		"ServiceEnabled":        true,
+		"Subscriptions":         map[string]string{"@odata.id": "/redfish/v1/EventService/Subscriptions"},
+		"DeliveryRetryAttempts": 3,
+	}
+	b, _ := json.Marshal(svc)
+	return b
+}
+
+// subscriptionJSON returns JSON for an EventDestination (subscription).
+// Note: EventFormatType is intentionally omitted to match real BMC behavior.
+func subscriptionJSON(id, destination, subContext string) []byte {
+	sub := map[string]any{
+		"@odata.id":   "/redfish/v1/EventService/Subscriptions/" + id,
+		"@odata.type": "#EventDestination.v1_14_0.EventDestination",
+		"Id":          id,
+		"Name":        "EventSubscription " + id,
+		"Destination": destination,
+		"Context":     subContext,
+		"Protocol":    "Redfish",
+		// EventFormatType intentionally omitted - many BMCs don't return it
+	}
+	b, _ := json.Marshal(sub)
+	return b
+}
+
+// subscriptionsCollectionJSON returns JSON for a subscriptions collection.
+func subscriptionsCollectionJSON(memberLinks []string) []byte {
+	type member struct {
+		ODataID string `json:"@odata.id"`
+	}
+	members := make([]member, len(memberLinks))
+	for i, link := range memberLinks {
+		members[i] = member{ODataID: link}
+	}
+	col := map[string]any{
+		"@odata.id":           "/redfish/v1/EventService/Subscriptions",
+		"Name":                "Event Subscriptions Collection",
+		"Members@odata.count": len(memberLinks),
+		"Members":             members,
+	}
+	b, _ := json.Marshal(col)
+	return b
+}
+
+// serviceRootWithEventServiceJSON returns JSON for a service root that includes EventService.
+func serviceRootWithEventServiceJSON() []byte {
+	root := map[string]any{
+		"@odata.id":      "/redfish/v1/",
+		"Id":             "ServiceRoot",
+		"Name":           "Service Root",
+		"RedfishVersion": "1.0.0",
+		"Managers":       map[string]string{"@odata.id": "/redfish/v1/Managers"},
+		"EventService":   map[string]string{"@odata.id": "/redfish/v1/EventService"},
+	}
+	b, _ := json.Marshal(root)
+	return b
+}
+
+var _ = Describe("RedfishBaseBMC findExistingSubscription", func() {
+	It("should find subscription matching destination and context", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootWithEventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(eventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(subscriptionsCollectionJSON([]string{"/redfish/v1/EventService/Subscriptions/1"})) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions/1", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(subscriptionJSON("1", "http://operator/serverevents/alerts/node1", "metal-operator")) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		link, err := bmc.findExistingSubscription("http://operator/serverevents/alerts/node1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link).To(Equal("/redfish/v1/EventService/Subscriptions/1"))
+	})
+
+	It("should not match subscription with different context", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootWithEventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(eventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(subscriptionsCollectionJSON([]string{"/redfish/v1/EventService/Subscriptions/1"})) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions/1", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// Same destination but different context (not "metal-operator")
+			w.Write(subscriptionJSON("1", "http://operator/serverevents/alerts/node1", "other-operator")) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		link, err := bmc.findExistingSubscription("http://operator/serverevents/alerts/node1")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("existing subscription not found"))
+		Expect(link).To(BeEmpty())
+	})
+
+	It("should return error when no subscriptions exist", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootWithEventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(eventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(subscriptionsCollectionJSON([]string{})) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		link, err := bmc.findExistingSubscription("http://operator/serverevents/alerts/node1")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("existing subscription not found"))
+		Expect(link).To(BeEmpty())
+	})
+
+	It("should find correct subscription among multiple", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootWithEventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(eventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(subscriptionsCollectionJSON([]string{
+				"/redfish/v1/EventService/Subscriptions/1",
+				"/redfish/v1/EventService/Subscriptions/2",
+				"/redfish/v1/EventService/Subscriptions/3",
+			}))
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions/1", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(subscriptionJSON("1", "http://other/callback", "metal-operator")) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions/2", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// This is the one we're looking for
+			w.Write(subscriptionJSON("2", "http://operator/serverevents/alerts/node1", "metal-operator")) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions/3", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(subscriptionJSON("3", "http://operator/serverevents/alerts/node1", "different-context")) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		link, err := bmc.findExistingSubscription("http://operator/serverevents/alerts/node1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link).To(Equal("/redfish/v1/EventService/Subscriptions/2"))
+	})
+})


### PR DESCRIPTION
Fix BMC subscription duplicate handling by matching on Context instead of EventFormatType

Fixes  #862

### Problem

The BMC reconciler was stuck in a retry loop when a Redfish event subscription already existed on the hardware. The operator's duplicate subscription handling was failing to find the existing subscription.

### Root Cause

The `findExistingSubscription()` function matched subscriptions using `Destination + EventFormatType`:

```go
if sub.Destination == destination && sub.EventFormatType == eventFormatType {
```

However, many BMCs (confirmed in mock test data) **do not return `EventFormatType`** in their subscription response. When the field is missing, gofish returns an empty string, causing the comparison to fail:

- Operator searches for: `eventFormatType = "Event"` or `"MetricReport"`
- BMC returns: `sub.EventFormatType = ""` (missing from JSON)
- Result: `"" == "Event"` → **false** → matching fails → error returned

### Fix

Changed matching logic to use `Destination + Context` instead:

```go
if sub.Destination == destination && sub.Context == "metal-operator" {
```

This works because:
1. Destinations are already unique per subscription type (`/metricsreport/` vs `/alerts/`)
2. Context `"metal-operator"` ensures we only match our own subscriptions
3. Both fields are reliably returned by BMCs

### Changes

- `bmc/redfish.go`: Updated `findExistingSubscription()` signature and matching logic
- `bmc/redfish_hpe.go`: Updated caller to use new signature
- `bmc/redfish_test.go`: Added 4 tests with `EventFormatType` intentionally omitted to verify the fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced event subscription creation to gracefully handle duplicate subscription errors by refining how the system detects and retrieves existing subscriptions.
* Improved BMC compatibility by ensuring event subscriptions work reliably with hardware models that report subscription information in different formats, enhancing overall system resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->