### PR TITLE
Reduce BMC API calls in applyBootOrder for empty spec.bootOrder 

### DIFF
--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -253,9 +253,8 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 	log.V(1).Info("Updated Server status")
 
 	if err := r.applyBootOrder(ctx, bmcClient, server); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update server bios boot order: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to apply server BIOS boot order: %w", err)
 	}
-	log.V(1).Info("Updated Server BIOS boot order")
 
 	_, err = r.ensureServerStateTransition(ctx, bmcClient, server)
 	if err != nil {
@@ -1162,23 +1161,28 @@ func (r *ServerReconciler) applyBootOrder(ctx context.Context, bmcClient bmc.BMC
 		return nil
 	}
 
+	if len(server.Spec.BootOrder) == 0 {
+		return nil
+	}
+
 	order, err := bmcClient.GetBootOrder(ctx, server.Spec.SystemURI)
 	if err != nil {
-		return fmt.Errorf("failed to create BMC client: %w", err)
+		return fmt.Errorf("failed to get boot order: %w", err)
 	}
 
 	sort.Slice(server.Spec.BootOrder, func(i, j int) bool {
 		return server.Spec.BootOrder[i].Priority < server.Spec.BootOrder[j].Priority
 	})
 	newOrder := []string{}
-	change := false
+	change := len(order) != len(server.Spec.BootOrder)
 	for i, boot := range server.Spec.BootOrder {
 		newOrder = append(newOrder, boot.Device)
-		if order[i] != boot.Device {
+		if i >= len(order) || order[i] != boot.Device {
 			change = true
 		}
 	}
 	if change {
+		log.V(1).Info("Applying boot order update", "newOrder", newOrder)
 		return bmcClient.SetBootOrder(ctx, server.Spec.SystemURI, newOrder)
 	}
 	return nil


### PR DESCRIPTION
# Proposed Changes

- skip the BMC GetBootOrder call entirely when spec.bootOrder is empty
- log message should only appear when the boot order is actually modified

Fixes #907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BIOS boot order change detection accuracy when comparing boot order specifications and device values.
  * Optimized boot order application to skip unnecessary operations when specifications are empty.
  * Enhanced error messages for clearer feedback during boot order operation failures.
  * Added detailed logging to assist with debugging boot order update operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/metal-operator/pull/911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->