### PR TITLE
BMC Settings Spec to support display names for enum typed settings attributes for Dell

### DIFF
--- a/bmc/oem_helpers.go
+++ b/bmc/oem_helpers.go
@@ -335,6 +335,12 @@ func checkAttributes(
 					validEnum = true
 					break
 				}
+				// Accept ValueDisplayName as input and substitute the canonical ValueName.
+				if attrValue.ValueDisplayName == value.(string) {
+					attrs[name] = attrValue.ValueName
+					validEnum = true
+					break
+				}
 			}
 			if !validEnum {
 				err := &InvalidBMCSettingsError{

--- a/bmc/redfish_dell.go
+++ b/bmc/redfish_dell.go
@@ -265,37 +265,32 @@ func (r *DellRedfishBMC) GetBMCAttributeValues(ctx context.Context, bmcUUID stri
 			// This avoids spurious diffs (and unnecessary BMC resets) when the attribute is
 			// already at the desired value but the two strings differ only in format.
 			specVal := attributes[name]
-			var currentDisplayName string
+			// Build lookup maps in a single pass.
+			displayNameToValueName := make(map[string]string)
+			valueNameExists := make(map[string]bool)
 			for _, attrValue := range entry.Value {
-				if attrValue.ValueDisplayName == currentVal {
-					currentDisplayName = attrValue.ValueDisplayName
-					break
-				}
+				displayNameToValueName[attrValue.ValueDisplayName] = attrValue.ValueName
+				valueNameExists[attrValue.ValueName] = true
 			}
-			if currentDisplayName == "" {
+			currentDisplayName, ok := currentVal.(string)
+			if !ok {
+				errs = append(errs,
+					fmt.Errorf("current setting '%v' for key '%v' has unexpected type",
+						currentVal, name))
+				continue
+			}
+			// Validate that iDRAC returned a known DisplayName.
+			if _, exists := displayNameToValueName[currentDisplayName]; !exists {
 				errs = append(errs,
 					fmt.Errorf("current setting '%v' for key '%v' not found in possible values: %v",
 						currentVal, name, entry.Value))
 				continue
 			}
-			// Determine whether the spec uses ValueName or ValueDisplayName.
-			specUsesValueName := false
-			for _, attrValue := range entry.Value {
-				if attrValue.ValueName == specVal {
-					specUsesValueName = true
-					break
-				}
-			}
-			if specUsesValueName {
-				// Return current value as ValueName so it is comparable to the spec.
-				for _, attrValue := range entry.Value {
-					if attrValue.ValueDisplayName == currentDisplayName {
-						result[name] = attrValue.ValueName
-						break
-					}
-				}
+			if valueNameExists[specVal] {
+				// Spec uses ValueName; translate current DisplayName to ValueName.
+				result[name] = displayNameToValueName[currentDisplayName]
 			} else {
-				// Spec uses ValueDisplayName; return current DisplayName as-is.
+				// Spec uses ValueDisplayName; return as-is.
 				result[name] = currentDisplayName
 			}
 		case schemas.IntegerAttributeType:

--- a/bmc/redfish_dell.go
+++ b/bmc/redfish_dell.go
@@ -256,20 +256,47 @@ func (r *DellRedfishBMC) GetBMCAttributeValues(ctx context.Context, bmcUUID stri
 
 		switch entry.Type {
 		case schemas.EnumerationAttributeType:
-			// Translate the DisplayName value reported by iDRAC to the canonical
-			// ValueName used by the registry and the PATCH payload.
-			// currentVal may be nil (iDRAC CurrentValue=null for factory-default attributes),
-			// in which case the loop below will find no match and we error accordingly.
+			// iDRAC reports enumeration current values as ValueDisplayName (e.g. "Enabled").
+			// The spec may use either ValueDisplayName ("Enabled") or ValueName ("1").
+			// To make the diff comparison work correctly regardless of which format the spec
+			// uses, we return the current value in the same format as the spec value:
+			//   - spec uses ValueName  → translate current DisplayName → ValueName
+			//   - spec uses DisplayName → return current DisplayName as-is
+			// This avoids spurious diffs (and unnecessary BMC resets) when the attribute is
+			// already at the desired value but the two strings differ only in format.
+			specVal := attributes[name]
+			var currentDisplayName string
 			for _, attrValue := range entry.Value {
 				if attrValue.ValueDisplayName == currentVal {
-					result[name] = attrValue.ValueName
+					currentDisplayName = attrValue.ValueDisplayName
 					break
 				}
 			}
-			if _, ok := result[name]; !ok {
+			if currentDisplayName == "" {
 				errs = append(errs,
 					fmt.Errorf("current setting '%v' for key '%v' not found in possible values: %v",
 						currentVal, name, entry.Value))
+				continue
+			}
+			// Determine whether the spec uses ValueName or ValueDisplayName.
+			specUsesValueName := false
+			for _, attrValue := range entry.Value {
+				if attrValue.ValueName == specVal {
+					specUsesValueName = true
+					break
+				}
+			}
+			if specUsesValueName {
+				// Return current value as ValueName so it is comparable to the spec.
+				for _, attrValue := range entry.Value {
+					if attrValue.ValueDisplayName == currentDisplayName {
+						result[name] = attrValue.ValueName
+						break
+					}
+				}
+			} else {
+				// Spec uses ValueDisplayName; return current DisplayName as-is.
+				result[name] = currentDisplayName
 			}
 		case schemas.IntegerAttributeType:
 			// Convert raw JSON value to the correct Go type based on registry metadata.


### PR DESCRIPTION

Fixes #901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enumeration attributes now accept display names as input values, complementing direct value specifications for greater flexibility.
  * Improved consistency when retrieving enumeration values by automatically matching the format used in your configuration (display names or canonical values).
  * Enhanced error handling and reporting when enumeration values cannot be properly mapped to available options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/metal-operator/pull/902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->