### PR TITLE
Fix BMC user creation HTTP 405 error

### DIFF
--- a/bmc/mock/server/data/AccountService/Accounts/3/index.json
+++ b/bmc/mock/server/data/AccountService/Accounts/3/index.json
@@ -1,0 +1,28 @@
+{
+    "@odata.type": "#ManagerAccount.v1_12_0.ManagerAccount",
+    "Id": "3",
+    "Name": "Empty Account Slot",
+    "Description": "Empty account slot available for creation",
+    "Enabled": false,
+    "Password": null,
+    "PasswordChangeRequired": false,
+    "PasswordExpiration": null,
+    "AccountTypes": [
+        "Redfish"
+    ],
+    "UserName": "",
+    "RoleId": "",
+    "Locked": false,
+    "Links": {
+        "Role": {
+            "@odata.id": ""
+        }
+    },
+    "Actions": {
+        "#ManagerAccount.ChangePassword": {
+            "target": "/redfish/v1/AccountService/Accounts/3/Actions/ManagerAccount.ChangePassword"
+        }
+    },
+    "@odata.id": "/redfish/v1/AccountService/Accounts/3",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/bmc/mock/server/data/AccountService/Accounts/4/index.json
+++ b/bmc/mock/server/data/AccountService/Accounts/4/index.json
@@ -1,0 +1,28 @@
+{
+    "@odata.type": "#ManagerAccount.v1_12_0.ManagerAccount",
+    "Id": "4",
+    "Name": "Empty Account Slot",
+    "Description": "Empty account slot available for creation",
+    "Enabled": false,
+    "Password": null,
+    "PasswordChangeRequired": false,
+    "PasswordExpiration": null,
+    "AccountTypes": [
+        "Redfish"
+    ],
+    "UserName": "",
+    "RoleId": "",
+    "Locked": false,
+    "Links": {
+        "Role": {
+            "@odata.id": ""
+        }
+    },
+    "Actions": {
+        "#ManagerAccount.ChangePassword": {
+            "target": "/redfish/v1/AccountService/Accounts/4/Actions/ManagerAccount.ChangePassword"
+        }
+    },
+    "@odata.id": "/redfish/v1/AccountService/Accounts/4",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/bmc/mock/server/data/AccountService/Accounts/5/index.json
+++ b/bmc/mock/server/data/AccountService/Accounts/5/index.json
@@ -1,0 +1,28 @@
+{
+    "@odata.type": "#ManagerAccount.v1_12_0.ManagerAccount",
+    "Id": "5",
+    "Name": "Empty Account Slot",
+    "Description": "Empty account slot available for creation",
+    "Enabled": false,
+    "Password": null,
+    "PasswordChangeRequired": false,
+    "PasswordExpiration": null,
+    "AccountTypes": [
+        "Redfish"
+    ],
+    "UserName": "",
+    "RoleId": "",
+    "Locked": false,
+    "Links": {
+        "Role": {
+            "@odata.id": ""
+        }
+    },
+    "Actions": {
+        "#ManagerAccount.ChangePassword": {
+            "target": "/redfish/v1/AccountService/Accounts/5/Actions/ManagerAccount.ChangePassword"
+        }
+    },
+    "@odata.id": "/redfish/v1/AccountService/Accounts/5",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/bmc/mock/server/data/AccountService/Accounts/index.json
+++ b/bmc/mock/server/data/AccountService/Accounts/index.json
@@ -1,13 +1,22 @@
 {
     "@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
     "Name": "Accounts Collection",
-    "Members@odata.count": 2,
+    "Members@odata.count": 5,
     "Members": [
         {
             "@odata.id": "/redfish/v1/AccountService/Accounts/1"
         },
         {
             "@odata.id": "/redfish/v1/AccountService/Accounts/2"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/3"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/4"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/5"
         }
     ],
     "@odata.id": "/redfish/v1/AccountService/Accounts",

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"maps"
 	"math/big"
+	"net/http"
 	"net/url"
 	"slices"
 	"strings"
@@ -796,11 +797,53 @@ func (r *RedfishBaseBMC) CreateOrUpdateAccount(
 			return nil
 		}
 	}
-	_, err = service.CreateAccount(userName, password, role)
-	if err != nil {
-		return fmt.Errorf("failed to create account: %w", err)
+
+	// Try standard Redfish POST method first (per Redfish spec)
+	account, err := service.CreateAccount(userName, password, role)
+	if err == nil {
+		// POST succeeded - but CreateAccount always sets Enabled=true
+		// If caller requested enabled=false, we need to update it
+		if !enabled && account != nil {
+			account.Enabled = false
+			if err := account.Update(); err != nil {
+				return fmt.Errorf("failed to disable account after creation: %w", err)
+			}
+		}
+		return nil
 	}
-	return nil
+
+	// Check if error is HTTP 405 (Method Not Allowed)
+	// If so, fall back to empty-slot PATCH approach.
+	// Many BMC vendors (Dell, HPE, Lenovo, etc.) don't support POST to /AccountService/Accounts
+	// but do support PATCH to individual pre-allocated account slots.
+	var redfishErr *schemas.Error
+	if errors.As(err, &redfishErr) && redfishErr.HTTPReturnedStatusCode == http.StatusMethodNotAllowed {
+		// HTTP 405 received - try empty-slot PATCH approach as fallback
+		for _, a := range accounts {
+			// Check if slot is truly empty (no username set)
+			// Do NOT reuse disabled accounts - they are real accounts that are just disabled
+			if a.UserName == "" {
+				// PATCH this slot with new account data including password in one call
+				a.UserName = userName
+				a.RoleID = role
+				a.Enabled = enabled
+				a.Password = password
+
+				// Apply all changes via single PATCH
+				if err := a.Update(); err != nil {
+					return fmt.Errorf("failed to create account via PATCH on slot %s: %w", a.ID, err)
+				}
+
+				return nil
+			}
+		}
+
+		// No empty slots available for fallback method
+		return fmt.Errorf("failed to create account: POST method not supported (HTTP 405) and no available account slots found (all %d slots occupied)", len(accounts))
+	}
+
+	// For non-405 errors, return immediately (e.g., auth failure, network issue, etc.)
+	return fmt.Errorf("failed to create account: %w", err)
 }
 
 func (r *RedfishBaseBMC) DeleteAccount(ctx context.Context, userName, id string) error {


### PR DESCRIPTION
# Fixes

- Try POST first, fall back to PATCH on HTTP 405 for vendor compatibility
  -  Dell for example does not allow to create users via POST, instead one needs to PATCH one of the existing user slots.
- Use single PATCH call to set username, role, password, and enabled state
- Add empty account slots to mock server for testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added three new empty account slots to mock account service test data for enhanced testing coverage
  * Enhanced account creation robustness by implementing fallback mechanism to utilize available account slots when standard creation method becomes unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->