### PR TITLE
Remove condition/reason migration logic

### DIFF
--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -63,36 +63,6 @@ const (
 	ReasonSettingsValidationFailed      = "SettingsValidationFailed"
 )
 
-// legacyBIOSSettingsConditionTypes maps old condition type strings to their new values.
-// This ensures backward compatibility with existing CRs created before the rename.
-var legacyBIOSSettingsConditionTypes = map[string]string{
-	"BIOSSettingsCheckPendingSettings":     ConditionPendingSettingsCheck,
-	"BIOSSettingsDuplicateKeys":            ConditionSettingsDuplicateKeys,
-	"BIOSSettingUpdateStartTime":           ConditionSettingsUpdateStartTime,
-	"BIOSSettingsTimedOut":                 ConditionSettingsTimedOut,
-	"ServerPowerOnCondition":               ConditionSettingsServerPowerOn,
-	"ServerRebootPostUpdateHasBeenIssued":  ConditionSettingsRebootPostUpdate,
-	"BMCResetIssued":                       ConditionResetIssued,
-	"BIOSVersionUpdatePending":             ConditionVersionUpdatePending,
-	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
-	"SettingsProvidedNotValid":             ConditionSettingsValidationFailed,
-}
-
-// legacyBIOSSettingsConditionReasons maps old condition reason strings to their new values.
-var legacyBIOSSettingsConditionReasons = map[string]string{
-	"BMCResetIssued":                                   ReasonResetIssued,
-	"BIOSVersionNeedsTObeUpgraded":                     ReasonVersionUpgradePending,
-	"BIOSPendingSettingsFound":                         ReasonPendingSettingsFound,
-	"BIOSSettingsDuplicateKeysFound":                   ReasonSettingsDuplicateKeysFound,
-	"BIOSSettingsUpdateHasStarted":                     ReasonSettingsUpdateStarted,
-	"BIOSSettingsTimedOutDuringUpdate":                 ReasonSettingsTimedOut,
-	"ServerPoweredHasBeenPoweredOn":                    ReasonSettingsServerPoweredOn,
-	"BIOSSettingUpdateIssued":                          ReasonSettingsUpdateIssued,
-	"UnexpectedPendingSettingsPostUpdateHasBeenIssued": ReasonSettingsUnexpectedPending,
-	"SkipServerRebootPostUpdateHasBeenIssued":          ReasonSettingsSkipReboot,
-	"SettingsProvidedAreNotValid":                      ReasonSettingsValidationFailed,
-}
-
 // BIOSSettingsReconciler reconciles a BIOSSettings object
 type BIOSSettingsReconciler struct {
 	client.Client
@@ -124,34 +94,7 @@ func (r *BIOSSettingsReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err := r.Get(ctx, req.NamespacedName, biosSettings); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	if err := r.migrateLegacyConditions(ctx, biosSettings); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
-	}
 	return r.reconcileExists(ctx, biosSettings)
-}
-
-// migrateLegacyConditions renames legacy condition type strings on existing CRs.
-// TODO: Remove this migration in the next release once all CRs have been reconciled.
-func (r *BIOSSettingsReconciler) migrateLegacyConditions(ctx context.Context, settings *metalv1alpha1.BIOSSettings) error {
-	settingsBase := settings.DeepCopy()
-	migrated := migrateConditionTypes(settings.Status.Conditions, legacyBIOSSettingsConditionTypes)
-	if migrateConditionReasons(settings.Status.Conditions, legacyBIOSSettingsConditionReasons) {
-		migrated = true
-	}
-	for i := range settings.Status.FlowState {
-		if migrateConditionTypes(settings.Status.FlowState[i].Conditions, legacyBIOSSettingsConditionTypes) {
-			migrated = true
-		}
-		if migrateConditionReasons(settings.Status.FlowState[i].Conditions, legacyBIOSSettingsConditionReasons) {
-			migrated = true
-		}
-	}
-	if !migrated {
-		return nil
-	}
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Migrated legacy condition types on BIOSSettings")
-	return r.Status().Patch(ctx, settings, client.MergeFrom(settingsBase))
 }
 
 func (r *BIOSSettingsReconciler) reconcileExists(ctx context.Context, settings *metalv1alpha1.BIOSSettings) (ctrl.Result, error) {
@@ -1585,12 +1528,7 @@ func (r *BIOSSettingsReconciler) enqueueBiosSettingsByBMC(ctx context.Context, o
 
 		// Only enqueue if BMC reset was issued but not yet completed
 		if settings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress {
-			// Normalize legacy condition types/reasons so unmigrated CRs are handled correctly.
-			conditions := settings.Status.Conditions
-			migrateConditionTypes(conditions, legacyBIOSSettingsConditionTypes)
-			migrateConditionReasons(conditions, legacyBIOSSettingsConditionReasons)
-
-			resetCond, err := GetCondition(r.Conditions, conditions, ConditionResetIssued)
+			resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionResetIssued)
 			if err == nil && resetCond.Status != metav1.ConditionTrue && resetCond.Reason == ReasonResetIssued {
 				reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: settings.Name}})
 			}

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -38,26 +38,6 @@ const (
 	ReasonRebootPowerOn  = "RebootPowerOn"
 )
 
-// legacyBIOSVersionConditionTypes maps old condition type strings to their new values.
-// TODO: Remove this migration in the next release once all CRs have been reconciled.
-var legacyBIOSVersionConditionTypes = map[string]string{
-	"BIOSUpgradeIssued":                    ConditionVersionUpgradeIssued,
-	"BIOSUpgradeCompleted":                 ConditionVersionUpgradeCompleted,
-	"BIOSUpgradePowerOn":                   ConditionUpgradePowerOn,
-	"BIOSUpgradePowerOff":                  ConditionUpgradePowerOff,
-	"BIOSUpgradeVerification":              ConditionVersionUpgradeVerification,
-	"BIOSVersionUpdatePending":             ConditionVersionUpdatePending,
-	"BMCResetIssued":                       ConditionResetIssued,
-	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
-}
-
-// legacyBIOSVersionConditionReasons maps old condition reason strings to their new values.
-var legacyBIOSVersionConditionReasons = map[string]string{
-	"BMCResetIssued":                ReasonResetIssued,
-	"BIOSVersionVerified":           ReasonVersionUpdateVerified,
-	"BIOSVersionVerificationFailed": ReasonVersionVerificationFailed,
-}
-
 type BIOSVersionReconciler struct {
 	client.Client
 	ManagerNamespace            string
@@ -86,18 +66,6 @@ func (r *BIOSVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	biosVersion := &metalv1alpha1.BIOSVersion{}
 	if err := r.Get(ctx, req.NamespacedName, biosVersion); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-	// TODO: Remove this migration in the next release once all CRs have been reconciled.
-	biosVersionBase := biosVersion.DeepCopy()
-	migrated := migrateConditionTypes(biosVersion.Status.Conditions, legacyBIOSVersionConditionTypes)
-	if migrateConditionReasons(biosVersion.Status.Conditions, legacyBIOSVersionConditionReasons) {
-		migrated = true
-	}
-	if migrated {
-		log.Info("Migrated legacy conditions on BIOSVersion")
-		if err := r.Status().Patch(ctx, biosVersion, client.MergeFrom(biosVersionBase)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
-		}
 	}
 	log.V(1).Info("Reconciling BIOSVersion")
 
@@ -1071,12 +1039,7 @@ func (r *BIOSVersionReconciler) enqueueBiosSettingsByBMC(ctx context.Context, ob
 	reqs := make([]ctrl.Request, 0)
 	for _, biosVersion := range biosVersionList.Items {
 		if biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
-			// Normalize legacy condition types/reasons so unmigrated CRs are handled correctly.
-			conditions := biosVersion.Status.Conditions
-			migrateConditionTypes(conditions, legacyBIOSVersionConditionTypes)
-			migrateConditionReasons(conditions, legacyBIOSVersionConditionReasons)
-
-			resetBMC, err := GetCondition(r.Conditions, conditions, ConditionResetIssued)
+			resetBMC, err := GetCondition(r.Conditions, biosVersion.Status.Conditions, ConditionResetIssued)
 			if err != nil {
 				log.Error(err, "Failed to get reset BMC condition")
 				continue

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -42,12 +42,6 @@ const (
 	bmcAutoResetMessage = "BMC reset initiated automatically after repeated connection failures. Waiting for it to come back online."
 )
 
-// legacyBMCConditionReasons maps old condition reason strings to their new values.
-// TODO: Remove this migration in the next release once all CRs have been reconciled.
-var legacyBMCConditionReasons = map[string]string{
-	"BMCConnected": ReasonConnected,
-}
-
 // BMCReconciler reconciles a BMC object
 type BMCReconciler struct {
 	client.Client
@@ -80,15 +74,6 @@ func (r *BMCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	bmcObj := &metalv1alpha1.BMC{}
 	if err := r.Get(ctx, req.NamespacedName, bmcObj); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-	// TODO: Remove this migration in the next release once all CRs have been reconciled.
-	bmcBase := bmcObj.DeepCopy()
-	if migrateConditionReasons(bmcObj.Status.Conditions, legacyBMCConditionReasons) {
-		log := ctrl.LoggerFrom(ctx)
-		log.Info("Migrated legacy condition reasons on BMC")
-		if err := r.Status().Patch(ctx, bmcObj, client.MergeFrom(bmcBase)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
-		}
 	}
 
 	return r.reconcileExists(ctx, bmcObj)

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -58,20 +58,6 @@ const (
 	ReasonBMCSettingsValidationFailed    = "SettingsValidationFailed"
 )
 
-// legacyBMCSettingsConditionTypes maps old condition type strings to their new values.
-// TODO: Remove this migration in the next release once all CRs have been reconciled.
-var legacyBMCSettingsConditionTypes = map[string]string{
-	"BMCResetIssued":                       ConditionResetIssued,
-	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
-}
-
-// legacyBMCSettingsConditionReasons maps old condition reason strings to their new values.
-var legacyBMCSettingsConditionReasons = map[string]string{
-	"BMCResetIssued":              ReasonResetIssued,
-	"SettingsProvidedAreNotValid": ReasonBMCSettingsValidationFailed,
-	"ChangesNotYetVerified":       ReasonBMCSettingsVerificationPending,
-}
-
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcsettings/finalizers,verbs=update
@@ -90,18 +76,6 @@ func (r *BMCSettingsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log := ctrl.LoggerFrom(ctx)
-	// TODO: Remove this migration in the next release once all CRs have been reconciled.
-	settingsBase := settings.DeepCopy()
-	migrated := migrateConditionTypes(settings.Status.Conditions, legacyBMCSettingsConditionTypes)
-	if migrateConditionReasons(settings.Status.Conditions, legacyBMCSettingsConditionReasons) {
-		migrated = true
-	}
-	if migrated {
-		log.Info("Migrated legacy conditions on BMCSettings")
-		if err := r.Status().Patch(ctx, settings, client.MergeFrom(settingsBase)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
-		}
-	}
 	log.V(1).Info("Reconciling BMCSettings")
 
 	return r.reconcileExists(ctx, settings)

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -31,21 +31,6 @@ const (
 	bmcVersionFinalizer = "metal.ironcore.dev/bmcversion"
 )
 
-// legacyBMCVersionConditionTypes maps old condition type strings to their new values.
-// TODO: Remove this migration in the next release once all CRs have been reconciled.
-var legacyBMCVersionConditionTypes = map[string]string{
-	"BMCResetIssued":                       ConditionResetIssued,
-	"RetryOfFailedResourceConditionIssued": ConditionRetryOfFailedResourceIssued,
-}
-
-// legacyBMCVersionConditionReasons maps old condition reason strings to their new values.
-var legacyBMCVersionConditionReasons = map[string]string{
-	"BMCResetIssued":           ReasonResetIssued,
-	"IssueBMCUpgradeFailed":    ReasonUpgradeIssueFailed,
-	"TaskCompleted":            ReasonUpgradeTaskCompleted,
-	"VerifiedBMCVersionUpdate": ReasonVersionUpdateVerified,
-}
-
 // BMCVersionReconciler reconciles a BMCVersion object
 type BMCVersionReconciler struct {
 	client.Client
@@ -77,18 +62,6 @@ func (r *BMCVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log := ctrl.LoggerFrom(ctx)
-	// TODO: Remove this migration in the next release once all CRs have been reconciled.
-	bmcVersionBase := bmcVersion.DeepCopy()
-	migrated := migrateConditionTypes(bmcVersion.Status.Conditions, legacyBMCVersionConditionTypes)
-	if migrateConditionReasons(bmcVersion.Status.Conditions, legacyBMCVersionConditionReasons) {
-		migrated = true
-	}
-	if migrated {
-		log.Info("Migrated legacy conditions on BMCVersion")
-		if err := r.Status().Patch(ctx, bmcVersion, client.MergeFrom(bmcVersionBase)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to migrate legacy conditions: %w", err)
-		}
-	}
 	log.V(1).Info("Reconciling BMCVersion")
 
 	return r.reconcileExists(ctx, bmcVersion)

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -88,34 +88,6 @@ func GetCondition(acc *conditionutils.Accessor, conditions []metav1.Condition, c
 	return condition, nil
 }
 
-// migrateConditionTypes renames legacy condition type strings in-place.
-// Returns true if any conditions were migrated.
-// TODO: Remove this function in the next release once all CRs have been reconciled.
-func migrateConditionTypes(conditions []metav1.Condition, migrations map[string]string) bool {
-	migrated := false
-	for i := range conditions {
-		if newType, ok := migrations[conditions[i].Type]; ok {
-			conditions[i].Type = newType
-			migrated = true
-		}
-	}
-	return migrated
-}
-
-// migrateConditionReasons renames legacy condition reason strings in-place.
-// Returns true if any reasons were migrated.
-// TODO: Remove this function in the next release once all CRs have been reconciled.
-func migrateConditionReasons(conditions []metav1.Condition, migrations map[string]string) bool {
-	migrated := false
-	for i := range conditions {
-		if newReason, ok := migrations[conditions[i].Reason]; ok {
-			conditions[i].Reason = newReason
-			migrated = true
-		}
-	}
-	return migrated
-}
-
 // GetServerByName returns a Server object by its name or an error in case the object can not be found.
 func GetServerByName(ctx context.Context, c client.Client, serverName string) (*metalv1alpha1.Server, error) {
 	server := &metalv1alpha1.Server{}
@@ -374,15 +346,6 @@ func handleRetryAnnotationPropagation(ctx context.Context, c client.Client, pare
 							retriedCondition.Status == metav1.ConditionTrue &&
 							retriedCondition.Message == metalv1alpha1.OperationAnnotationRetryFailedPropagated {
 							// retry was already propagated to child, we can skip re-propagation to avoid infinite loop
-							return nil
-						}
-
-						// Also check legacy condition type for unmigrated CRs.
-						// TODO: Remove this check in the next release once all CRs have been reconciled.
-						legacyCondition, err := GetCondition(acc, conditions, "RetryOfFailedResourceConditionIssued")
-						if err == nil && legacyCondition != nil &&
-							legacyCondition.Status == metav1.ConditionTrue &&
-							legacyCondition.Message == metalv1alpha1.OperationAnnotationRetryFailedPropagated {
 							return nil
 						}
 					}


### PR DESCRIPTION
Fixes #832


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed automatic migration of legacy condition types and reason strings from all system controllers. Conditions are now processed directly without any automatic normalization or translation of outdated values. Resources using legacy condition formats will no longer be automatically updated and will require manual intervention to maintain full compatibility and functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/metal-operator/pull/895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->