### PR TITLE
Exclude 'third_party' from add-license/check-license make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,11 @@ cleandocs: ## Remove all local mkdocs Docker images (cleanup).
 
 .PHONY: add-license
 add-license: addlicense ## Add license headers to all go files.
-	find . -name '*.go' -exec "$(ADDLICENSE)" -f hack/license-header.txt {} +
+	find . -path ./third_party -prune -o -name '*.go' -exec "$(ADDLICENSE)" -f hack/license-header.txt {} +
 
 .PHONY: check-license
 check-license: addlicense ## Check that every file has a license header present.
-	find . -name '*.go' -exec "$(ADDLICENSE)" -check -c 'IronCore authors' {} +
+	find . -path ./third_party -prune -o -name '*.go' -exec "$(ADDLICENSE)" -check -c 'IronCore authors' {} +
 
 .PHONY: check
 check: generate manifests add-license fmt lint test # Generate manifests, code, lint, add licenses, test


### PR DESCRIPTION
files in `third_party` were wrongfully matched on the `add-license` and `check-license` make targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to exclude third-party code directories from license header checks, improving build efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/metal-operator/pull/883)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->