### PR TITLE
Honor `--kubeconfig` and add `--context` flag in `metalctl`

### DIFF
--- a/cmd/metalctl/app/console.go
+++ b/cmd/metalctl/app/console.go
@@ -23,6 +23,7 @@ import (
 
 var (
 	kubeconfig            string
+	kubeContext           string
 	serialConsoleNumber   int
 	skipHostKeyValidation bool
 	knownHostsFile        string
@@ -36,6 +37,7 @@ func NewConsoleCommand() *cobra.Command {
 	}
 
 	consoleCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig.")
+	consoleCmd.Flags().StringVar(&kubeContext, "context", "", "Name of the kubeconfig context to use.")
 	consoleCmd.Flags().IntVar(&serialConsoleNumber, "serial-console-number", 1, "Serial console number.")
 	consoleCmd.Flags().BoolVar(&skipHostKeyValidation, "skip-host-key-validation", false, "Skip host key validation.")
 	consoleCmd.Flags().StringVar(&knownHostsFile, "known-hosts-file", "~/.ssh/known_hosts", "Path to known_hosts file.")
@@ -53,7 +55,7 @@ func runConsole(cmd *cobra.Command, args []string) error {
 	}
 	serverName = args[0]
 
-	k8sClient, err := cmdclient.CreateClient(kubeconfig, scheme)
+	k8sClient, err := cmdclient.CreateClient(kubeconfig, kubeContext, scheme)
 	if err != nil {
 		return err
 	}

--- a/cmd/metalctl/app/visualizer.go
+++ b/cmd/metalctl/app/visualizer.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	port int
+	port           int
+	vizKubeContext string
 )
 
 func NewVisualizationCommand() *cobra.Command {
@@ -26,6 +27,7 @@ func NewVisualizationCommand() *cobra.Command {
 	}
 
 	visualizerCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig.")
+	visualizerCmd.Flags().StringVar(&vizKubeContext, "context", "", "Name of the kubeconfig context to use.")
 	visualizerCmd.Flags().IntVar(&port, "port", 8080, "Port to run the web server on")
 
 	return visualizerCmd
@@ -34,7 +36,7 @@ func NewVisualizationCommand() *cobra.Command {
 func runVisualizer(_ *cobra.Command, _ []string) error {
 	log.Println("A 3D visualizer for server resources")
 
-	c, err := cmdclient.CreateClient(kubeconfig, scheme)
+	c, err := cmdclient.CreateClient(kubeconfig, vizKubeContext, scheme)
 	if err != nil {
 		log.Fatalf("Error creating kubernetes client: %v", err)
 	}

--- a/internal/cmd/client/client.go
+++ b/internal/cmd/client/client.go
@@ -6,13 +6,14 @@ package client
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-func CreateClient(kubeconfig string, scheme *runtime.Scheme) (client.Client, error) {
+func CreateClient(kubeconfig, context string, scheme *runtime.Scheme) (client.Client, error) {
 	if len(kubeconfig) == 0 {
 		kubeconfig = os.Getenv("KUBECONFIG")
 		if kubeconfig == "" {
@@ -21,7 +22,18 @@ func CreateClient(kubeconfig string, scheme *runtime.Scheme) (client.Client, err
 		}
 	}
 
-	clientConfig, err := config.GetConfigWithContext("")
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	paths := filepath.SplitList(kubeconfig)
+	if len(paths) == 1 {
+		loadingRules.ExplicitPath = kubeconfig
+	} else {
+		loadingRules.Precedence = paths
+	}
+	overrides := &clientcmd.ConfigOverrides{}
+	if context != "" {
+		overrides.CurrentContext = context
+	}
+	clientConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed getting client config: %w", err)
 	}


### PR DESCRIPTION
CreateClient was validating/falling back for the kubeconfig path, but then ignoring it completely — config.GetConfigWithContext("") went through controller-runtime's default discovery chain with an empty context string, so the flag had no effect and clusters that require an explicit context would fail with:

  failed getting client config: invalid configuration:
  no configuration has been provided

Fix by replacing GetConfigWithContext with
clientcmd.NewNonInteractiveDeferredLoadingClientConfig, which actually reads the specified kubeconfig file and respects the context override.

Also add a --context flag to both the visualizer and console commands so users can target a specific context without editing their kubeconfig.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--context` flag to the console and visualizer commands to select a Kubernetes context at runtime.
  * CLI now respects the chosen context when connecting to the Kubernetes API, so console streaming and visualization use the selected context.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/metal-operator/pull/877)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->