### PR TITLE
Remove deprecated APIVersion, Kind, and UID fields from ObjectReference types

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/immutableobjectreference.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/immutableobjectreference.go
@@ -5,48 +5,22 @@
 
 package v1alpha1
 
-import (
-	types "k8s.io/apimachinery/pkg/types"
-)
-
 // ImmutableObjectReferenceApplyConfiguration represents a declarative configuration of the ImmutableObjectReference type for use
 // with apply.
 //
 // ImmutableObjectReference is a namespaced name reference whose name and namespace
 // cannot be changed once set (the entire reference can still be set or cleared).
 type ImmutableObjectReferenceApplyConfiguration struct {
-	// Deprecated: APIVersion is no longer used. Retained for backwards compatibility.
-	APIVersion *string `json:"apiVersion,omitempty"`
-	// Deprecated: Kind is no longer used. Retained for backwards compatibility.
-	Kind *string `json:"kind,omitempty"`
 	// Namespace is the namespace of the referenced object.
 	Namespace *string `json:"namespace,omitempty"`
 	// Name is the name of the referenced object.
 	Name *string `json:"name,omitempty"`
-	// Deprecated: UID is no longer used. Retained for backwards compatibility.
-	UID *types.UID `json:"uid,omitempty"`
 }
 
 // ImmutableObjectReferenceApplyConfiguration constructs a declarative configuration of the ImmutableObjectReference type for use with
 // apply.
 func ImmutableObjectReference() *ImmutableObjectReferenceApplyConfiguration {
 	return &ImmutableObjectReferenceApplyConfiguration{}
-}
-
-// WithAPIVersion sets the APIVersion field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the APIVersion field is set to the value of the last call.
-func (b *ImmutableObjectReferenceApplyConfiguration) WithAPIVersion(value string) *ImmutableObjectReferenceApplyConfiguration {
-	b.APIVersion = &value
-	return b
-}
-
-// WithKind sets the Kind field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Kind field is set to the value of the last call.
-func (b *ImmutableObjectReferenceApplyConfiguration) WithKind(value string) *ImmutableObjectReferenceApplyConfiguration {
-	b.Kind = &value
-	return b
 }
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
@@ -62,13 +36,5 @@ func (b *ImmutableObjectReferenceApplyConfiguration) WithNamespace(value string)
 // If called multiple times, the Name field is set to the value of the last call.
 func (b *ImmutableObjectReferenceApplyConfiguration) WithName(value string) *ImmutableObjectReferenceApplyConfiguration {
 	b.Name = &value
-	return b
-}
-
-// WithUID sets the UID field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the UID field is set to the value of the last call.
-func (b *ImmutableObjectReferenceApplyConfiguration) WithUID(value types.UID) *ImmutableObjectReferenceApplyConfiguration {
-	b.UID = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/objectreference.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/objectreference.go
@@ -5,47 +5,21 @@
 
 package v1alpha1
 
-import (
-	types "k8s.io/apimachinery/pkg/types"
-)
-
 // ObjectReferenceApplyConfiguration represents a declarative configuration of the ObjectReference type for use
 // with apply.
 //
 // ObjectReference is the namespaced name reference to an object.
 type ObjectReferenceApplyConfiguration struct {
-	// Deprecated: APIVersion is no longer used. Retained for backwards compatibility.
-	APIVersion *string `json:"apiVersion,omitempty"`
-	// Deprecated: Kind is no longer used. Retained for backwards compatibility.
-	Kind *string `json:"kind,omitempty"`
 	// Namespace is the namespace of the referenced object.
 	Namespace *string `json:"namespace,omitempty"`
 	// Name is the name of the referenced object.
 	Name *string `json:"name,omitempty"`
-	// Deprecated: UID is no longer used. Retained for backwards compatibility.
-	UID *types.UID `json:"uid,omitempty"`
 }
 
 // ObjectReferenceApplyConfiguration constructs a declarative configuration of the ObjectReference type for use with
 // apply.
 func ObjectReference() *ObjectReferenceApplyConfiguration {
 	return &ObjectReferenceApplyConfiguration{}
-}
-
-// WithAPIVersion sets the APIVersion field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the APIVersion field is set to the value of the last call.
-func (b *ObjectReferenceApplyConfiguration) WithAPIVersion(value string) *ObjectReferenceApplyConfiguration {
-	b.APIVersion = &value
-	return b
-}
-
-// WithKind sets the Kind field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Kind field is set to the value of the last call.
-func (b *ObjectReferenceApplyConfiguration) WithKind(value string) *ObjectReferenceApplyConfiguration {
-	b.Kind = &value
-	return b
 }
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
@@ -61,13 +35,5 @@ func (b *ObjectReferenceApplyConfiguration) WithNamespace(value string) *ObjectR
 // If called multiple times, the Name field is set to the value of the last call.
 func (b *ObjectReferenceApplyConfiguration) WithName(value string) *ObjectReferenceApplyConfiguration {
 	b.Name = &value
-	return b
-}
-
-// WithUID sets the UID field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the UID field is set to the value of the last call.
-func (b *ObjectReferenceApplyConfiguration) WithUID(value types.UID) *ObjectReferenceApplyConfiguration {
-	b.UID = &value
 	return b
 }

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -8,38 +8,22 @@ import (
 	"net/netip"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // ObjectReference is the namespaced name reference to an object.
 type ObjectReference struct {
-	// Deprecated: APIVersion is no longer used. Retained for backwards compatibility.
-	// +optional
-	APIVersion string `json:"apiVersion,omitempty"`
-	// Deprecated: Kind is no longer used. Retained for backwards compatibility.
-	// +optional
-	Kind string `json:"kind,omitempty"`
 	// Namespace is the namespace of the referenced object.
 	// +required
 	Namespace string `json:"namespace"`
 	// Name is the name of the referenced object.
 	// +required
 	Name string `json:"name"`
-	// Deprecated: UID is no longer used. Retained for backwards compatibility.
-	// +optional
-	UID types.UID `json:"uid,omitempty"`
 }
 
 // ImmutableObjectReference is a namespaced name reference whose name and namespace
 // cannot be changed once set (the entire reference can still be set or cleared).
 type ImmutableObjectReference struct {
-	// Deprecated: APIVersion is no longer used. Retained for backwards compatibility.
-	// +optional
-	APIVersion string `json:"apiVersion,omitempty"`
-	// Deprecated: Kind is no longer used. Retained for backwards compatibility.
-	// +optional
-	Kind string `json:"kind,omitempty"`
 	// Namespace is the namespace of the referenced object.
 	// +required
 	// +kubebuilder:validation:MaxLength=63
@@ -50,9 +34,6 @@ type ImmutableObjectReference struct {
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf"
 	Name string `json:"name"`
-	// Deprecated: UID is no longer used. Retained for backwards compatibility.
-	// +optional
-	UID types.UID `json:"uid,omitempty"`
 }
 
 // RetryPolicy defines the retry behavior on transient failures.

--- a/config/crd/bases/metal.ironcore.dev_biossettings.yaml
+++ b/config/crd/bases/metal.ironcore.dev_biossettings.yaml
@@ -82,23 +82,11 @@ spec:
                 description: ServerMaintenanceRef is a reference to a ServerMaintenance
                   object that BIOSSettings has requested for the referred server.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     type: string
                   namespace:
                     description: Namespace is the namespace of the referenced object.
-                    type: string
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
                     type: string
                 required:
                 - name

--- a/config/crd/bases/metal.ironcore.dev_biosversions.yaml
+++ b/config/crd/bases/metal.ironcore.dev_biosversions.yaml
@@ -119,23 +119,11 @@ spec:
                 description: ServerMaintenanceRef is a reference to a ServerMaintenance
                   object that the controller has requested for the referred server.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     type: string
                   namespace:
                     description: Namespace is the namespace of the referenced object.
-                    type: string
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
                     type: string
                 required:
                 - name

--- a/config/crd/bases/metal.ironcore.dev_bmcsettings.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcsettings.yaml
@@ -98,24 +98,12 @@ spec:
                         object that the BMCSettings has requested for the referred
                         server.
                       properties:
-                        apiVersion:
-                          description: 'Deprecated: APIVersion is no longer used.
-                            Retained for backwards compatibility.'
-                          type: string
-                        kind:
-                          description: 'Deprecated: Kind is no longer used. Retained
-                            for backwards compatibility.'
-                          type: string
                         name:
                           description: Name is the name of the referenced object.
                           type: string
                         namespace:
                           description: Namespace is the namespace of the referenced
                             object.
-                          type: string
-                        uid:
-                          description: 'Deprecated: UID is no longer used. Retained
-                            for backwards compatibility.'
                           type: string
                       required:
                       - name

--- a/config/crd/bases/metal.ironcore.dev_bmcversions.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcversions.yaml
@@ -137,23 +137,11 @@ spec:
                   description: ObjectReference is the namespaced name reference to
                     an object.
                   properties:
-                    apiVersion:
-                      description: 'Deprecated: APIVersion is no longer used. Retained
-                        for backwards compatibility.'
-                      type: string
-                    kind:
-                      description: 'Deprecated: Kind is no longer used. Retained for
-                        backwards compatibility.'
-                      type: string
                     name:
                       description: Name is the name of the referenced object.
                       type: string
                     namespace:
                       description: Namespace is the namespace of the referenced object.
-                      type: string
-                    uid:
-                      description: 'Deprecated: UID is no longer used. Retained for
-                        backwards compatibility.'
                       type: string
                   required:
                   - name

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -156,23 +156,11 @@ spec:
                   BootConfigurationRef is a reference to a BootConfiguration object that specifies
                   the boot configuration for this server.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     type: string
                   namespace:
                     description: Namespace is the namespace of the referenced object.
-                    type: string
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
                     type: string
                 required:
                 - name
@@ -207,23 +195,11 @@ spec:
                   MaintenanceBootConfigurationRef is a reference to a BootConfiguration object that specifies
                   the boot configuration for this server during maintenance.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     type: string
                   namespace:
                     description: Namespace is the namespace of the referenced object.
-                    type: string
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
                     type: string
                 required:
                 - name
@@ -236,14 +212,6 @@ spec:
                 description: ServerClaimRef is a reference to a ServerClaim object
                   that claims this server.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     maxLength: 253
@@ -256,10 +224,6 @@ spec:
                     type: string
                     x-kubernetes-validations:
                     - rule: self == oldSelf
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                 required:
                 - name
                 - namespace
@@ -268,23 +232,11 @@ spec:
                 description: ServerMaintenanceRef is a reference to a ServerMaintenance
                   object that maintains this server.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     type: string
                   namespace:
                     description: Namespace is the namespace of the referenced object.
-                    type: string
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
                     type: string
                 required:
                 - name

--- a/dist/chart/templates/crd/metal.ironcore.dev_biossettings.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_biossettings.yaml
@@ -88,23 +88,11 @@ spec:
                 description: ServerMaintenanceRef is a reference to a ServerMaintenance
                   object that BIOSSettings has requested for the referred server.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     type: string
                   namespace:
                     description: Namespace is the namespace of the referenced object.
-                    type: string
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
                     type: string
                 required:
                 - name

--- a/dist/chart/templates/crd/metal.ironcore.dev_biosversions.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_biosversions.yaml
@@ -125,23 +125,11 @@ spec:
                 description: ServerMaintenanceRef is a reference to a ServerMaintenance
                   object that the controller has requested for the referred server.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     type: string
                   namespace:
                     description: Namespace is the namespace of the referenced object.
-                    type: string
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
                     type: string
                 required:
                 - name

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcsettings.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcsettings.yaml
@@ -104,24 +104,12 @@ spec:
                         object that the BMCSettings has requested for the referred
                         server.
                       properties:
-                        apiVersion:
-                          description: 'Deprecated: APIVersion is no longer used.
-                            Retained for backwards compatibility.'
-                          type: string
-                        kind:
-                          description: 'Deprecated: Kind is no longer used. Retained
-                            for backwards compatibility.'
-                          type: string
                         name:
                           description: Name is the name of the referenced object.
                           type: string
                         namespace:
                           description: Namespace is the namespace of the referenced
                             object.
-                          type: string
-                        uid:
-                          description: 'Deprecated: UID is no longer used. Retained
-                            for backwards compatibility.'
                           type: string
                       required:
                       - name

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcversions.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcversions.yaml
@@ -143,23 +143,11 @@ spec:
                   description: ObjectReference is the namespaced name reference to
                     an object.
                   properties:
-                    apiVersion:
-                      description: 'Deprecated: APIVersion is no longer used. Retained
-                        for backwards compatibility.'
-                      type: string
-                    kind:
-                      description: 'Deprecated: Kind is no longer used. Retained for
-                        backwards compatibility.'
-                      type: string
                     name:
                       description: Name is the name of the referenced object.
                       type: string
                     namespace:
                       description: Namespace is the namespace of the referenced object.
-                      type: string
-                    uid:
-                      description: 'Deprecated: UID is no longer used. Retained for
-                        backwards compatibility.'
                       type: string
                   required:
                   - name

--- a/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
@@ -162,23 +162,11 @@ spec:
                   BootConfigurationRef is a reference to a BootConfiguration object that specifies
                   the boot configuration for this server.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     type: string
                   namespace:
                     description: Namespace is the namespace of the referenced object.
-                    type: string
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
                     type: string
                 required:
                 - name
@@ -213,23 +201,11 @@ spec:
                   MaintenanceBootConfigurationRef is a reference to a BootConfiguration object that specifies
                   the boot configuration for this server during maintenance.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     type: string
                   namespace:
                     description: Namespace is the namespace of the referenced object.
-                    type: string
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
                     type: string
                 required:
                 - name
@@ -242,14 +218,6 @@ spec:
                 description: ServerClaimRef is a reference to a ServerClaim object
                   that claims this server.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     maxLength: 253
@@ -262,10 +230,6 @@ spec:
                     type: string
                     x-kubernetes-validations:
                     - rule: self == oldSelf
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                 required:
                 - name
                 - namespace
@@ -274,23 +238,11 @@ spec:
                 description: ServerMaintenanceRef is a reference to a ServerMaintenance
                   object that maintains this server.
                 properties:
-                  apiVersion:
-                    description: 'Deprecated: APIVersion is no longer used. Retained
-                      for backwards compatibility.'
-                    type: string
-                  kind:
-                    description: 'Deprecated: Kind is no longer used. Retained for
-                      backwards compatibility.'
-                    type: string
                   name:
                     description: Name is the name of the referenced object.
                     type: string
                   namespace:
                     description: Namespace is the namespace of the referenced object.
-                    type: string
-                  uid:
-                    description: 'Deprecated: UID is no longer used. Retained for
-                      backwards compatibility.'
                     type: string
                 required:
                 - name

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1079,11 +1079,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `apiVersion` _string_ | Deprecated: APIVersion is no longer used. Retained for backwards compatibility. |  |  |
-| `kind` _string_ | Deprecated: Kind is no longer used. Retained for backwards compatibility. |  |  |
 | `namespace` _string_ | Namespace is the namespace of the referenced object. |  | MaxLength: 63 <br /> |
 | `name` _string_ | Name is the name of the referenced object. |  | MaxLength: 253 <br /> |
-| `uid` _[UID](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#uid-types-pkg)_ | Deprecated: UID is no longer used. Retained for backwards compatibility. |  |  |
 
 
 #### IndicatorLED
@@ -1199,11 +1196,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `apiVersion` _string_ | Deprecated: APIVersion is no longer used. Retained for backwards compatibility. |  |  |
-| `kind` _string_ | Deprecated: Kind is no longer used. Retained for backwards compatibility. |  |  |
 | `namespace` _string_ | Namespace is the namespace of the referenced object. |  |  |
 | `name` _string_ | Name is the name of the referenced object. |  |  |
-| `uid` _[UID](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#uid-types-pkg)_ | Deprecated: UID is no longer used. Retained for backwards compatibility. |  |  |
 
 
 #### Phase

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -280,14 +280,6 @@ func (r *BIOSSettingsReconciler) reconcile(ctx context.Context, settings *metalv
 		return ctrl.Result{}, nil
 	}
 
-	base := settings.DeepCopy()
-	if settings.Spec.ServerMaintenanceRef != nil && clearDeprecatedObjectRefFields(settings.Spec.ServerMaintenanceRef) {
-		if err := r.Patch(ctx, settings, client.MergeFrom(base)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to clear deprecated ObjectReference fields on BIOSSettings: %w", err)
-		}
-		return ctrl.Result{}, nil
-	}
-
 	if settings.Spec.ServerRef == nil {
 		log.V(1).Info("BIOSSettings does not have a ServerRef")
 		return ctrl.Result{}, nil

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -186,14 +186,6 @@ func (r *BIOSVersionReconciler) reconcile(ctx context.Context, biosVersion *meta
 		return ctrl.Result{}, nil
 	}
 
-	base := biosVersion.DeepCopy()
-	if biosVersion.Spec.ServerMaintenanceRef != nil && clearDeprecatedObjectRefFields(biosVersion.Spec.ServerMaintenanceRef) {
-		if err := r.Patch(ctx, biosVersion, client.MergeFrom(base)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to clear deprecated ObjectReference fields on BIOSVersion: %w", err)
-		}
-		return ctrl.Result{}, nil
-	}
-
 	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, biosVersion, BIOSVersionFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -234,18 +234,6 @@ func (r *BMCSettingsReconciler) reconcile(ctx context.Context, settings *metalv1
 		return ctrl.Result{}, nil
 	}
 
-	base := settings.DeepCopy()
-	changed := false
-	for i := range settings.Spec.ServerMaintenanceRefs {
-		changed = clearDeprecatedObjectRefFields(settings.Spec.ServerMaintenanceRefs[i].ServerMaintenanceRef) || changed
-	}
-	if changed {
-		if err := r.Patch(ctx, settings, client.MergeFrom(base)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to clear deprecated ObjectReference fields on BMCSettings: %w", err)
-		}
-		return ctrl.Result{}, nil
-	}
-
 	if settings.Spec.BMCRef == nil {
 		log.V(1).Info("Object does not refer to BMC object")
 		return ctrl.Result{}, nil

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -189,18 +189,6 @@ func (r *BMCVersionReconciler) reconcile(ctx context.Context, bmcVersion *metalv
 		return ctrl.Result{}, nil
 	}
 
-	base := bmcVersion.DeepCopy()
-	changed := false
-	for i := range bmcVersion.Spec.ServerMaintenanceRefs {
-		changed = clearDeprecatedObjectRefFields(&bmcVersion.Spec.ServerMaintenanceRefs[i]) || changed
-	}
-	if changed {
-		if err := r.Patch(ctx, bmcVersion, client.MergeFrom(base)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to clear deprecated ObjectReference fields on BMCVersion: %w", err)
-		}
-		return ctrl.Result{}, nil
-	}
-
 	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, bmcVersion, bmcVersionFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -432,28 +432,6 @@ func GetImageCredentialsForSecretRef(ctx context.Context, c client.Client, secre
 	return string(username), string(password), nil
 }
 
-func clearDeprecatedObjectRefFields(ref *metalv1alpha1.ObjectReference) bool {
-	if ref == nil {
-		return false
-	}
-	changed := ref.APIVersion != "" || ref.Kind != "" || ref.UID != "" //nolint:staticcheck // clearing deprecated fields
-	ref.APIVersion = ""                                                //nolint:staticcheck // clearing deprecated fields
-	ref.Kind = ""                                                      //nolint:staticcheck // clearing deprecated fields
-	ref.UID = ""                                                       //nolint:staticcheck // clearing deprecated fields
-	return changed
-}
-
-func clearDeprecatedImmutableObjectRefFields(ref *metalv1alpha1.ImmutableObjectReference) bool {
-	if ref == nil {
-		return false
-	}
-	changed := ref.APIVersion != "" || ref.Kind != "" || ref.UID != "" //nolint:staticcheck // clearing deprecated fields
-	ref.APIVersion = ""                                                //nolint:staticcheck // clearing deprecated fields
-	ref.Kind = ""                                                      //nolint:staticcheck // clearing deprecated fields
-	ref.UID = ""                                                       //nolint:staticcheck // clearing deprecated fields
-	return changed
-}
-
 func labelChangeOrAnyFieldChangeInObject(e event.UpdateEvent, oldFields, newFields []any) bool {
 	isNil := func(arg any) bool {
 		if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Ptr ||

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -210,10 +210,6 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 		return ctrl.Result{}, nil
 	}
 
-	if modified, err := r.clearDeprecatedRefFields(ctx, server); err != nil || modified {
-		return ctrl.Result{}, err
-	}
-
 	// do late state initialization
 	if server.Status.State == "" {
 		if modified, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateInitial); err != nil || modified {
@@ -1225,21 +1221,6 @@ func (r *ServerReconciler) checkLastStatusUpdateAfter(duration time.Duration, se
 		}
 	}
 	return false
-}
-
-func (r *ServerReconciler) clearDeprecatedRefFields(ctx context.Context, server *metalv1alpha1.Server) (bool, error) {
-	base := server.DeepCopy()
-	changed := clearDeprecatedImmutableObjectRefFields(server.Spec.ServerClaimRef)
-	changed = clearDeprecatedObjectRefFields(server.Spec.BootConfigurationRef) || changed
-	changed = clearDeprecatedObjectRefFields(server.Spec.MaintenanceBootConfigurationRef) || changed
-	changed = clearDeprecatedObjectRefFields(server.Spec.ServerMaintenanceRef) || changed
-	if !changed {
-		return false, nil
-	}
-	if err := r.Patch(ctx, server, client.MergeFrom(base)); err != nil {
-		return false, fmt.Errorf("failed to clear deprecated ObjectReference fields on Server: %w", err)
-	}
-	return true, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
# Proposed Changes

Remove deprecated APIVersion, Kind, and UID fields from ObjectReference and ImmutableObjectReference structs along with all associated cleanup

The deprecated fields (APIVersion, Kind, UID) were previously retained for backwards compatibility but are no longer needed. This removes:
- The fields from the API types and apply configurations
- The clearDeprecatedObjectRefFields/clearDeprecatedImmutableObjectRefFields helper functions
- All controller reconciliation logic that patched objects to clear these fields
- The corresponding API documentation entries

Fixes #884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed deprecated metadata fields (`apiVersion`, `kind`, `uid`) from object references across the API. References now support only `name` and `namespace` for identifying resources.
  * Updated all Custom Resource Definitions to reflect the simplified reference schema.

* **Documentation**
  * Updated API reference documentation to reflect simplified reference types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/metal-operator/pull/885)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->