### PR TITLE
Publish Chart Workflow needs to consider tags on all branches

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -8,16 +8,16 @@ on:
     branches:
       - main
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+      - "docs/**"
+      - "**/*.md"
   pull_request:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+      - "docs/**"
+      - "**/*.md"
     types: [labeled, opened, synchronize, reopened]
 
 jobs:
@@ -51,7 +51,7 @@ jobs:
             CHART_VERSION="${GITHUB_REF#refs/tags/v}"
           else
             # Get the latest tag
-            LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "v0.0.0")
+            LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -1 || echo "v0.0.0")
             # Strip 'v' prefix
             VERSION="${LATEST_TAG#v}"
             # Remove prerelease/build metadata (everything after '-' or '+')


### PR DESCRIPTION
in metal-operator, current main, latest tag being `v0.5.1`

```
old, broken
❯ git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "v0.0.0"
v0.5.0

new, fixed
❯ git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -1 || echo "v0.0.0"
v0.5.1
```