### PR TITLE
fix cherry-pick.sh pushing to release branch instead of creating a new branch

### DIFF
--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -68,13 +68,13 @@ if ! git cherry-pick -x -m1 "${MERGE_COMMIT}"; then
     echo ""
     echo "Cherry-pick has conflicts. Please resolve them, then run:"
     echo "  git cherry-pick --continue"
-    echo "  git push origin ${CHERRY_PICK_BRANCH}"
+    echo "  git push origin ${CHERRY_PICK_BRANCH}:${CHERRY_PICK_BRANCH}"
     echo "  gh pr create --base ${RELEASE_BRANCH} --title \"🍒 [${RELEASE_BRANCH}] ${PR_TITLE}\" --body \"Cherry-pick of #${PR_NUMBER} into ${RELEASE_BRANCH}.\""
     exit 1
 fi
 
 # Push and create PR
-git push origin "${CHERRY_PICK_BRANCH}"
+git push origin "${CHERRY_PICK_BRANCH}:${CHERRY_PICK_BRANCH}"
 gh pr create \
     --base "${RELEASE_BRANCH}" \
     --title "🍒 [${RELEASE_BRANCH}] ${PR_TITLE}" \


### PR DESCRIPTION
git switch -c <branch> origin/<release> sets the upstream to origin/<release>, causing git push origin <branch> to push directly to the release branch. Use an explicit src:dst refspec to always create the correct remote branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cherry-pick workflow for enhanced conflict handling and refined release pull request creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->