### PR TITLE
Fix(lldp): handle mgmt-ip and mgmt-iface as string or array

### DIFF
--- a/internal/api/registry/lldp.go
+++ b/internal/api/registry/lldp.go
@@ -26,6 +26,23 @@ type Neighbor struct {
 	VlanID            string   `json:"vlanId,omitempty"`
 }
 
+func parseMgmtIP(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	// Try string first
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	// Try array
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil && len(arr) > 0 {
+		return arr[0]
+	}
+	return ""
+}
+
 // ParseLLDPCTL converts raw lldpctl JSON (format: {"lldp":{"interface":[{iface:{...}},...]}})
 // into the normalized LLDP struct.
 func ParseLLDPCTL(data []byte) (LLDP, error) {
@@ -44,8 +61,8 @@ func ParseLLDPCTL(data []byte) (LLDP, error) {
 	type rawChassis struct {
 		ID         rawChassisID    `json:"id"`
 		Descr      string          `json:"descr"`
-		MgmtIP     string          `json:"mgmt-ip"`
-		MgmtIface  string          `json:"mgmt-iface"`
+		MgmtIP     json.RawMessage `json:"mgmt-ip"`
+		MgmtIface  json.RawMessage `json:"mgmt-iface"`
 		Capability []rawCapability `json:"capability"`
 	}
 	type rawPort struct {
@@ -104,7 +121,7 @@ func ParseLLDPCTL(data []byte) (LLDP, error) {
 					ChassisID:         ch.ID.Value,
 					PortID:            details.Port.ID.Value,
 					PortDescription:   details.Port.Descr,
-					MgmtIP:            ch.MgmtIP,
+					MgmtIP:            parseMgmtIP(ch.MgmtIP),
 				}
 				// Parse vlan field which can be either a single object or an array
 				if len(details.Vlan) > 0 {

--- a/internal/api/registry/lldp_test.go
+++ b/internal/api/registry/lldp_test.go
@@ -4,11 +4,60 @@
 package registry
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 )
+
+func TestParseMgmtIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    json.RawMessage
+		expected string
+	}{
+		{
+			name:     "string value",
+			input:    json.RawMessage(`"192.168.1.1"`),
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "array with single value",
+			input:    json.RawMessage(`["192.168.1.1"]`),
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "array with multiple values returns first",
+			input:    json.RawMessage(`["192.168.1.1", "10.0.0.1"]`),
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "empty raw message",
+			input:    json.RawMessage(``),
+			expected: "",
+		},
+		{
+			name:     "empty array",
+			input:    json.RawMessage(`[]`),
+			expected: "",
+		},
+		{
+			name:     "null",
+			input:    json.RawMessage(`null`),
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseMgmtIP(tt.input)
+			if result != tt.expected {
+				t.Errorf("parseMgmtIP(%s) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
 
 func TestParseLLDPCTL(t *testing.T) {
 	// Determine test data directory, search upward from the test file location for a test/data directory
@@ -40,6 +89,7 @@ func TestParseLLDPCTL(t *testing.T) {
 		{filepath.Join(baseDir, "lldpctl_incomplete.json"), "incomplete"},
 		{filepath.Join(baseDir, "lldpctl_partial.json"), "partial"},
 		{filepath.Join(baseDir, "lldpctl_single.json"), "single"},
+		{filepath.Join(baseDir, "lldpctl_mgmtip_array.json"), "mgmtip_array"},
 	}
 
 	for _, f := range fixtures {
@@ -64,6 +114,8 @@ func TestParseLLDPCTL(t *testing.T) {
 				validatePartial(t, parsed)
 			case "single":
 				validateSingle(t, parsed)
+			case "mgmtip_array":
+				validateMgmtIPArray(t, parsed)
 			}
 		})
 	}
@@ -134,5 +186,24 @@ func validateSingle(t *testing.T, parsed LLDP) {
 	}
 	if n.PortID != "Eth1/17" {
 		t.Errorf("unexpected port id in single fixture: %s", n.PortID)
+	}
+}
+
+func validateMgmtIPArray(t *testing.T, parsed LLDP) {
+	if len(parsed.Interfaces) != 1 {
+		t.Fatalf("expected 1 interface in mgmtip_array fixture, got %d", len(parsed.Interfaces))
+	}
+	if parsed.Interfaces[0].Name != "ens3f0np0" {
+		t.Fatalf("expected interface name ens3f0np0, got %s", parsed.Interfaces[0].Name)
+	}
+	if len(parsed.Interfaces[0].Neighbors) != 1 {
+		t.Fatalf("expected 1 neighbor, got %d", len(parsed.Interfaces[0].Neighbors))
+	}
+	n := parsed.Interfaces[0].Neighbors[0]
+	if n.ChassisID != "e8:eb:d3:e4:5a:2e" {
+		t.Errorf("unexpected chassis id: %s", n.ChassisID)
+	}
+	if n.MgmtIP != "192.168.30.242" {
+		t.Errorf("expected MgmtIP 192.168.30.242, got %q", n.MgmtIP)
 	}
 }

--- a/test/data/lldpctl_mgmtip_array.json
+++ b/test/data/lldpctl_mgmtip_array.json
@@ -1,0 +1,28 @@
+{
+    "lldp": {
+        "interface": [{
+            "ens3f0np0": {
+                "via": "LLDP",
+                "rid": "1",
+                "age": "0 day, 00:01:00",
+                "chassis": {
+                    "sw-test-spine-1": {
+                        "id": {"type": "mac", "value": "e8:eb:d3:e4:5a:2e"},
+                        "descr": "Cumulus Linux version 5.11.5",
+                        "mgmt-ip": ["192.168.30.242", "fe80::1"],
+                        "mgmt-iface": ["2", "2"],
+                        "capability": [
+                            {"type": "Bridge", "enabled": true},
+                            {"type": "Router", "enabled": true}
+                        ]
+                    }
+                },
+                "port": {
+                    "id": {"type": "ifname", "value": "swp1s0"},
+                    "descr": "server ACCESS",
+                    "ttl": "120"
+                }
+            }
+        }]
+    }
+}


### PR DESCRIPTION
Mellanox Cumulus Linux switches report these fields as JSON arrays instead of strings, causing metalprobe to fail parsing LLDP data and preventing servers from leaving Discovery state. Add a parseMgmtIP helper and update the struct fields to json.RawMessage to handle both formats gracefully.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced LLDP management IP address parsing to correctly handle IP addresses provided in multiple formats, improving data compatibility and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/metal-operator/pull/873)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->