### PR TITLE
Implement reclaim state and policy

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/serverspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/serverspec.go
@@ -23,6 +23,12 @@ type ServerSpecApplyConfiguration struct {
 	Power *apiv1alpha1.Power `json:"power,omitempty"`
 	// IndicatorLED specifies the desired state of the server's indicator LED.
 	IndicatorLED *apiv1alpha1.IndicatorLED `json:"indicatorLED,omitempty"`
+	// ReclaimPolicy specifies how the server is reclaimed after use.
+	// Can be
+	// * Recycle (default), immediately transitioning the server to `Available` after use.
+	// * Retain, transitioning the server to `Released` after use, leaving `spec.serverClaimRef` set,
+	// transitioning to `Available` once `spec.serverClaimRef` is removed.
+	ReclaimPolicy *apiv1alpha1.ServerReclaimPolicy `json:"reclaimPolicy,omitempty"`
 	// ServerClaimRef is a reference to a ServerClaim object that claims this server.
 	ServerClaimRef *ImmutableObjectReferenceApplyConfiguration `json:"serverClaimRef,omitempty"`
 	// ServerMaintenanceRef is a reference to a ServerMaintenance object that maintains this server.
@@ -81,6 +87,14 @@ func (b *ServerSpecApplyConfiguration) WithPower(value apiv1alpha1.Power) *Serve
 // If called multiple times, the IndicatorLED field is set to the value of the last call.
 func (b *ServerSpecApplyConfiguration) WithIndicatorLED(value apiv1alpha1.IndicatorLED) *ServerSpecApplyConfiguration {
 	b.IndicatorLED = &value
+	return b
+}
+
+// WithReclaimPolicy sets the ReclaimPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ReclaimPolicy field is set to the value of the last call.
+func (b *ServerSpecApplyConfiguration) WithReclaimPolicy(value apiv1alpha1.ServerReclaimPolicy) *ServerSpecApplyConfiguration {
+	b.ReclaimPolicy = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -1191,6 +1191,8 @@ var schemaYAML = typed.YAMLObject(`types:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.ServerMaintenanceState
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.ServerPowerState
   scalar: string
+- name: com.github.ironcore-dev.metal-operator.api.v1alpha1.ServerReclaimPolicy
+  scalar: string
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.ServerSpec
   map:
     fields:
@@ -1221,6 +1223,10 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: power
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.Power
+    - name: reclaimPolicy
+      type:
+        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.ServerReclaimPolicy
+      default: Recycle
     - name: serverClaimRef
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.ImmutableObjectReference

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -82,6 +82,13 @@ type BootOrder struct {
 	Device string `json:"device"`
 }
 
+type ServerReclaimPolicy string
+
+const (
+	ServerReclaimPolicyRecycle ServerReclaimPolicy = "Recycle"
+	ServerReclaimPolicyRetain  ServerReclaimPolicy = "Retain"
+)
+
 // ServerSpec defines the desired state of a Server.
 type ServerSpec struct {
 	// SystemUUID is the unique identifier for the server.
@@ -98,6 +105,15 @@ type ServerSpec struct {
 	// IndicatorLED specifies the desired state of the server's indicator LED.
 	// +optional
 	IndicatorLED IndicatorLED `json:"indicatorLED,omitempty"`
+
+	// ReclaimPolicy specifies how the server is reclaimed after use.
+	// Can be
+	// * Recycle (default), immediately transitioning the server to `Available` after use.
+	// * Retain, transitioning the server to `Released` after use, leaving `spec.serverClaimRef` set,
+	//   transitioning to `Available` once `spec.serverClaimRef` is removed.
+	// +kubebuilder:default=Recycle
+	// +kubebuilder:validation:Enum=Recycle;Retain
+	ReclaimPolicy ServerReclaimPolicy `json:"reclaimPolicy,omitempty"`
 
 	// ServerClaimRef is a reference to a ServerClaim object that claims this server.
 	// +kubebuilder:validation:Optional
@@ -155,6 +171,9 @@ const (
 
 	// ServerStateReserved indicates that the server is reserved for a specific use or user.
 	ServerStateReserved ServerState = "Reserved"
+
+	// ServerStateReleased indicates that the server is released after use.
+	ServerStateReleased ServerState = "Released"
 
 	// ServerStateError indicates that there is an error with the server.
 	ServerStateError ServerState = "Error"

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -208,6 +208,18 @@ spec:
               power:
                 description: Power specifies the desired power state of the server.
                 type: string
+              reclaimPolicy:
+                default: Recycle
+                description: |-
+                  ReclaimPolicy specifies how the server is reclaimed after use.
+                  Can be
+                  * Recycle (default), immediately transitioning the server to `Available` after use.
+                  * Retain, transitioning the server to `Released` after use, leaving `spec.serverClaimRef` set,
+                    transitioning to `Available` once `spec.serverClaimRef` is removed.
+                enum:
+                - Recycle
+                - Retain
+                type: string
               serverClaimRef:
                 description: ServerClaimRef is a reference to a ServerClaim object
                   that claims this server.

--- a/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
@@ -214,6 +214,18 @@ spec:
               power:
                 description: Power specifies the desired power state of the server.
                 type: string
+              reclaimPolicy:
+                default: Recycle
+                description: |-
+                  ReclaimPolicy specifies how the server is reclaimed after use.
+                  Can be
+                  * Recycle (default), immediately transitioning the server to `Available` after use.
+                  * Retain, transitioning the server to `Released` after use, leaving `spec.serverClaimRef` set,
+                    transitioning to `Available` once `spec.serverClaimRef` is removed.
+                enum:
+                - Recycle
+                - Retain
+                type: string
               serverClaimRef:
                 description: ServerClaimRef is a reference to a ServerClaim object
                   that claims this server.

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1656,6 +1656,23 @@ _Appears in:_
 | `PoweringOff` | ServerPoweringOffPowerState indicates a temporary state between On and Off.<br />The power off action can take time while the OS is in the shutdown process.<br /> |
 
 
+#### ServerReclaimPolicy
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [ServerSpec](#serverspec)
+
+| Field | Description |
+| --- | --- |
+| `Recycle` |  |
+| `Retain` |  |
+
+
 #### ServerSpec
 
 
@@ -1673,6 +1690,7 @@ _Appears in:_
 | `systemURI` _string_ | SystemURI is the unique URI for the server resource in REDFISH API. |  |  |
 | `power` _[Power](#power)_ | Power specifies the desired power state of the server. |  |  |
 | `indicatorLED` _[IndicatorLED](#indicatorled)_ | IndicatorLED specifies the desired state of the server's indicator LED. |  |  |
+| `reclaimPolicy` _[ServerReclaimPolicy](#serverreclaimpolicy)_ | ReclaimPolicy specifies how the server is reclaimed after use.<br />Can be<br />* Recycle (default), immediately transitioning the server to `Available` after use.<br />* Retain, transitioning the server to `Released` after use, leaving `spec.serverClaimRef` set,<br />  transitioning to `Available` once `spec.serverClaimRef` is removed. | Recycle | Enum: [Recycle Retain] <br /> |
 | `serverClaimRef` _[ImmutableObjectReference](#immutableobjectreference)_ | ServerClaimRef is a reference to a ServerClaim object that claims this server. |  | Optional: \{\} <br /> |
 | `serverMaintenanceRef` _[ObjectReference](#objectreference)_ | ServerMaintenanceRef is a reference to a ServerMaintenance object that maintains this server. |  |  |
 | `bmcRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCRef is a reference to the BMC object associated with this server. |  |  |
@@ -1701,6 +1719,7 @@ _Appears in:_
 | `Discovery` | ServerStateDiscovery indicates that the server is in its discovery state.<br /> |
 | `Available` | ServerStateAvailable indicates that the server is available for use.<br /> |
 | `Reserved` | ServerStateReserved indicates that the server is reserved for a specific use or user.<br /> |
+| `Released` | ServerStateReleased indicates that the server is released after use.<br /> |
 | `Error` | ServerStateError indicates that there is an error with the server.<br /> |
 | `Maintenance` | ServerStateMaintenance indicates that the server is in maintenance.<br /> |
 

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -250,7 +251,6 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 	if err := r.updateServerStatus(ctx, bmcClient, server); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update server status: %w", err)
 	}
-	log.V(1).Info("Updated Server status")
 
 	if err := r.applyBootOrder(ctx, bmcClient, server); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to apply server BIOS boot order: %w", err)
@@ -308,6 +308,8 @@ func (r *ServerReconciler) ensureServerStateTransition(ctx context.Context, bmcC
 		return r.handleAvailableState(ctx, bmcClient, server)
 	case metalv1alpha1.ServerStateReserved:
 		return r.handleReservedState(ctx, bmcClient, server)
+	case metalv1alpha1.ServerStateReleased:
+		return r.handleReleasedState(ctx, bmcClient, server)
 	case metalv1alpha1.ServerStateMaintenance:
 		return r.handleMaintenanceState(ctx, bmcClient, server)
 	default:
@@ -467,33 +469,44 @@ func (r *ServerReconciler) handleAvailableState(ctx context.Context, bmcClient b
 
 func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	// TODO: This needs be reworked later as the Server cleanup has to happen here. For now we just transition the server
-	// 		 back to available state.
-	if server.Spec.ServerClaimRef == nil {
+	serverClaimRef := server.Spec.ServerClaimRef
+	if serverClaimRef == nil {
 		if modified, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateAvailable); err != nil || modified {
 			return true, err
 		}
 	}
 
-	// TODO: fix properly, we need to free up the server if the claim does not exist anymore
+	log = log.WithValues("ServerClaimRef", serverClaimRef)
+
 	claim := &metalv1alpha1.ServerClaim{}
-	err := r.Get(ctx, client.ObjectKey{
+	claimKey := client.ObjectKey{
 		Name:      server.Spec.ServerClaimRef.Name,
-		Namespace: server.Spec.ServerClaimRef.Namespace}, claim)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.V(1).Info(
-				"ServerClaim not found, removing ServerClaimRef",
-				"Server", server.Name,
-				"ServerClaim", server.Spec.ServerClaimRef.Name)
+		Namespace: server.Spec.ServerClaimRef.Namespace,
+	}
+	if err := r.Get(ctx, claimKey, claim); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("getting server claim %s: %w", claimKey, err)
+		}
+
+		if modified, err := r.ensureServerPoweredOffWithoutBootConfig(ctx, bmcClient, server); err != nil || modified {
+			return modified, err
+		}
+
+		switch server.Spec.ReclaimPolicy {
+		case metalv1alpha1.ServerReclaimPolicyRetain:
+			log.V(1).Info("Transitioning server to released state")
+			return r.patchServerState(ctx, server, metalv1alpha1.ServerStateReleased)
+		case metalv1alpha1.ServerReclaimPolicyRecycle:
+			log.V(1).Info("Server claim not found, releasing server")
 			serverBase := server.DeepCopy()
 			server.Spec.ServerClaimRef = nil
 			if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
 				return false, fmt.Errorf("failed to remove ServerClaimRef: %w", err)
 			}
 			return false, nil
+		default:
+			return false, reconcile.TerminalError(fmt.Errorf("unknown reclaim policy %q", server.Spec.ReclaimPolicy))
 		}
-		return false, fmt.Errorf("failed to get ServerClaim: %w", err)
 	}
 
 	if ready, err := r.serverBootConfigurationIsReady(ctx, server); err != nil || !ready {
@@ -518,6 +531,41 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bm
 	}
 	log.V(1).Info("Reconciled reserved state")
 	return true, nil
+}
+
+func (r *ServerReconciler) ensureServerPoweredOffWithoutBootConfig(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (modified bool, err error) {
+	if server.Spec.Power == metalv1alpha1.PowerOff && server.Spec.BootConfigurationRef == nil {
+		return false, nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	log.V(1).Info("Server claim is gone, powering off server and removing boot configuration")
+	base := server.DeepCopy()
+	server.Spec.Power = metalv1alpha1.PowerOff
+	server.Spec.BootConfigurationRef = nil
+	if err := r.Patch(ctx, server, client.MergeFrom(base)); err != nil {
+		return false, fmt.Errorf("failed to update server power state: %w", err)
+	}
+	if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
+		return true, fmt.Errorf("failed to power off server after claim deletion: %w", err)
+	}
+	return true, nil
+}
+
+func (r *ServerReconciler) handleReleasedState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	if modified, err := r.ensureServerPoweredOffWithoutBootConfig(ctx, bmcClient, server); err != nil || modified {
+		return modified, err
+	}
+
+	if serverClaimRef := server.Spec.ServerClaimRef; serverClaimRef != nil {
+		log.V(1).Info("ServerClaimRef still present, nothing to do", "ServerClaimRef", serverClaimRef)
+		return false, nil
+	}
+
+	log.V(1).Info("ServerClaimRef is gone, transitioning server to available state")
+	return r.patchServerState(ctx, server, metalv1alpha1.ServerStateAvailable)
 }
 
 func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
@@ -561,9 +609,17 @@ func (r *ServerReconciler) updateServerStatus(ctx context.Context, bmcClient bmc
 	if err != nil {
 		return fmt.Errorf("failed to get system info for Server: %w", err)
 	}
+
+	updatedPowerState := metalv1alpha1.ServerPowerState(systemInfo.PowerState)
+	updatedIndicatorLED := metalv1alpha1.IndicatorLED(systemInfo.IndicatorLED)
+
+	if updatedPowerState == server.Status.PowerState && updatedIndicatorLED == server.Status.IndicatorLED {
+		return nil
+	}
+
 	serverBase := server.DeepCopy()
-	server.Status.PowerState = metalv1alpha1.ServerPowerState(systemInfo.PowerState)
-	server.Status.IndicatorLED = metalv1alpha1.IndicatorLED(systemInfo.IndicatorLED)
+	server.Status.PowerState = updatedPowerState
+	server.Status.IndicatorLED = updatedIndicatorLED
 	if err = r.Status().Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
 		return fmt.Errorf("failed to patch Server status: %w", err)
 	}

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -37,6 +37,95 @@ var _ = Describe("Server Controller", func() {
 		EnsureCleanState()
 	})
 
+	It("should transition a server to released state and back to available", func(ctx SpecContext) {
+		By("Creating a BMCSecret")
+		bmcSecret := &metalv1alpha1.BMCSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-server-",
+			},
+			Data: map[string][]byte{
+				"username": []byte("foo"),
+				"password": []byte("bar"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+		By("Creating a Server with inline BMC configuration")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "server-",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "38947555-7742-3448-3784-823347823834",
+				BMC: &metalv1alpha1.BMCAccess{
+					Protocol: metalv1alpha1.Protocol{
+						Name: metalv1alpha1.ProtocolRedfishLocal,
+						Port: MockServerPort,
+					},
+					Address: MockServerIP,
+					BMCSecretRef: v1.LocalObjectReference{
+						Name: bmcSecret.Name,
+					},
+				},
+				ReclaimPolicy: metalv1alpha1.ServerReclaimPolicyRetain,
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+
+		By("Updating the Server to available state")
+		Eventually(UpdateStatus(server, func() {
+			server.Status.State = metalv1alpha1.ServerStateAvailable
+		})).Should(Succeed())
+
+		By("creating a server claim")
+		claim := &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-claim",
+				Namespace: ns.Name,
+			},
+			Spec: metalv1alpha1.ServerClaimSpec{
+				ServerRef: &v1.LocalObjectReference{
+					Name: server.Name,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, claim)).To(Succeed())
+
+		By("waiting for the server to be reserved")
+		claimRef := metalv1alpha1.ImmutableObjectReference{
+			Namespace: claim.Namespace,
+			Name:      claim.Name,
+		}
+		Eventually(Object(server)).To(SatisfyAll(
+			HaveField("Spec.ServerClaimRef", Equal(&claimRef)),
+			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
+		))
+
+		By("deleting the server claim")
+		Expect(k8sClient.Delete(ctx, claim)).To(Succeed())
+
+		By("waiting for the server claim to be gone")
+		Eventually(Get(claim)).To(Satisfy(apierrors.IsNotFound))
+
+		By("waiting for the server be released")
+		Eventually(Object(server)).To(SatisfyAll(
+			HaveField("Spec.ServerClaimRef", &claimRef),
+			HaveField("Status.State", metalv1alpha1.ServerStateReleased),
+		))
+
+		By("deleting the claim ref of the server")
+		Eventually(Update(server, func() {
+			server.Spec.ServerClaimRef = nil
+		})).To(Succeed())
+
+		By("waiting for the server to be available again")
+		Eventually(Object(server)).To(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+		// cleanup
+		Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
+	})
+
 	It("should initialize a Server from Endpoint", func(ctx SpecContext) {
 		By("Creating an Endpoint object")
 		endpoint := &metalv1alpha1.Endpoint{

--- a/internal/controller/serverclaim_controller.go
+++ b/internal/controller/serverclaim_controller.go
@@ -97,12 +97,6 @@ func (r *ServerClaimReconciler) cleanupAndShutdownServer(ctx context.Context, cl
 		log.V(1).Info("Server gone")
 	}
 
-	if server.Spec.ServerClaimRef != nil {
-		if err := r.removeClaimRefFromServer(ctx, server); err != nil {
-			return fmt.Errorf("failed to remove claim ref from server: %w", err)
-		}
-	}
-
 	config := &metalv1alpha1.ServerBootConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      claim.Name,
@@ -116,10 +110,6 @@ func (r *ServerClaimReconciler) cleanupAndShutdownServer(ctx context.Context, cl
 		log.V(1).Info("ServerBootConfiguration gone")
 	}
 
-	if err := r.removeBootConfigRefFromServerAndPowerOff(ctx, config, server); err != nil {
-		return fmt.Errorf("failed to remove boot config ref from server: %w", err)
-	}
-	log.V(1).Info("Removed boot config ref from server")
 	return nil
 }
 
@@ -276,26 +266,6 @@ func (r *ServerClaimReconciler) applyBootConfiguration(ctx context.Context, serv
 		Name:      config.Name,
 	}
 	return r.Patch(ctx, server, client.MergeFrom(serverBase))
-}
-
-func (r *ServerClaimReconciler) removeClaimRefFromServer(ctx context.Context, server *metalv1alpha1.Server) error {
-	serverBase := server.DeepCopy()
-	server.Spec.ServerClaimRef = nil
-	return r.Patch(ctx, server, client.MergeFrom(serverBase))
-}
-
-func (r *ServerClaimReconciler) removeBootConfigRefFromServerAndPowerOff(ctx context.Context, config *metalv1alpha1.ServerBootConfiguration, server *metalv1alpha1.Server) error {
-	if ref := server.Spec.BootConfigurationRef; ref == nil || (ref.Name != config.Name && ref.Namespace != config.Namespace) {
-		return nil
-	}
-
-	serverBase := server.DeepCopy()
-	server.Spec.BootConfigurationRef = nil
-	server.Spec.Power = metalv1alpha1.PowerOff
-	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	return nil
 }
 
 func (r *ServerClaimReconciler) claimServer(ctx context.Context, claim *metalv1alpha1.ServerClaim) (*metalv1alpha1.Server, error) {


### PR DESCRIPTION
# Proposed Changes

* Introduce `reclaimPolicy`, allowing to transition a server to `state: Released` once the corresponding claim is gone.
* Update logic for the claim ref and boot configuration ref removal.
* Add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Servers now support configurable reclaim policies (Recycle/Retain) to control post-release behavior
  * Added new Released server state to represent servers pending recycling

* **Documentation**
  * API reference updated with new ServerReclaimPolicy type and Released state documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->