### PR TITLE
Add additional labels from BMC and Server resources to metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -732,7 +732,9 @@ func main() { // nolint: gocyclo
 		}
 		if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 			setupLog.Info("starting event server for alerts and metrics", "EventURL", eventURL)
-			eventServer := serverevents.NewServer(setupLog, fmt.Sprintf(":%d", eventPort), mgr.GetClient(), bmcLabelMappings, serverLabelMappings)
+			eventServer := serverevents.NewServer(
+				setupLog, fmt.Sprintf(":%d", eventPort), mgr.GetClient(), bmcLabelMappings, serverLabelMappings,
+			)
 			if err := eventServer.Start(ctx); err != nil {
 				return fmt.Errorf("unable to start event server: %w", err)
 			}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,6 +83,8 @@ func main() { // nolint: gocyclo
 		eventPort                          int
 		eventURL                           string
 		eventProtocol                      string
+		redfishMetricLabelsFromBMC         string
+		redfishMetricLabelsFromServer      string
 		registryClientTimeout              time.Duration
 		registryDataMaxAge                 time.Duration
 		registryResyncInterval             time.Duration
@@ -143,6 +145,16 @@ func main() { // nolint: gocyclo
 	flag.IntVar(&eventPort, "event-port", 10001, "The port to use for the server events endpoint for alerts and metrics.")
 	flag.StringVar(&eventProtocol, "event-protocol", "http",
 		"The protocol to use for the server events endpoint for alerts and metrics.")
+	flag.StringVar(&redfishMetricLabelsFromBMC, "redfish-metric-labels-from-bmc", "",
+		"Comma-separated list of 'kubernetes-label-key=prometheus-label-name' pairs. "+
+			"Each pair adds an additional label dimension to Redfish telemetry metrics, "+
+			"sourced from the matching label on the BMC resource. "+
+			"Example: topology.kubernetes.io/region=region,topology.kubernetes.io/zone=zone")
+	flag.StringVar(&redfishMetricLabelsFromServer, "redfish-metric-labels-from-server", "",
+		"Comma-separated list of 'kubernetes-label-key=prometheus-label-name' pairs. "+
+			"Each pair adds an additional label dimension to Redfish telemetry metrics, "+
+			"sourced from the matching label on the Server resource linked via spec.bmcRef.name. "+
+			"Example: metadata.metal.ironcore.dev/location=location,metadata.metal.ironcore.dev/rack=rack")
 	flag.StringVar(&probeImage, "probe-image", "", "Image for the first boot probing of a Server.")
 	flag.StringVar(&probeOSImage, "probe-os-image", "", "OS image for the first boot probing of a Server.")
 	flag.StringVar(&managerNamespace, "manager-namespace", "default", "Namespace the manager is running in.")
@@ -708,9 +720,19 @@ func main() { // nolint: gocyclo
 	}
 
 	if eventURL != "" {
+		bmcLabelMappings, err := serverevents.ParseLabelMappings(redfishMetricLabelsFromBMC)
+		if err != nil {
+			setupLog.Error(err, "Invalid --redfish-metric-labels-from-bmc")
+			os.Exit(1)
+		}
+		serverLabelMappings, err := serverevents.ParseLabelMappings(redfishMetricLabelsFromServer)
+		if err != nil {
+			setupLog.Error(err, "Invalid --redfish-metric-labels-from-server")
+			os.Exit(1)
+		}
 		if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 			setupLog.Info("starting event server for alerts and metrics", "EventURL", eventURL)
-			eventServer := serverevents.NewServer(setupLog, fmt.Sprintf(":%d", eventPort))
+			eventServer := serverevents.NewServer(setupLog, fmt.Sprintf(":%d", eventPort), mgr.GetClient(), bmcLabelMappings, serverLabelMappings)
 			if err := eventServer.Start(ctx); err != nil {
 				return fmt.Errorf("unable to start event server: %w", err)
 			}

--- a/dist/chart/templates/_helpers.tpl
+++ b/dist/chart/templates/_helpers.tpl
@@ -48,3 +48,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     $hasValidating = true }}{{- end }}
 {{- end }}
 {{ $hasValidating }}}}{{- end }}
+
+{{/*
+chart.redfishLabelFlag renders a single CLI flag string from a map of
+kubernetes-label-key -> prometheus-label-name entries.
+
+Usage: {{ include "chart.redfishLabelFlag" (dict "flag" "redfish-metric-labels-from-bmc" "map" .Values.redfishLabels.bmc) }}
+*/}}
+{{- define "chart.redfishLabelFlag" -}}
+{{- $pairs := list -}}
+{{- range $k, $v := .map -}}
+  {{- $pairs = append $pairs (printf "%s=%s" $k $v) -}}
+{{- end -}}
+{{- printf "--%s=%s" .flag (join "," ($pairs | sortAlpha)) -}}
+{{- end }}

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -34,6 +34,12 @@ spec:
         {{- range .Values.controllerManager.manager.args }}
         - {{ . }}
         {{- end }}
+        {{- if .Values.redfishLabels.bmc }}
+        - {{ include "chart.redfishLabelFlag" (dict "flag" "redfish-metric-labels-from-bmc" "map" .Values.redfishLabels.bmc) | quote }}
+        {{- end }}
+        {{- if .Values.redfishLabels.server }}
+        - {{ include "chart.redfishLabelFlag" (dict "flag" "redfish-metric-labels-from-server" "map" .Values.redfishLabels.server) | quote }}
+        {{- end }}
         command:
         - /manager
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -67,6 +67,23 @@ crd:
   # (Certificates, Issuers, ...) due to garbage collection.
   keep: true
 
+# [REDFISH LABEL ENRICHMENT]: Optional label enrichment for Redfish telemetry metrics.
+# Define mappings from Kubernetes resource label keys to Prometheus label names.
+# Mapped labels are appended as additional dimensions to redfish_monitor_reading and
+# redfish_event_alert_total metrics. Leave empty ({}) to disable enrichment.
+redfishLabels:
+  # Labels sourced from the BMC resource (matched by hostname == BMC resource name).
+  bmc: {}
+  # Example:
+  #   topology.kubernetes.io/region: region
+  #   topology.kubernetes.io/zone: zone
+
+  # Labels sourced from the Server resource linked via spec.bmcRef.name.
+  server: {}
+  # Example:
+  #   metadata.metal.ironcore.dev/location: location
+  #   metadata.metal.ironcore.dev/rack: rack
+
 # [METRICS]: Set to true to generate manifests for exporting metrics.
 # To disable metrics export set false, and ensure that the
 # ControllerManager argument "--metrics-bind-address=:8443" is removed.
@@ -101,4 +118,3 @@ ignition:
   # Template content that can be customized - this will be created as a ConfigMap
   # and mounted to override the default template
   # template: |
-    

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -281,6 +281,97 @@ rate(metal_server_reconciliation_total{result=~"error_.*"}[5m])
 count(metal_server_state{state="Available"} == 1)
 ```
 
+## Redfish Telemetry Metrics
+
+When the operator is configured with an event URL (`--event-url`), it subscribes to Redfish MetricReport and Alert events from each BMC and exposes two additional metrics.
+
+### Sensor Readings (`redfish_monitor_reading`)
+
+**Type:** Gauge
+**Description:** Latest sensor value pushed via a Redfish MetricReport event.
+**Fixed labels:**
+- `hostname`: BMC Kubernetes resource name
+- `metric_id`: Redfish metric ID (e.g., `CPU1Temp`)
+- `type`: Metric type (e.g., `Temperature`, `Voltage`)
+- `unit`: Unit of measure (e.g., `Cel`, `V`)
+- `origin_context`: Originating hardware component path
+
+**Dynamic labels:** Additional label dimensions can be injected from the BMC or Server resource (see [Label Enrichment](#label-enrichment) below).
+
+**Example values:**
+```text
+redfish_monitor_reading{hostname="node001-bmc", metric_id="CPU1Temp", type="Temperature", unit="Cel", origin_context="/Chassis/1/Thermal"} 42.5
+redfish_monitor_reading{hostname="node001-bmc", metric_id="FanSpeed1", type="Rotational", unit="RPM", origin_context="/Chassis/1/Thermal"} 3200
+```
+
+**Use cases:**
+- Alert on thermal readings exceeding thresholds: `redfish_monitor_reading{type="Temperature"} > 80`
+- Track fan speeds: `redfish_monitor_reading{type="Rotational"}`
+- Compare readings across regions or racks when enriched with topology labels
+
+### Alert Event Counter (`redfish_event_alert_total`)
+
+**Type:** Counter
+**Description:** Total count of Redfish alert/event messages received from each BMC.
+**Fixed labels:**
+- `hostname`: BMC Kubernetes resource name
+- `severity`: Event severity (e.g., `OK`, `Warning`, `Critical`)
+- `message_id`: Redfish MessageId (e.g., `Alert.1.0.ResourceStatusChangedOK`)
+- `component`: Originating hardware component
+
+**Dynamic labels:** Same enrichment as `redfish_monitor_reading`.
+
+**Example values:**
+```text
+redfish_event_alert_total{hostname="node001-bmc", severity="Warning", message_id="ThermalEvents.1.0.TemperatureAboveUpperCautionThreshold", component="/Chassis/1/Thermal/CPU1Temp"} 3
+redfish_event_alert_total{hostname="node001-bmc", severity="OK", message_id="Alert.1.0.ResourceStatusChangedOK", component="/Systems/1"} 12
+```
+
+**Use cases:**
+- Alert on sustained critical events: `increase(redfish_event_alert_total{severity="Critical"}[5m]) > 0`
+- Track warning frequency per host: `rate(redfish_event_alert_total{severity="Warning"}[1h])`
+
+### Label Enrichment
+
+When managing a large number of servers, it is often necessary to filter dashboard panels and alert rules by topology or location (e.g., region, availability zone, rack). Both Redfish metrics support optional dynamic label dimensions sourced from Kubernetes resources for exactly this purpose — enabling operators to slice telemetry by any organisational dimension without modifying the operator itself.
+
+This is configured via two CLI flags:
+
+| Flag | Source resource | Match key |
+|------|----------------|-----------|
+| `--redfish-metric-labels-from-bmc` | `BMC` resource | resource name == `hostname` label |
+| `--redfish-metric-labels-from-server` | `Server` resource | `spec.bmcRef.name` == `hostname` label |
+
+**Flag format:** `kubernetes-label-key=prometheus-label-name,...`
+
+**Example:**
+```bash
+--redfish-metric-labels-from-bmc=topology.kubernetes.io/region=region,topology.kubernetes.io/zone=zone
+--redfish-metric-labels-from-server=metadata.metal.ironcore.dev/location=location,metadata.metal.ironcore.dev/rack=rack
+```
+
+When configured, every Redfish metric gains the extra label columns. If a label key is missing from the resource, the value is emitted as an empty string — missing labels never block metric emission.
+
+Label lookups are cached per hostname with a 1-hour TTL to avoid excessive Kubernetes API calls.
+
+#### Helm chart configuration
+
+```yaml
+redfishLabels:
+  bmc:
+    topology.kubernetes.io/region: region
+    topology.kubernetes.io/zone: zone
+  server:
+    metadata.metal.ironcore.dev/location: location
+    metadata.metal.ironcore.dev/rack: rack
+```
+
+#### Example enriched output
+
+```text
+redfish_monitor_reading{hostname="node001-bmc", metric_id="CPU1Temp", type="Temperature", unit="Cel", origin_context="/Chassis/1/Thermal", region="eu-de-1", zone="eu-de-1a", location="building-b", rack="row3-rack7"} 42.5
+```
+
 ## Implementation Details
 
 ### Metric Collection Strategy

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -352,7 +352,7 @@ This is configured via two CLI flags:
 
 When configured, every Redfish metric gains the extra label columns. If a label key is missing from the resource, the value is emitted as an empty string — missing labels never block metric emission.
 
-Label lookups are cached per hostname with a 1-hour TTL to avoid excessive Kubernetes API calls.
+Labels are read from the controller-runtime informer cache, which is watch-based and always reflects the current cluster state. There is no TTL — label changes on BMC or Server resources are visible immediately.
 
 #### Helm chart configuration
 

--- a/internal/serverevents/metrics.go
+++ b/internal/serverevents/metrics.go
@@ -14,15 +14,8 @@ import (
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
-)
-
-const (
-	// labelCacheTTL is how long a cached label set is considered fresh.
-	// After expiry the next incoming metrics event will re-fetch from the API.
-	labelCacheTTL = 1 * time.Hour
 )
 
 // LabelMapping maps a Kubernetes resource label key to a Prometheus label name.
@@ -83,12 +76,6 @@ type MetricEntry struct {
 	Timestamp     time.Time
 }
 
-// labelCacheEntry holds the enrichment label values for a given hostname along with an expiry time.
-type labelCacheEntry struct {
-	vals      []string
-	expiresAt time.Time
-}
-
 type RedfishEventCollector struct {
 	lastReadings map[string]MetricEntry
 	alertCounts  map[EventKey]uint64
@@ -100,8 +87,6 @@ type RedfishEventCollector struct {
 	bmcMappings    []LabelMapping
 	serverMappings []LabelMapping
 	allLabelCount  int
-	labelCache     map[string]labelCacheEntry
-	labelMux       sync.RWMutex
 }
 
 type EventKey struct {
@@ -129,7 +114,6 @@ func NewRedfishEventCollector(k8sClient client.Client, bmcMappings, serverMappin
 	c := &RedfishEventCollector{
 		lastReadings:   make(map[string]MetricEntry),
 		alertCounts:    make(map[EventKey]uint64),
-		labelCache:     make(map[string]labelCacheEntry),
 		k8sClient:      k8sClient,
 		bmcMappings:    bmcMappings,
 		serverMappings: serverMappings,
@@ -151,42 +135,21 @@ func NewRedfishEventCollector(k8sClient client.Client, bmcMappings, serverMappin
 	return c
 }
 
-// lookupLabels fetches and caches BMC + Server label values for the given hostname.
-// The hostname is the BMC Kubernetes resource name, which equals Server.spec.bmcRef.name.
-//
-// Caching behaviour:
-//   - Cache hit and not expired → return cached values immediately (no API calls).
-//   - Cache miss or expired → fetch from API, cache the result for labelCacheTTL, return values.
-//   - BMC not found (IsNotFound) → cache empty BMC labels, still attempt Server lookup.
-//   - BMC transient error → do not cache, return current values so the next event retries.
-//   - Server lookup failure or unexpected count → cache whatever BMC labels we have with empty
-//     Server labels (avoids hammering the API when the Server does not exist yet).
-//
-// Missing individual label keys on a resource return empty strings via Go map defaults.
-// Metrics are always emitted regardless of label availability.
-func (c *RedfishEventCollector) lookupLabels(ctx context.Context, hostname string) []string {
-	c.labelMux.RLock()
-	if entry, ok := c.labelCache[hostname]; ok && time.Now().Before(entry.expiresAt) {
-		c.labelMux.RUnlock()
-		return entry.vals
-	}
-	c.labelMux.RUnlock()
-
+// getLabels returns the enrichment label values for the given hostname by reading from the
+// controller-runtime informer cache. Reads are local in-memory operations — the informer cache
+// is watch-based and always reflects the current cluster state without making API server calls.
+// Returns empty strings for any label that cannot be resolved.
+func (c *RedfishEventCollector) getLabels(hostname string) []string {
 	vals := make([]string, c.allLabelCount)
 	if c.k8sClient == nil || c.allLabelCount == 0 {
 		return vals
 	}
+	ctx := context.Background()
 
 	// --- BMC labels ---
 	if len(c.bmcMappings) > 0 {
 		bmc := &metalv1alpha1.BMC{}
-		if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: hostname}, bmc); err != nil {
-			if !apierrors.IsNotFound(err) {
-				// Transient error: do not cache, let the next event retry.
-				return vals
-			}
-			// BMC not found: leave BMC slots empty and fall through to Server lookup.
-		} else {
+		if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: hostname}, bmc); err == nil {
 			for i, m := range c.bmcMappings {
 				vals[i] = bmc.Labels[m.K8sKey]
 			}
@@ -202,31 +165,11 @@ func (c *RedfishEventCollector) lookupLabels(ctx context.Context, hostname strin
 			}
 		}
 	}
-	// On Server lookup failure or unexpected item count we leave Server slots empty and still
-	// cache so we don't hammer the API. The cache will expire after labelCacheTTL.
-
-	c.labelMux.Lock()
-	c.labelCache[hostname] = labelCacheEntry{vals: vals, expiresAt: time.Now().Add(labelCacheTTL)}
-	c.labelMux.Unlock()
 	return vals
 }
 
-// labelsCached returns the cached combined label values for a hostname without making an API call.
-// Returns a slice of empty strings when the hostname is not cached or the cache entry has expired.
-func (c *RedfishEventCollector) labelsCached(hostname string) []string {
-	c.labelMux.RLock()
-	defer c.labelMux.RUnlock()
-	if entry, ok := c.labelCache[hostname]; ok && time.Now().Before(entry.expiresAt) {
-		return entry.vals
-	}
-	return make([]string, c.allLabelCount)
-}
-
 // UpdateFromMetricsReport processes incoming MetricReport events and updates the internal state.
-func (c *RedfishEventCollector) UpdateFromMetricsReport(ctx context.Context, hostname string, report MetricsReport) {
-	// Populate the label cache before acquiring the main lock (different mutex).
-	c.lookupLabels(ctx, hostname)
-
+func (c *RedfishEventCollector) UpdateFromMetricsReport(hostname string, report MetricsReport) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
@@ -262,10 +205,7 @@ func (c *RedfishEventCollector) UpdateFromMetricsReport(ctx context.Context, hos
 }
 
 // UpdateFromEvent processes incoming Redfish events and updates the alert counts.
-func (c *RedfishEventCollector) UpdateFromEvent(ctx context.Context, hostname string, data EventData) {
-	// Populate the label cache before acquiring the main lock (different mutex).
-	c.lookupLabels(ctx, hostname)
-
+func (c *RedfishEventCollector) UpdateFromEvent(hostname string, data EventData) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
@@ -304,7 +244,7 @@ func (c *RedfishEventCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		labelValues := append(
 			[]string{data.Source, data.MetricID, data.Type, data.Unit, data.OriginContext},
-			c.labelsCached(data.Source)...,
+			c.getLabels(data.Source)...,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.sensorDesc,
@@ -316,7 +256,7 @@ func (c *RedfishEventCollector) Collect(ch chan<- prometheus.Metric) {
 	for key, count := range c.alertCounts {
 		labelValues := append(
 			[]string{key.Source, key.Severity, key.EventID, key.Component},
-			c.labelsCached(key.Source)...,
+			c.getLabels(key.Source)...,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.alertDesc,

--- a/internal/serverevents/metrics.go
+++ b/internal/serverevents/metrics.go
@@ -4,14 +4,74 @@
 package serverevents
 
 import (
+	"context"
+	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
+
+const (
+	// labelCacheTTL is how long a cached label set is considered fresh.
+	// After expiry the next incoming metrics event will re-fetch from the API.
+	labelCacheTTL = 1 * time.Hour
+)
+
+// LabelMapping maps a Kubernetes resource label key to a Prometheus label name.
+type LabelMapping struct {
+	K8sKey    string
+	PromLabel string
+}
+
+// promLabelPattern is the set of valid Prometheus label name characters.
+var promLabelPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// ParseLabelMappings parses a comma-separated list of "kubernetes-label-key=prometheus-label-name"
+// pairs into a []LabelMapping.
+//
+// Format: "some.domain/key=prom_label,other.domain/key2=prom_label2"
+//
+// Rules:
+//   - Empty string returns nil (no mappings, valid).
+//   - Each token must contain exactly one "=".
+//   - The Prometheus label name must match [a-zA-Z_][a-zA-Z0-9_]*.
+//   - Whitespace is trimmed from both sides of each token and each part.
+func ParseLabelMappings(s string) ([]LabelMapping, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	tokens := strings.Split(s, ",")
+	mappings := make([]LabelMapping, 0, len(tokens))
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		parts := strings.SplitN(token, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid label mapping %q: must be 'kubernetes-label=prometheus-label'", token)
+		}
+		k8sKey := strings.TrimSpace(parts[0])
+		promLabel := strings.TrimSpace(parts[1])
+		if k8sKey == "" {
+			return nil, fmt.Errorf("invalid label mapping %q: Kubernetes label key must not be empty", token)
+		}
+		if !promLabelPattern.MatchString(promLabel) {
+			return nil, fmt.Errorf("invalid label mapping %q: Prometheus label name %q must match [a-zA-Z_][a-zA-Z0-9_]*", token, promLabel)
+		}
+		mappings = append(mappings, LabelMapping{K8sKey: k8sKey, PromLabel: promLabel})
+	}
+	return mappings, nil
+}
 
 type MetricEntry struct {
 	MetricID      string
@@ -23,12 +83,25 @@ type MetricEntry struct {
 	Timestamp     time.Time
 }
 
+// labelCacheEntry holds the enrichment label values for a given hostname along with an expiry time.
+type labelCacheEntry struct {
+	vals      []string
+	expiresAt time.Time
+}
+
 type RedfishEventCollector struct {
 	lastReadings map[string]MetricEntry
 	alertCounts  map[EventKey]uint64
 	mux          sync.RWMutex
 	sensorDesc   *prometheus.Desc
 	alertDesc    *prometheus.Desc
+
+	k8sClient      client.Client
+	bmcMappings    []LabelMapping
+	serverMappings []LabelMapping
+	allLabelCount  int
+	labelCache     map[string]labelCacheEntry
+	labelMux       sync.RWMutex
 }
 
 type EventKey struct {
@@ -39,20 +112,38 @@ type EventKey struct {
 }
 
 // NewRedfishEventCollector initializes a new RedfishEventCollector and registers it with Prometheus.
-func NewRedfishEventCollector() *RedfishEventCollector {
+//
+// bmcMappings and serverMappings define which Kubernetes resource labels are propagated to Redfish
+// metrics as additional Prometheus label dimensions. Pass nil for either to disable enrichment from
+// that resource. The k8sClient is used to look up the resources at runtime; pass nil to disable all
+// enrichment (e.g. in tests or standalone tooling).
+func NewRedfishEventCollector(k8sClient client.Client, bmcMappings, serverMappings []LabelMapping) *RedfishEventCollector {
+	allLabelCount := len(bmcMappings) + len(serverMappings)
+	allLabels := make([]string, 0, allLabelCount)
+	for _, m := range bmcMappings {
+		allLabels = append(allLabels, m.PromLabel)
+	}
+	for _, m := range serverMappings {
+		allLabels = append(allLabels, m.PromLabel)
+	}
 	c := &RedfishEventCollector{
-		lastReadings: make(map[string]MetricEntry),
-		alertCounts:  make(map[EventKey]uint64),
+		lastReadings:   make(map[string]MetricEntry),
+		alertCounts:    make(map[EventKey]uint64),
+		labelCache:     make(map[string]labelCacheEntry),
+		k8sClient:      k8sClient,
+		bmcMappings:    bmcMappings,
+		serverMappings: serverMappings,
+		allLabelCount:  allLabelCount,
 		sensorDesc: prometheus.NewDesc(
 			"redfish_monitor_reading",
 			"Latest value pushed via Redfish MetricReport event",
-			[]string{"hostname", "metric_id", "type", "unit", "origin_context"},
+			append([]string{"hostname", "metric_id", "type", "unit", "origin_context"}, allLabels...),
 			nil,
 		),
 		alertDesc: prometheus.NewDesc(
 			"redfish_event_alert_total",
 			"Total count of Redfish alerts/events received",
-			[]string{"hostname", "severity", "message_id", "component"},
+			append([]string{"hostname", "severity", "message_id", "component"}, allLabels...),
 			nil,
 		),
 	}
@@ -60,8 +151,82 @@ func NewRedfishEventCollector() *RedfishEventCollector {
 	return c
 }
 
+// lookupLabels fetches and caches BMC + Server label values for the given hostname.
+// The hostname is the BMC Kubernetes resource name, which equals Server.spec.bmcRef.name.
+//
+// Caching behaviour:
+//   - Cache hit and not expired → return cached values immediately (no API calls).
+//   - Cache miss or expired → fetch from API, cache the result for labelCacheTTL, return values.
+//   - BMC not found (IsNotFound) → cache empty BMC labels, still attempt Server lookup.
+//   - BMC transient error → do not cache, return current values so the next event retries.
+//   - Server lookup failure or unexpected count → cache whatever BMC labels we have with empty
+//     Server labels (avoids hammering the API when the Server does not exist yet).
+//
+// Missing individual label keys on a resource return empty strings via Go map defaults.
+// Metrics are always emitted regardless of label availability.
+func (c *RedfishEventCollector) lookupLabels(ctx context.Context, hostname string) []string {
+	c.labelMux.RLock()
+	if entry, ok := c.labelCache[hostname]; ok && time.Now().Before(entry.expiresAt) {
+		c.labelMux.RUnlock()
+		return entry.vals
+	}
+	c.labelMux.RUnlock()
+
+	vals := make([]string, c.allLabelCount)
+	if c.k8sClient == nil || c.allLabelCount == 0 {
+		return vals
+	}
+
+	// --- BMC labels ---
+	if len(c.bmcMappings) > 0 {
+		bmc := &metalv1alpha1.BMC{}
+		if err := c.k8sClient.Get(ctx, client.ObjectKey{Name: hostname}, bmc); err != nil {
+			if !apierrors.IsNotFound(err) {
+				// Transient error: do not cache, let the next event retry.
+				return vals
+			}
+			// BMC not found: leave BMC slots empty and fall through to Server lookup.
+		} else {
+			for i, m := range c.bmcMappings {
+				vals[i] = bmc.Labels[m.K8sKey]
+			}
+		}
+	}
+
+	// --- Server labels (looked up via spec.bmcRef.name field index) ---
+	if len(c.serverMappings) > 0 {
+		serverList := &metalv1alpha1.ServerList{}
+		if err := c.k8sClient.List(ctx, serverList, client.MatchingFields{"spec.bmcRef.name": hostname}); err == nil && len(serverList.Items) == 1 {
+			for i, m := range c.serverMappings {
+				vals[len(c.bmcMappings)+i] = serverList.Items[0].Labels[m.K8sKey]
+			}
+		}
+	}
+	// On Server lookup failure or unexpected item count we leave Server slots empty and still
+	// cache so we don't hammer the API. The cache will expire after labelCacheTTL.
+
+	c.labelMux.Lock()
+	c.labelCache[hostname] = labelCacheEntry{vals: vals, expiresAt: time.Now().Add(labelCacheTTL)}
+	c.labelMux.Unlock()
+	return vals
+}
+
+// labelsCached returns the cached combined label values for a hostname without making an API call.
+// Returns a slice of empty strings when the hostname is not cached or the cache entry has expired.
+func (c *RedfishEventCollector) labelsCached(hostname string) []string {
+	c.labelMux.RLock()
+	defer c.labelMux.RUnlock()
+	if entry, ok := c.labelCache[hostname]; ok && time.Now().Before(entry.expiresAt) {
+		return entry.vals
+	}
+	return make([]string, c.allLabelCount)
+}
+
 // UpdateFromMetricsReport processes incoming MetricReport events and updates the internal state.
-func (c *RedfishEventCollector) UpdateFromMetricsReport(hostname string, report MetricsReport) {
+func (c *RedfishEventCollector) UpdateFromMetricsReport(ctx context.Context, hostname string, report MetricsReport) {
+	// Populate the label cache before acquiring the main lock (different mutex).
+	c.lookupLabels(ctx, hostname)
+
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
@@ -97,11 +262,14 @@ func (c *RedfishEventCollector) UpdateFromMetricsReport(hostname string, report 
 }
 
 // UpdateFromEvent processes incoming Redfish events and updates the alert counts.
-func (c *RedfishEventCollector) UpdateFromEvent(hostname string, data EventData) {
+func (c *RedfishEventCollector) UpdateFromEvent(ctx context.Context, hostname string, data EventData) {
+	// Populate the label cache before acquiring the main lock (different mutex).
+	c.lookupLabels(ctx, hostname)
+
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
-	events := data.GetEvents() // Use new method to get events from either field
+	events := data.GetEvents()
 	for _, event := range events {
 		// Determine the component from the URI (e.g., .../Sensors/Fan1 -> Fan1)
 		component := "system"
@@ -118,7 +286,6 @@ func (c *RedfishEventCollector) UpdateFromEvent(hostname string, data EventData)
 		}
 		c.alertCounts[key]++
 	}
-
 }
 
 // Describe and Collect implement the prometheus.Collector interface to expose metrics.
@@ -135,26 +302,27 @@ func (c *RedfishEventCollector) Collect(ch chan<- prometheus.Metric) {
 		if time.Since(data.Timestamp) > 10*time.Minute {
 			continue
 		}
+		labelValues := append(
+			[]string{data.Source, data.MetricID, data.Type, data.Unit, data.OriginContext},
+			c.labelsCached(data.Source)...,
+		)
 		ch <- prometheus.MustNewConstMetric(
 			c.sensorDesc,
 			prometheus.GaugeValue,
 			data.Value,
-			data.Source,
-			data.MetricID,
-			data.Type,
-			data.Unit,
-			data.OriginContext,
+			labelValues...,
 		)
 	}
 	for key, count := range c.alertCounts {
+		labelValues := append(
+			[]string{key.Source, key.Severity, key.EventID, key.Component},
+			c.labelsCached(key.Source)...,
+		)
 		ch <- prometheus.MustNewConstMetric(
 			c.alertDesc,
 			prometheus.CounterValue,
 			float64(count),
-			key.Source,
-			key.Severity,
-			key.EventID,
-			key.Component,
+			labelValues...,
 		)
 	}
 }

--- a/internal/serverevents/server.go
+++ b/internal/serverevents/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Server struct {
@@ -71,13 +72,17 @@ type Event struct {
 	OriginOfCondition string `json:"OriginOfCondition"`
 }
 
-func NewServer(log logr.Logger, addr string) *Server {
+// NewServer creates a new event server. bmcMappings and serverMappings define which Kubernetes
+// resource labels are propagated to Redfish metrics as additional Prometheus label dimensions;
+// pass nil for either to disable enrichment from that resource. The k8sClient is used to look up
+// the resources at runtime; pass nil to disable all enrichment.
+func NewServer(log logr.Logger, addr string, k8sClient client.Client, bmcMappings, serverMappings []LabelMapping) *Server {
 	mux := http.NewServeMux()
 	server := &Server{
 		addr:      addr,
 		mux:       mux,
 		log:       log,
-		collector: NewRedfishEventCollector(),
+		collector: NewRedfishEventCollector(k8sClient, bmcMappings, serverMappings),
 	}
 	server.routes()
 	return server
@@ -129,7 +134,7 @@ func (s *Server) alertHandler(w http.ResponseWriter, r *http.Request) {
 		s.log.Info("Processed events successfully", "hostname", hostname, "count", len(events))
 	}
 
-	s.collector.UpdateFromEvent(hostname, eventData)
+	s.collector.UpdateFromEvent(r.Context(), hostname, eventData)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -173,7 +178,7 @@ func (s *Server) metricsreportHandler(w http.ResponseWriter, r *http.Request) {
 		s.log.Info("Processed metrics successfully", "hostname", hostname, "count", len(metricsReport.MetricValues))
 	}
 
-	s.collector.UpdateFromMetricsReport(hostname, metricsReport)
+	s.collector.UpdateFromMetricsReport(r.Context(), hostname, metricsReport)
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/internal/serverevents/server.go
+++ b/internal/serverevents/server.go
@@ -134,7 +134,7 @@ func (s *Server) alertHandler(w http.ResponseWriter, r *http.Request) {
 		s.log.Info("Processed events successfully", "hostname", hostname, "count", len(events))
 	}
 
-	s.collector.UpdateFromEvent(r.Context(), hostname, eventData)
+	s.collector.UpdateFromEvent(hostname, eventData)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -178,7 +178,7 @@ func (s *Server) metricsreportHandler(w http.ResponseWriter, r *http.Request) {
 		s.log.Info("Processed metrics successfully", "hostname", hostname, "count", len(metricsReport.MetricValues))
 	}
 
-	s.collector.UpdateFromMetricsReport(r.Context(), hostname, metricsReport)
+	s.collector.UpdateFromMetricsReport(hostname, metricsReport)
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/test/serverevents/main.go
+++ b/test/serverevents/main.go
@@ -28,7 +28,7 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	setupLog.Info("starting serverevent agent")
-	server := serverevents.NewServer(setupLog, ":8888")
+	server := serverevents.NewServer(setupLog, ":8888", nil, nil, nil)
 
 	if err := server.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running telemetry server")


### PR DESCRIPTION
Fixes #893 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI flags to enrich Redfish metrics with labels from Kubernetes BMC and Server resources using configurable key-to-label mappings.
  * Enhanced observability with additional dynamic label dimensions for metrics when event monitoring is enabled.

* **Documentation**
  * Added documentation describing Redfish telemetry metrics, label enrichment configuration, and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/metal-operator/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->