### PR TITLE
Fix `findExistingSubscription` bailing on partial CollectionError

### DIFF
--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -1133,7 +1133,15 @@ func (r *RedfishBaseBMC) findExistingSubscription(destination string) (string, e
 	// Get all subscriptions
 	subscriptions, err := ev.Subscriptions()
 	if err != nil {
-		return "", fmt.Errorf("failed to list subscriptions: %w", err)
+		// CollectionError means some members failed to fetch but others may have succeeded.
+		// Gofish also wraps a failure on the collection endpoint itself as a CollectionError
+		// (the collection URI is added as a failure entry), so we cannot distinguish between
+		// "collection endpoint unreachable" and "some members failed". Proceed with whatever
+		// was returned; only bail on other error types.
+		var collErr *schemas.CollectionError
+		if !errors.As(err, &collErr) {
+			return "", fmt.Errorf("failed to list subscriptions: %w", err)
+		}
 	}
 
 	// Find subscription matching our destination and context

--- a/bmc/redfish_test.go
+++ b/bmc/redfish_test.go
@@ -446,4 +446,68 @@ var _ = Describe("RedfishBaseBMC findExistingSubscription", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(link).To(Equal("/redfish/v1/EventService/Subscriptions/2"))
 	})
+
+	It("should find subscription even if some other subscriptions fail to fetch (CollectionError)", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootWithEventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(eventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(subscriptionsCollectionJSON([]string{ //nolint:errcheck
+				"/redfish/v1/EventService/Subscriptions/1", // will return 500
+				"/redfish/v1/EventService/Subscriptions/2", // this is the one we want
+			}))
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions/1", func(w http.ResponseWriter, _ *http.Request) {
+			// Simulate a subscription that fails to fetch (causes CollectionError)
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions/2", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(subscriptionJSON("2", "http://operator/serverevents/alerts/node1", "metal-operator")) //nolint:errcheck
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		link, err := bmc.findExistingSubscription("http://operator/serverevents/alerts/node1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link).To(Equal("/redfish/v1/EventService/Subscriptions/2"))
+	})
+
+	It("should return 'not found' when subscription collection endpoint itself fails", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(serviceRootWithEventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(eventServiceJSON()) //nolint:errcheck
+		})
+		mux.HandleFunc("/redfish/v1/EventService/Subscriptions", func(w http.ResponseWriter, _ *http.Request) {
+			// Simulate the subscriptions collection endpoint itself being unavailable.
+			// Note: gofish wraps this too as a CollectionError (the collection URI is
+			// added as a failure), so ev.Subscriptions() returns an empty slice +
+			// CollectionError. We tolerate CollectionError, find no subscriptions,
+			// and return "not found".
+			w.WriteHeader(http.StatusForbidden)
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		bmc := newTestRedfishBMC(server)
+		link, err := bmc.findExistingSubscription("http://operator/serverevents/alerts/node1")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("existing subscription not found"))
+		Expect(link).To(BeEmpty())
+	})
 })


### PR DESCRIPTION
fixes #862 (follow-up fix)

### Problem

After the initial fix (merged), the BMC reconciler could still fail to find an
existing subscription if any individual subscription in the collection failed
to fetch. Gofish's `ev.Subscriptions()` fetches members concurrently and
returns a `CollectionError` when any member fails — alongside the successfully
fetched results. The original code bailed immediately on any error, discarding
the partial results:

```go
subscriptions, err := ev.Subscriptions()
if err != nil {
    return "", fmt.Errorf("failed to list subscriptions: %w", err)
}
```

If the target subscription was fetched successfully but another subscription in
the collection returned an error, the match would never be found.

### Fix

Tolerate `CollectionError` and continue searching through partial results. Only
fail on other error types:

```go
var collErr *schemas.CollectionError
if !errors.As(err, &collErr) {
    return "", fmt.Errorf("failed to list subscriptions: %w", err)
}
```

Note: gofish wraps even a failure on the collection endpoint itself as a
`CollectionError`, so both "some members failed" and "collection endpoint
unreachable" fall through to a "not found" result rather than a hard error.

### Changes

- `bmc/redfish.go`: Tolerate `CollectionError` in `findExistingSubscription()`
- `bmc/redfish_test.go`: Added 2 tests — one verifying a match is found when a
  sibling subscription fails to fetch, one verifying behaviour when the
  collection endpoint itself is unavailable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event subscription retrieval reliability. The system now uses available subscription data when some individual subscriptions encounter errors, instead of failing completely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->