### PR TITLE
IEP-18: Add metaldata component and add `UserData` to `ServerClaim`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN go mod download
 # Copy the go source
 COPY cmd/main.go cmd/main.go
 COPY cmd/metalprobe/main.go cmd/metalprobe/main.go
+COPY cmd/metaldata/main.go cmd/metaldata/main.go
 COPY api/ api/
 COPY internal/ internal/
 COPY bmc/ bmc/
@@ -33,6 +34,11 @@ FROM builder AS probe-builder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o metalprobe cmd/metalprobe/main.go
+
+FROM builder AS metaldata-builder
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o metaldata cmd/metaldata/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
@@ -67,3 +73,10 @@ WORKDIR /
 COPY --from=mock-builder /workspace/mock-server .
 USER 65532:65532
 ENTRYPOINT ["/mock-server"]
+
+FROM gcr.io/distroless/static:nonroot AS metaldata
+LABEL source_repository="https://github.com/ironcore-dev/metal-operator"
+WORKDIR /
+COPY --from=metaldata-builder /workspace/metaldata .
+USER 65532:65532
+ENTRYPOINT ["/metaldata"]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 CONTROLLER_IMG ?= controller:latest
 METALPROBE_IMG ?= metalprobe:latest
 BMCTOOLS_IMG   ?= bmctools:latest
+METALDATA_IMG  ?= metaldata:latest
 
 # Docker image name for the mkdocs based local development setup
 IMAGE=ironcore-dev/metal-operator-docs
@@ -180,7 +181,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: docker-build-controller-manager docker-build-metalprobe
+docker-build: docker-build-controller-manager docker-build-metalprobe docker-build-metaldata
 
 .PHONY: docker-build-controller-manager
 docker-build-controller-manager: ## Build controller-manager.
@@ -194,11 +195,16 @@ docker-build-metalprobe: ## Build metalprobe.
 docker-build-bmctools: ## Build bmctools.
 	docker build --target bmctools -t ${BMCTOOLS_IMG} .
 
+.PHONY: docker-build-metaldata
+docker-build-metaldata: ## Build metaldata.
+	docker build --target metaldata -t ${METALDATA_IMG} .
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${CONTROLLER_IMG}
 	$(CONTAINER_TOOL) push ${METALPROBE_IMG}
 	$(CONTAINER_TOOL) push ${BMCTOOLS_IMG}
+	$(CONTAINER_TOOL) push ${METALDATA_IMG}
 
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/serverclaimspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/serverclaimspec.go
@@ -25,6 +25,10 @@ type ServerClaimSpecApplyConfiguration struct {
 	// IgnitionSecretRef is a reference to the Secret object that contains
 	// the ignition configuration for the server.
 	IgnitionSecretRef *v1.LocalObjectReference `json:"ignitionSecretRef,omitempty"`
+	// UserDataRef references a Secret in the same namespace as this ServerClaim
+	// containing user-data exposed to the claimed server via the metaldata
+	// service. The referenced Secret must be of type metal.ironcore.dev/user-data.
+	UserDataRef *v1.LocalObjectReference `json:"userDataRef,omitempty"`
 	// Image specifies the boot image to be used for the server.
 	Image *string `json:"image,omitempty"`
 	// Tolerations allow a ServerClaim to bind to a Server with matching taints.
@@ -66,6 +70,14 @@ func (b *ServerClaimSpecApplyConfiguration) WithServerSelector(value *metav1.Lab
 // If called multiple times, the IgnitionSecretRef field is set to the value of the last call.
 func (b *ServerClaimSpecApplyConfiguration) WithIgnitionSecretRef(value v1.LocalObjectReference) *ServerClaimSpecApplyConfiguration {
 	b.IgnitionSecretRef = &value
+	return b
+}
+
+// WithUserDataRef sets the UserDataRef field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the UserDataRef field is set to the value of the last call.
+func (b *ServerClaimSpecApplyConfiguration) WithUserDataRef(value v1.LocalObjectReference) *ServerClaimSpecApplyConfiguration {
+	b.UserDataRef = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -1141,6 +1141,9 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.Toleration
           elementRelationship: atomic
+    - name: userDataRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.ServerClaimStatus
   map:
     fields:

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -3,7 +3,11 @@
 
 package v1alpha1
 
-import "github.com/stmcginnis/gofish/schemas"
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/stmcginnis/gofish/schemas"
+)
 
 // establishing general rule for constants naming for Annotations
 // "Key" for Annotation constants should be named OperationAnnotation.
@@ -51,7 +55,22 @@ const (
 
 	// OperationAnnotationRotateCredentials is used to indicate that credentials should be rotated.
 	OperationAnnotationRotateCredentials = "rotate-credentials"
+
+	// MetadataKeyPrefix is the shared prefix for labels and annotations on a Server
+	// whose suffix is exposed via the metaldata service to the booted server.
+	MetadataKeyPrefix = "metadata.metal.ironcore.dev/"
+
+	// MetadataFlavorHeader is the HTTP header the metaldata service requires on
+	// every request, mirroring GCE/GCP metadata server conventions.
+	MetadataFlavorHeader = "Metadata-Flavor"
+
+	// MetadataFlavorValue is the expected value for MetadataFlavorHeader.
+	MetadataFlavorValue = "IronCore Metal"
 )
+
+// SecretTypeUserData is the Secret type required for Secrets referenced by
+// ServerClaim.Spec.UserDataRef.
+const SecretTypeUserData v1.SecretType = "metal.ironcore.dev/user-data"
 
 const (
 	// GracefulShutdownServerPower indicates to gracefully restart the baremetal server power.

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -21,16 +21,16 @@ const (
 	PowerOff Power = "Off"
 
 	// LabelLocation is the label key for the user-defined location identifier (e.g. FRA-DC5-3F).
-	LabelLocation = "metadata.metal.ironcore.dev/location"
+	LabelLocation = MetadataKeyPrefix + "location"
 
 	// LabelRack is the label key for the opaque rack identifier within a location.
-	LabelRack = "metadata.metal.ironcore.dev/rack"
+	LabelRack = MetadataKeyPrefix + "rack"
 
 	// LabelShelf is the label key for the position within the rack (bottom-up U number).
-	LabelShelf = "metadata.metal.ironcore.dev/shelf"
+	LabelShelf = MetadataKeyPrefix + "shelf"
 
 	// LabelHeight is the label key for the device height in rack units (U).
-	LabelHeight = "metadata.metal.ironcore.dev/height"
+	LabelHeight = MetadataKeyPrefix + "height"
 )
 
 // ServerPowerState defines the possible power states for a server.

--- a/api/v1alpha1/serverclaim_types.go
+++ b/api/v1alpha1/serverclaim_types.go
@@ -34,6 +34,12 @@ type ServerClaimSpec struct {
 	// +optional
 	IgnitionSecretRef *v1.LocalObjectReference `json:"ignitionSecretRef,omitempty"`
 
+	// UserDataRef references a Secret in the same namespace as this ServerClaim
+	// containing user-data exposed to the claimed server via the metaldata
+	// service. The referenced Secret must be of type metal.ironcore.dev/user-data.
+	// +optional
+	UserDataRef *v1.LocalObjectReference `json:"userDataRef,omitempty"`
+
 	// Image specifies the boot image to be used for the server.
 	// +required
 	Image string `json:"image"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1875,6 +1875,11 @@ func (in *ServerClaimSpec) DeepCopyInto(out *ServerClaimSpec) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
+	if in.UserDataRef != nil {
+		in, out := &in.UserDataRef, &out.UserDataRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]Toleration, len(*in))

--- a/cmd/metaldata/main.go
+++ b/cmd/metaldata/main.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	"github.com/ironcore-dev/metal-operator/internal/metaldata"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(metalv1alpha1.AddToScheme(scheme))
+}
+
+// stringMapFlag is a flag.Value that accumulates repeated key=value pairs.
+type stringMapFlag map[string]string
+
+func (m *stringMapFlag) String() string {
+	if m == nil || *m == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(*m))
+	for k := range *m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, k+"="+(*m)[k])
+	}
+	return strings.Join(pairs, ",")
+}
+
+func (m *stringMapFlag) Set(s string) error {
+	k, v, ok := strings.Cut(s, "=")
+	if !ok {
+		return fmt.Errorf("expected key=value, got %q", s)
+	}
+	if *m == nil {
+		*m = make(stringMapFlag)
+	}
+	(*m)[k] = v
+	return nil
+}
+
+func main() {
+	os.Exit(Main())
+}
+
+func Main() int {
+	var (
+		listenPort         int
+		metricsBindAddress string
+		healthBindAddress  string
+		staticMetadata     stringMapFlag
+	)
+
+	flag.IntVar(&listenPort, "metaldata-port", 10002, "The port the metadata HTTP server listens on.")
+	flag.StringVar(&metricsBindAddress, "metrics-bind-address", ":8080",
+		"The address the metrics endpoint binds to. Use \"0\" to disable.")
+	flag.StringVar(&healthBindAddress, "health-probe-bind-address", ":8081",
+		"The address the health probe endpoint binds to. Use \"0\" to disable.")
+	flag.Var(&staticMetadata, "static-metadata",
+		"Static metadata key=value pair exposed to all servers. May be repeated.")
+
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	for _, reserved := range []string{"server-name", "user-data"} {
+		if _, ok := staticMetadata[reserved]; ok {
+			setupLog.Error(nil, "Reserved static-metadata key", "key", reserved)
+			return 1
+		}
+	}
+
+	// metaldata is a stateless HTTP service; deploy multiple replicas and
+	// rely on a Service for HA. Leader election is intentionally disabled.
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		LeaderElection:         false,
+		HealthProbeBindAddress: healthBindAddress,
+		Metrics: metricsserver.Options{
+			BindAddress: metricsBindAddress,
+		},
+	})
+	if err != nil {
+		setupLog.Error(err, "Failed to create manager")
+		return 1
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "Failed to add healthz check")
+		return 1
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "Failed to add readyz check")
+		return 1
+	}
+
+	idx := metaldata.NewIndex(ctrl.Log.WithName("index"), staticMetadata)
+
+	informer, err := mgr.GetCache().GetInformer(context.Background(), &metalv1alpha1.Server{})
+	if err != nil {
+		setupLog.Error(err, "Failed to get Server informer")
+		return 1
+	}
+	if _, err := informer.AddEventHandler(idx.EventHandler()); err != nil {
+		setupLog.Error(err, "Failed to add event handler")
+		return 1
+	}
+
+	// ServerClaim and Secret reads happen per /v1/user-data request and bypass
+	// the cache so we don't watch every Secret in the cluster.
+	srv := metaldata.NewServer(ctrl.Log.WithName("http"), idx, mgr.GetAPIReader(), fmt.Sprintf(":%d", listenPort))
+	if err := mgr.Add(srv); err != nil {
+		setupLog.Error(err, "Failed to add HTTP server")
+		return 1
+	}
+
+	setupLog.Info("Starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "Manager exited with error")
+		return 1
+	}
+
+	return 0
+}

--- a/config/crd/bases/metal.ironcore.dev_serverclaims.yaml
+++ b/config/crd/bases/metal.ironcore.dev_serverclaims.yaml
@@ -180,6 +180,23 @@ spec:
                   - key
                   type: object
                 type: array
+              userDataRef:
+                description: |-
+                  UserDataRef references a Secret in the same namespace as this ServerClaim
+                  containing user-data exposed to the claimed server via the metaldata
+                  service. The referenced Secret must be of type metal.ironcore.dev/user-data.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
             required:
             - image
             - power

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ../crd
   - ../rbac
   - ../manager
+  - ../metaldata
   # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
   # crd/kustomization.yaml
   - ../webhook

--- a/config/metaldata/daemonset.yaml
+++ b/config/metaldata/daemonset.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: metaldata
+  namespace: system
+  labels:
+    app.kubernetes.io/name: metal-operator
+    app.kubernetes.io/component: metaldata
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: metal-operator
+      app.kubernetes.io/component: metaldata
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: metal-operator
+        app.kubernetes.io/component: metaldata
+    spec:
+      serviceAccountName: metaldata
+      terminationGracePeriodSeconds: 10
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: metaldata
+        image: metaldata:latest
+        command:
+        - /metaldata
+        ports:
+        - name: http
+          containerPort: 10002
+          protocol: TCP
+        - name: health
+          containerPort: 8081
+          protocol: TCP
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi

--- a/config/metaldata/kustomization.yaml
+++ b/config/metaldata/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- service_account.yaml
+- role.yaml
+- role_binding.yaml
+- service.yaml
+- daemonset.yaml

--- a/config/metaldata/role.yaml
+++ b/config/metaldata/role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metaldata-role
+  labels:
+    app.kubernetes.io/name: metal-operator
+    app.kubernetes.io/component: metaldata
+    app.kubernetes.io/managed-by: kustomize
+rules:
+- apiGroups:
+  - metal.ironcore.dev
+  resources:
+  - servers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metal.ironcore.dev
+  resources:
+  - serverclaims
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/config/metaldata/role_binding.yaml
+++ b/config/metaldata/role_binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metaldata-rolebinding
+  labels:
+    app.kubernetes.io/name: metal-operator
+    app.kubernetes.io/component: metaldata
+    app.kubernetes.io/managed-by: kustomize
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metaldata-role
+subjects:
+- kind: ServiceAccount
+  name: metaldata
+  namespace: system

--- a/config/metaldata/service.yaml
+++ b/config/metaldata/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: metaldata
+  namespace: system
+  labels:
+    app.kubernetes.io/name: metal-operator
+    app.kubernetes.io/component: metaldata
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector:
+    app.kubernetes.io/name: metal-operator
+    app.kubernetes.io/component: metaldata
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    protocol: TCP

--- a/config/metaldata/service_account.yaml
+++ b/config/metaldata/service_account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metaldata
+  namespace: system
+  labels:
+    app.kubernetes.io/name: metal-operator
+    app.kubernetes.io/component: metaldata
+    app.kubernetes.io/managed-by: kustomize

--- a/dist/chart/templates/crd/metal.ironcore.dev_serverclaims.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_serverclaims.yaml
@@ -186,6 +186,23 @@ spec:
                   - key
                   type: object
                 type: array
+              userDataRef:
+                description: |-
+                  UserDataRef references a Secret in the same namespace as this ServerClaim
+                  containing user-data exposed to the claimed server via the metaldata
+                  service. The referenced Secret must be of type metal.ironcore.dev/user-data.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
             required:
             - image
             - power

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1539,6 +1539,7 @@ _Appears in:_
 | `serverRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | ServerRef is a reference to a specific server to be claimed. |  | Optional: \{\} <br /> |
 | `serverSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta)_ | ServerSelector specifies a label selector to identify the server to be claimed. |  | Optional: \{\} <br /> |
 | `ignitionSecretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | IgnitionSecretRef is a reference to the Secret object that contains<br />the ignition configuration for the server. |  |  |
+| `userDataRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | UserDataRef references a Secret in the same namespace as this ServerClaim<br />containing user-data exposed to the claimed server via the metaldata<br />service. The referenced Secret must be of type metal.ironcore.dev/user-data. |  |  |
 | `image` _string_ | Image specifies the boot image to be used for the server. |  |  |
 | `tolerations` _[Toleration](#toleration) array_ | Tolerations allow a ServerClaim to bind to a Server with matching taints. |  |  |
 

--- a/internal/metaldata/http.go
+++ b/internal/metaldata/http.go
@@ -1,0 +1,331 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metaldata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+)
+
+const (
+	shutdownTimeout = 5 * time.Second
+)
+
+type Server struct {
+	srv      *http.Server
+	listener net.Listener
+	log      logr.Logger
+	ready    chan struct{}
+}
+
+// Ready returns true as soon as the listener has been opened. It does not
+// guarantee that the HTTP server is already running. Once it returns true it is
+// safe to call [Server.Addr].
+func (s *Server) Ready() bool {
+	select {
+	case <-s.ready:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Server) Addr() net.Addr {
+	return s.listener.Addr()
+}
+
+func (s *Server) Start(ctx context.Context) (err error) {
+	s.log.Info("Starting HTTP server", "addr", s.srv.Addr)
+
+	s.listener, err = net.Listen("tcp", s.srv.Addr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", s.srv.Addr, err)
+	}
+
+	close(s.ready)
+
+	errChan := make(chan error, 1)
+	go func() {
+		if err := s.srv.Serve(s.listener); !errors.Is(err, http.ErrServerClosed) {
+			errChan <- fmt.Errorf("HTTP metaldata server Serve: %w", err)
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		s.log.Info("Shutting down HTTP server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := s.srv.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("HTTP server Shutdown: %w", err)
+		}
+		s.log.Info("HTTP server gracefully stopped")
+		return nil
+	case err := <-errChan:
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if shutdownErr := s.srv.Shutdown(shutdownCtx); shutdownErr != nil {
+			s.log.Error(shutdownErr, "Error shutting down HTTP server")
+		}
+		return err
+	}
+}
+
+func NewServer(log logr.Logger, idx *Index, reader client.Reader, addr string) *Server {
+	v1 := &v1Handler{
+		log:    log.WithName("v1"),
+		index:  idx,
+		reader: reader,
+	}
+	v1Mux := http.NewServeMux()
+	v1Mux.HandleFunc("GET /v1/{$}", v1.serveFullMetadata)
+	v1Mux.HandleFunc("GET /v1/user-data", v1.serveUserData)
+	v1Mux.HandleFunc("GET /v1/user-data/{key}", v1.serveUserDataKey)
+	v1Mux.HandleFunc("GET /v1/{field}", v1.serveField)
+
+	mux := http.NewServeMux()
+	mux.Handle("/v1/", metadataFlavorMiddleware(v1Mux))
+
+	return &Server{
+		srv: &http.Server{
+			Addr:    addr,
+			Handler: accessLogger(log.WithName("access"), mux),
+		},
+		log:   log,
+		ready: make(chan struct{}),
+	}
+}
+
+func accessLogger(log logr.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Wrapping the response writer is the only way to capture the status
+		// code from net/http; doing so breaks any handler that relies on
+		// casting the writer to other interfaces. Unwrap mitigates this for
+		// callers that use http.ResponseController, at the cost of losing the
+		// status code recording for that path.
+		rec := &statusRecorder{
+			ResponseWriter: w,
+			statusCode:     http.StatusOK,
+		}
+
+		start := time.Now()
+
+		next.ServeHTTP(rec, r)
+
+		log.Info("Handled request",
+			"client", r.RemoteAddr,
+			"duration", time.Since(start),
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rec.statusCode,
+		)
+	})
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.statusCode = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}
+
+func metadataFlavorMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(metalv1alpha1.MetadataFlavorHeader) != metalv1alpha1.MetadataFlavorValue {
+			http.Error(w, "missing required header: Metadata-Flavor: IronCore Metal", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+type v1Handler struct {
+	log    logr.Logger
+	index  *Index
+	reader client.Reader
+}
+
+// lookupEntry resolves the client's IP to a ServerEntry. On failure it writes
+// an error response (400 or 404) to w and returns false.
+func (h *v1Handler) lookupEntry(w http.ResponseWriter, r *http.Request) (*ServerEntry, bool) {
+	addrPort, err := netip.ParseAddrPort(r.RemoteAddr)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return nil, false
+	}
+	entry, ok := h.index.Lookup(addrPort.Addr())
+	if !ok {
+		http.NotFound(w, r)
+		return nil, false
+	}
+	return entry, true
+}
+
+// buildMetadata returns a mutable copy of the entry's metadata as
+// map[string]any. A copy is needed because callers add the user-data key (a
+// nested map) and because the original map is shared with the index.
+func (h *v1Handler) buildMetadata(entry *ServerEntry) map[string]any {
+	md := make(map[string]any, len(entry.Metadata))
+	for k, v := range entry.Metadata {
+		md[k] = v
+	}
+	return md
+}
+
+// fetchUserData resolves a Server's claimed user-data Secret. It looks up the
+// ServerClaim referenced by the entry, follows its UserDataRef, fetches the
+// Secret, and returns its data. Both reads are direct API calls.
+func (h *v1Handler) fetchUserData(ctx context.Context, claimRef *metalv1alpha1.ImmutableObjectReference) (map[string][]byte, error) {
+	if claimRef == nil {
+		return nil, nil
+	}
+	claim := &metalv1alpha1.ServerClaim{}
+	claimKey := client.ObjectKey{Namespace: claimRef.Namespace, Name: claimRef.Name}
+	if err := h.reader.Get(ctx, claimKey, claim); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		h.log.Error(err, "Failed to fetch ServerClaim", "namespace", claimKey.Namespace, "name", claimKey.Name)
+		return nil, err
+	}
+	if claim.Spec.UserDataRef == nil {
+		return nil, nil
+	}
+
+	secret := &corev1.Secret{}
+	secretKey := client.ObjectKey{Namespace: claim.Namespace, Name: claim.Spec.UserDataRef.Name}
+	if err := h.reader.Get(ctx, secretKey, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		h.log.Error(err, "Failed to fetch user-data Secret", "namespace", secretKey.Namespace, "name", secretKey.Name)
+		return nil, err
+	}
+	if secret.Type != metalv1alpha1.SecretTypeUserData {
+		return nil, fmt.Errorf("wrong secret type for user-data '%s'", secret.Type)
+	}
+	return secret.Data, nil
+}
+
+func userDataToStrings(data map[string][]byte) map[string]string {
+	m := make(map[string]string, len(data))
+	for k, v := range data {
+		m[k] = string(v)
+	}
+	return m
+}
+
+func (h *v1Handler) serveFullMetadata(w http.ResponseWriter, r *http.Request) {
+	entry, ok := h.lookupEntry(w, r)
+	if !ok {
+		return
+	}
+
+	md := h.buildMetadata(entry)
+	userData, err := h.fetchUserData(r.Context(), entry.ClaimRef)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if userData != nil {
+		md["user-data"] = userDataToStrings(userData)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	err = json.NewEncoder(w).Encode(md)
+	if err != nil {
+		h.log.V(1).Info("Failed to encode metadata response", "error", err)
+	}
+}
+
+func (h *v1Handler) serveField(w http.ResponseWriter, r *http.Request) {
+	entry, ok := h.lookupEntry(w, r)
+	if !ok {
+		return
+	}
+
+	field := r.PathValue("field")
+	val, ok := entry.Metadata[field]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = fmt.Fprint(w, val)
+}
+
+func (h *v1Handler) serveUserData(w http.ResponseWriter, r *http.Request) {
+	entry, ok := h.lookupEntry(w, r)
+	if !ok {
+		return
+	}
+
+	userData, err := h.fetchUserData(r.Context(), entry.ClaimRef)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if userData == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	err = json.NewEncoder(w).Encode(userDataToStrings(userData))
+	if err != nil {
+		h.log.V(1).Info("Failed to encode user-data response", "error", err)
+	}
+}
+
+func (h *v1Handler) serveUserDataKey(w http.ResponseWriter, r *http.Request) {
+	entry, ok := h.lookupEntry(w, r)
+	if !ok {
+		return
+	}
+
+	userData, err := h.fetchUserData(r.Context(), entry.ClaimRef)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if userData == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	key := r.PathValue("key")
+	val, ok := userData[key]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(val)
+	if err != nil {
+		h.log.V(1).Info("Failed to send user-data key response", "error", err)
+	}
+}

--- a/internal/metaldata/http_test.go
+++ b/internal/metaldata/http_test.go
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metaldata_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+)
+
+const (
+	flavorHeader = "Metadata-Flavor"
+	flavorValue  = "IronCore Metal"
+
+	testNamespace = "default"
+	testClaimName = "claim-a"
+	testSecretRef = "user-data-a"
+)
+
+var _ = Describe("HTTP server", func() {
+	Describe("metadata-flavor middleware", func() {
+		It("rejects requests without the Metadata-Flavor header", func() {
+			resp, err := http.Get(testServerURL + "/v1/")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(resp.Body.Close)
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("rejects requests with an incorrect Metadata-Flavor value", func() {
+			req, err := http.NewRequest(http.MethodGet, testServerURL+"/v1/", nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set(flavorHeader, "Google")
+
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(resp.Body.Close)
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+		})
+	})
+
+	Describe("when the client IP is not indexed", func() {
+		BeforeEach(func() {
+			reader.reset()
+		})
+
+		It("returns 404 for /v1/", func() {
+			resp := getMetadata("/v1/")
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns 404 for /v1/{field}", func() {
+			resp := getMetadata("/v1/server-name")
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns 404 for /v1/user-data", func() {
+			resp := getMetadata("/v1/user-data")
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Describe("when the client IP is indexed", func() {
+		var server *metalv1alpha1.Server
+
+		BeforeEach(func() {
+			server = newServer("server-loopback", "127.0.0.1")
+			server.Labels = map[string]string{
+				metalv1alpha1.MetadataKeyPrefix + "rack": "rack-1",
+			}
+			idx.EventHandler().AddFunc(server)
+			reader.reset()
+		})
+
+		AfterEach(func() {
+			idx.EventHandler().DeleteFunc(server)
+		})
+
+		Describe("/v1/", func() {
+			It("returns the metadata as JSON", func() {
+				resp := getMetadata("/v1/")
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(resp.Header.Get("Content-Type")).To(Equal("application/json"))
+
+				body := decodeJSON(resp)
+				Expect(body).To(HaveKeyWithValue("server-name", "server-loopback"))
+				Expect(body).To(HaveKeyWithValue("rack", "rack-1"))
+				Expect(body).To(HaveKeyWithValue(staticKey, staticVal))
+			})
+
+			It("does not include user-data when the Server is unclaimed", func() {
+				resp := getMetadata("/v1/")
+				body := decodeJSON(resp)
+				Expect(body).NotTo(HaveKey("user-data"))
+			})
+		})
+
+		Describe("/v1/{field}", func() {
+			It("returns the field value as plain text", func() {
+				resp := getMetadata("/v1/server-name")
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(resp.Header.Get("Content-Type")).To(Equal("text/plain; charset=utf-8"))
+				Expect(readBody(resp)).To(Equal("server-loopback"))
+			})
+
+			It("returns 404 for an unknown field", func() {
+				resp := getMetadata("/v1/does-not-exist")
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			})
+		})
+
+		Describe("/v1/user-data", func() {
+			It("returns 404 when the Server has no ServerClaim", func() {
+				resp := getMetadata("/v1/user-data")
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			})
+
+			When("the Server is claimed", func() {
+				BeforeEach(func() {
+					idx.EventHandler().DeleteFunc(server)
+					server = newServer("server-loopback", "127.0.0.1")
+					server.Spec.ServerClaimRef = &metalv1alpha1.ImmutableObjectReference{
+						Namespace: testNamespace,
+						Name:      testClaimName,
+					}
+					idx.EventHandler().AddFunc(server)
+				})
+
+				It("returns 404 when the ServerClaim does not exist", func() {
+					resp := getMetadata("/v1/user-data")
+					Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+				})
+
+				It("returns 404 when the ServerClaim has no UserDataRef", func() {
+					reader.reset(claim(nil))
+					resp := getMetadata("/v1/user-data")
+					Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+				})
+
+				It("returns 404 when the referenced Secret does not exist", func() {
+					reader.reset(claim(&corev1.LocalObjectReference{Name: testSecretRef}))
+					resp := getMetadata("/v1/user-data")
+					Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+				})
+
+				It("returns 500 when the referenced Secret has the wrong type", func() {
+					reader.reset(
+						claim(&corev1.LocalObjectReference{Name: testSecretRef}),
+						userDataSecret(corev1.SecretTypeOpaque, map[string][]byte{
+							"key": []byte("value"),
+						}),
+					)
+					resp := getMetadata("/v1/user-data")
+					Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+				})
+
+				It("returns the Secret data as JSON", func() {
+					reader.reset(
+						claim(&corev1.LocalObjectReference{Name: testSecretRef}),
+						userDataSecret(metalv1alpha1.SecretTypeUserData, map[string][]byte{
+							"key1": []byte("value1"),
+							"key2": []byte("value2"),
+						}),
+					)
+					resp := getMetadata("/v1/user-data")
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
+					Expect(resp.Header.Get("Content-Type")).To(Equal("application/json"))
+
+					body := decodeJSON(resp)
+					Expect(body).To(HaveKeyWithValue("key1", "value1"))
+					Expect(body).To(HaveKeyWithValue("key2", "value2"))
+				})
+
+				It("includes user-data in the /v1/ response", func() {
+					reader.reset(
+						claim(&corev1.LocalObjectReference{Name: testSecretRef}),
+						userDataSecret(metalv1alpha1.SecretTypeUserData, map[string][]byte{
+							"key": []byte("value"),
+						}),
+					)
+					resp := getMetadata("/v1/")
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+					body := decodeJSON(resp)
+					Expect(body).To(HaveKey("user-data"))
+					Expect(body["user-data"]).To(Equal(map[string]any{"key": "value"}))
+				})
+			})
+		})
+
+		Describe("/v1/user-data/{key}", func() {
+			BeforeEach(func() {
+				idx.EventHandler().DeleteFunc(server)
+				server = newServer("server-loopback", "127.0.0.1")
+				server.Spec.ServerClaimRef = &metalv1alpha1.ImmutableObjectReference{
+					Namespace: testNamespace,
+					Name:      testClaimName,
+				}
+				idx.EventHandler().AddFunc(server)
+				reader.reset(
+					claim(&corev1.LocalObjectReference{Name: testSecretRef}),
+					userDataSecret(metalv1alpha1.SecretTypeUserData, map[string][]byte{
+						"key1": []byte("value1"),
+					}),
+				)
+			})
+
+			It("returns the value for an existing key as plain text", func() {
+				resp := getMetadata("/v1/user-data/key1")
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(resp.Header.Get("Content-Type")).To(Equal("text/plain; charset=utf-8"))
+				Expect(readBody(resp)).To(Equal("value1"))
+			})
+
+			It("returns 404 for an unknown key", func() {
+				resp := getMetadata("/v1/user-data/missing")
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			})
+		})
+
+		Describe("route precedence", func() {
+			It("routes /v1/user-data to the user-data handler even when a metadata key with that name is set", func() {
+				idx.EventHandler().DeleteFunc(server)
+				server = newServer("server-loopback", "127.0.0.1")
+				server.Labels = map[string]string{
+					metalv1alpha1.MetadataKeyPrefix + "user-data": "from-label",
+				}
+				idx.EventHandler().AddFunc(server)
+
+				resp := getMetadata("/v1/user-data")
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			})
+		})
+	})
+})
+
+func getMetadata(path string) *http.Response {
+	GinkgoHelper()
+	req, err := http.NewRequest(http.MethodGet, testServerURL+path, nil)
+	Expect(err).NotTo(HaveOccurred())
+	req.Header.Set(flavorHeader, flavorValue)
+
+	resp, err := http.DefaultClient.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(resp.Body.Close)
+	return resp
+}
+
+func decodeJSON(resp *http.Response) map[string]any {
+	GinkgoHelper()
+	out := map[string]any{}
+	Expect(json.NewDecoder(resp.Body).Decode(&out)).To(Succeed())
+	return out
+}
+
+func readBody(resp *http.Response) string {
+	GinkgoHelper()
+	body, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+	return string(body)
+}
+
+func claim(userDataRef *corev1.LocalObjectReference) *metalv1alpha1.ServerClaim {
+	return &metalv1alpha1.ServerClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testClaimName,
+		},
+		Spec: metalv1alpha1.ServerClaimSpec{
+			Power:       metalv1alpha1.PowerOn,
+			Image:       "image",
+			UserDataRef: userDataRef,
+		},
+	}
+}
+
+func userDataSecret(secretType corev1.SecretType, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testSecretRef,
+		},
+		Type: secretType,
+		Data: data,
+	}
+}

--- a/internal/metaldata/index.go
+++ b/internal/metaldata/index.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metaldata
+
+import (
+	"maps"
+	"net/netip"
+	"strings"
+	"sync"
+
+	"github.com/go-logr/logr"
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type ServerEntry struct {
+	Name     string
+	Metadata map[string]string
+	ClaimRef *metalv1alpha1.ImmutableObjectReference
+}
+
+type Index struct {
+	log            logr.Logger
+	mu             sync.RWMutex
+	hosts          map[netip.Addr]*ServerEntry
+	serverIPs      map[string][]netip.Addr
+	staticMetadata map[string]string
+}
+
+func NewIndex(log logr.Logger, staticMetadata map[string]string) *Index {
+	return &Index{
+		log:            log,
+		hosts:          make(map[netip.Addr]*ServerEntry),
+		serverIPs:      make(map[string][]netip.Addr),
+		staticMetadata: staticMetadata,
+	}
+}
+
+func (idx *Index) Lookup(addr netip.Addr) (*ServerEntry, bool) {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	h, ok := idx.hosts[addr]
+	return h, ok
+}
+
+func (idx *Index) EventHandler() cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    idx.onAdd,
+		UpdateFunc: idx.onUpdate,
+		DeleteFunc: idx.onDelete,
+	}
+}
+
+func (idx *Index) onAdd(obj any) {
+	server, ok := obj.(*metalv1alpha1.Server)
+	if !ok {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.syncLocked(server)
+}
+
+func (idx *Index) onUpdate(_, newObj any) {
+	server, ok := newObj.(*metalv1alpha1.Server)
+	if !ok {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.removeLocked(server.Name)
+	idx.syncLocked(server)
+}
+
+func (idx *Index) onDelete(obj any) {
+	server, ok := obj.(*metalv1alpha1.Server)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		server, ok = tombstone.Obj.(*metalv1alpha1.Server)
+		if !ok {
+			return
+		}
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.removeLocked(server.Name)
+}
+
+func (idx *Index) syncLocked(server *metalv1alpha1.Server) {
+	entry := &ServerEntry{
+		Name:     server.Name,
+		Metadata: make(map[string]string, len(idx.staticMetadata)),
+	}
+
+	maps.Copy(entry.Metadata, idx.staticMetadata)
+	entry.Metadata["server-name"] = server.Name
+
+	for k, v := range server.Annotations {
+		key, ok := strings.CutPrefix(k, metalv1alpha1.MetadataKeyPrefix)
+		if ok {
+			entry.Metadata[key] = v
+		}
+	}
+	for k, v := range server.Labels {
+		key, ok := strings.CutPrefix(k, metalv1alpha1.MetadataKeyPrefix)
+		if ok {
+			entry.Metadata[key] = v
+		}
+	}
+
+	if server.Spec.ServerClaimRef != nil {
+		ref := *server.Spec.ServerClaimRef
+		entry.ClaimRef = &ref
+	}
+
+	var addrs []netip.Addr
+	for _, nic := range server.Status.NetworkInterfaces {
+		for _, ip := range nic.IPs {
+			addr := ip.Addr
+			if !addr.IsValid() {
+				continue
+			}
+			if existing, ok := idx.hosts[addr]; ok && existing.Name != server.Name {
+				idx.log.Info("IP claimed by multiple Servers, overwriting index entry",
+					"ip", addr, "previous", existing.Name, "current", server.Name)
+			}
+			idx.hosts[addr] = entry
+			addrs = append(addrs, addr)
+		}
+	}
+	idx.serverIPs[server.Name] = addrs
+
+	idx.log.Info("Indexed Server", "name", server.Name, "ips", len(addrs))
+}
+
+func (idx *Index) removeLocked(name string) {
+	addrs, ok := idx.serverIPs[name]
+	if !ok {
+		return
+	}
+	for _, addr := range addrs {
+		delete(idx.hosts, addr)
+	}
+	delete(idx.serverIPs, name)
+}

--- a/internal/metaldata/index_test.go
+++ b/internal/metaldata/index_test.go
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metaldata_test
+
+import (
+	"net/netip"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+)
+
+var _ = Describe("Index", func() {
+	var server *metalv1alpha1.Server
+
+	addServer := func(s *metalv1alpha1.Server) {
+		idx.EventHandler().AddFunc(s)
+	}
+	deleteServer := func(s *metalv1alpha1.Server) {
+		idx.EventHandler().DeleteFunc(s)
+	}
+	updateServer := func(oldS, newS *metalv1alpha1.Server) {
+		idx.EventHandler().UpdateFunc(oldS, newS)
+	}
+
+	BeforeEach(func() {
+		server = newServer("server-a", "192.0.2.10")
+		server.Annotations = map[string]string{
+			"unrelated": "ignored",
+			metalv1alpha1.MetadataKeyPrefix + "owner": "alice",
+			metalv1alpha1.MetadataKeyPrefix + "rack":  "from-annotation",
+		}
+		server.Labels = map[string]string{
+			"unrelated":                              "ignored",
+			metalv1alpha1.MetadataKeyPrefix + "rack": "from-label",
+		}
+		addServer(server)
+	})
+
+	AfterEach(func() {
+		deleteServer(server)
+	})
+
+	It("returns the entry for an indexed IP", func() {
+		entry, ok := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+		Expect(ok).To(BeTrue())
+		Expect(entry.Name).To(Equal("server-a"))
+	})
+
+	It("returns nothing for an unindexed IP", func() {
+		_, ok := idx.Lookup(netip.MustParseAddr("198.51.100.1"))
+		Expect(ok).To(BeFalse())
+	})
+
+	It("merges static metadata, annotations and labels into the entry", func() {
+		entry, ok := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+		Expect(ok).To(BeTrue())
+		Expect(entry.Metadata).To(HaveKeyWithValue("owner", "alice"))
+		Expect(entry.Metadata).To(HaveKeyWithValue(staticKey, staticVal))
+	})
+
+	It("strips the metadata.metal.ironcore.dev/ prefix", func() {
+		entry, _ := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+		Expect(entry.Metadata).NotTo(HaveKey(metalv1alpha1.MetadataKeyPrefix + "owner"))
+		Expect(entry.Metadata).To(HaveKey("owner"))
+	})
+
+	It("excludes annotations and labels without the prefix", func() {
+		entry, _ := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+		Expect(entry.Metadata).NotTo(HaveKey("unrelated"))
+	})
+
+	It("lets labels override annotations on the same key", func() {
+		entry, _ := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+		Expect(entry.Metadata).To(HaveKeyWithValue("rack", "from-label"))
+	})
+
+	It("lets annotations override static metadata on the same key", func() {
+		deleteServer(server)
+		server = newServer("server-a", "192.0.2.10")
+		server.Annotations = map[string]string{
+			metalv1alpha1.MetadataKeyPrefix + staticKey: "from-annotation",
+		}
+		addServer(server)
+
+		entry, _ := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+		Expect(entry.Metadata).To(HaveKeyWithValue(staticKey, "from-annotation"))
+	})
+
+	It("includes a server-name key matching the Server's name, overriding any static value", func() {
+		entry, _ := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+		Expect(entry.Metadata).To(HaveKeyWithValue("server-name", "server-a"))
+	})
+
+	It("forwards the ServerClaimRef onto the entry", func() {
+		deleteServer(server)
+		server = newServer("server-a", "192.0.2.10")
+		server.Spec.ServerClaimRef = &metalv1alpha1.ImmutableObjectReference{
+			Namespace: "default",
+			Name:      "claim-a",
+		}
+		addServer(server)
+
+		entry, _ := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+		Expect(entry.ClaimRef).NotTo(BeNil())
+		Expect(*entry.ClaimRef).To(Equal(metalv1alpha1.ImmutableObjectReference{
+			Namespace: "default",
+			Name:      "claim-a",
+		}))
+	})
+
+	When("a Server is updated with a new IP set", func() {
+		It("removes the old IPs and indexes the new ones", func() {
+			updated := newServer("server-a", "192.0.2.20")
+			updateServer(server, updated)
+			server = updated
+
+			_, ok := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+			Expect(ok).To(BeFalse())
+
+			entry, ok := idx.Lookup(netip.MustParseAddr("192.0.2.20"))
+			Expect(ok).To(BeTrue())
+			Expect(entry.Name).To(Equal("server-a"))
+		})
+	})
+
+	When("a Server is deleted", func() {
+		It("removes all of its IPs from the index", func() {
+			deleteServer(server)
+			server = newServer("placeholder", "192.0.2.10")
+
+			_, ok := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+			Expect(ok).To(BeFalse())
+
+			addServer(server)
+		})
+	})
+
+	When("a Server is deleted via a tombstone", func() {
+		It("removes all of its IPs from the index", func() {
+			tombstone := cache.DeletedFinalStateUnknown{
+				Key: server.Namespace + "/" + server.Name,
+				Obj: server,
+			}
+			idx.EventHandler().DeleteFunc(tombstone)
+
+			_, ok := idx.Lookup(netip.MustParseAddr("192.0.2.10"))
+			Expect(ok).To(BeFalse())
+
+			server = newServer("server-a", "192.0.2.10")
+			addServer(server)
+		})
+	})
+
+	When("a Server has IPs that fail to parse", func() {
+		It("skips them without indexing", func() {
+			deleteServer(server)
+			server = &metalv1alpha1.Server{
+				ObjectMeta: metav1.ObjectMeta{Name: "server-a"},
+				Status: metalv1alpha1.ServerStatus{
+					NetworkInterfaces: []metalv1alpha1.NetworkInterface{
+						{IPs: []metalv1alpha1.IP{{}}},
+					},
+				},
+			}
+			addServer(server)
+
+			_, ok := idx.Lookup(netip.Addr{})
+			Expect(ok).To(BeFalse())
+		})
+	})
+})
+
+func newServer(name string, ips ...string) *metalv1alpha1.Server {
+	parsed := make([]metalv1alpha1.IP, 0, len(ips))
+	for _, ip := range ips {
+		parsed = append(parsed, metalv1alpha1.MustParseIP(ip))
+	}
+	return &metalv1alpha1.Server{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: metalv1alpha1.ServerStatus{
+			NetworkInterfaces: []metalv1alpha1.NetworkInterface{
+				{Name: "eth0", IPs: parsed},
+			},
+		},
+	}
+}

--- a/internal/metaldata/metaldata_suite_test.go
+++ b/internal/metaldata/metaldata_suite_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metaldata_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	"github.com/ironcore-dev/metal-operator/internal/metaldata"
+)
+
+const (
+	staticKey = "static-key"
+	staticVal = "static-val"
+)
+
+var (
+	idx           *metaldata.Index
+	reader        *mutableReader
+	scheme        = runtime.NewScheme()
+	testServerURL string
+)
+
+// mutableReader lets tests swap the backing client.Reader between cases while
+// keeping the metaldata.Server constructed once at suite start.
+type mutableReader struct {
+	inner client.Reader
+}
+
+func (m *mutableReader) reset(objs ...client.Object) {
+	m.inner = fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func (m *mutableReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return m.inner.Get(ctx, key, obj, opts...)
+}
+
+func (m *mutableReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return m.inner.List(ctx, list, opts...)
+}
+
+func TestMetaldata(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metaldata Suite")
+}
+
+var _ = BeforeSuite(func() {
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(metalv1alpha1.AddToScheme(scheme))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	DeferCleanup(cancel)
+
+	idx = metaldata.NewIndex(GinkgoLogr, map[string]string{staticKey: staticVal})
+	reader = &mutableReader{}
+	reader.reset()
+
+	srv := metaldata.NewServer(GinkgoLogr, idx, reader, "127.0.0.1:0")
+	go func() {
+		defer GinkgoRecover()
+		Expect(srv.Start(ctx)).To(Succeed(), "failed to start metaldata server")
+	}()
+
+	Eventually(srv.Ready).Should(BeTrue())
+
+	testServerURL = fmt.Sprintf("http://%s", srv.Addr())
+
+	Eventually(func() error {
+		_, err := http.Get(testServerURL)
+		return err
+	}).Should(Succeed())
+})


### PR DESCRIPTION
Resolves: https://github.com/ironcore-dev/metal-operator/issues/932


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `metaldata` component (DaemonSet + Service) providing REST endpoints for per-server metadata and optional user-data.
  * Extended `ServerClaim` with `spec.userDataRef` to reference a same-namespace Secret containing user-data.
* **Infrastructure**
  * Added Kubernetes manifests and RBAC for `metaldata`, and updated image build/push to include the new `metaldata` image/stage.
* **Documentation**
  * Documented `userDataRef` in the API reference.
* **Tests**
  * Added tests covering metadata responses and user-data Secret validation/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->