### PR TITLE
Remove deprecated maintenance annotation based approval logic

### DIFF
--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -403,7 +403,6 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Approving the maintenance")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 		})).Should(Succeed())
 
@@ -551,7 +550,6 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Approving the maintenance")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 		})).Should(Succeed())
 
@@ -1157,7 +1155,7 @@ var _ = Describe("BIOSSettings Controller with BMCRef BMC", func() {
 
 		By("Approving the maintenance")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, "true")
+			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, "true")
 		})).Should(Succeed())
 
 		By("Ensuring that the biosSettings resource has started bios setting update")

--- a/internal/controller/biosversion_controller_test.go
+++ b/internal/controller/biosversion_controller_test.go
@@ -305,7 +305,6 @@ var _ = Describe("BIOSVersion Controller", func() {
 
 		By("Approving the maintenance")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 		})).Should(Succeed())
 

--- a/internal/controller/bmcversion_controller_test.go
+++ b/internal/controller/bmcversion_controller_test.go
@@ -317,7 +317,6 @@ var _ = Describe("BMCVersion Controller", func() {
 
 		By("Approving the maintenance")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 		})).Should(Succeed())
 

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -232,7 +232,7 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 		return ctrl.Result{}, err
 	}
 
-	if modified, err := r.handleAnnotionOperations(ctx, bmcClient, server); err != nil || modified {
+	if modified, err := r.handleAnnotationOperations(ctx, bmcClient, server); err != nil || modified {
 		return ctrl.Result{}, err
 	}
 	log.V(1).Info("Handled annotation operations")
@@ -1266,7 +1266,7 @@ func (r *ServerReconciler) applyBootOrder(ctx context.Context, bmcClient bmc.BMC
 	return nil
 }
 
-func (r *ServerReconciler) handleAnnotionOperations(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
+func (r *ServerReconciler) handleAnnotationOperations(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	annotations := server.GetAnnotations()
 	operation, ok := annotations[metalv1alpha1.OperationAnnotation]

--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -154,21 +154,16 @@ func (r *ServerMaintenanceReconciler) handlePendingState(ctx context.Context, ma
 	if serverClaim.Annotations == nil {
 		serverClaim.Annotations = make(map[string]string)
 	}
-	serverClaim.Annotations[metalv1alpha1.ServerMaintenanceNeededLabelKey] = trueValue
-	if maintenance.Annotations[metalv1alpha1.ServerMaintenanceReasonAnnotationKey] != "" {
-		serverClaim.Annotations[metalv1alpha1.ServerMaintenanceReasonAnnotationKey] = maintenance.Annotations[metalv1alpha1.ServerMaintenanceReasonAnnotationKey]
-	}
+
 	if err := r.Patch(ctx, serverClaim, patch); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to patch ServerClaim: %w", err)
 	}
 	log.V(1).Info("Patched ServerClaim labels and annotations", "ServerClaim", client.ObjectKeyFromObject(serverClaim))
 	if maintenance.Spec.Policy == metalv1alpha1.ServerMaintenancePolicyOwnerApproval {
-		annotations := serverClaim.GetAnnotations()
 		labels := serverClaim.GetLabels()
-		_, hasAnnotation := annotations[metalv1alpha1.ServerMaintenanceApprovedLabelKey]
 		_, hasLabel := labels[metalv1alpha1.ServerMaintenanceApprovedLabelKey]
 
-		if hasAnnotation || hasLabel {
+		if hasLabel {
 			log.V(1).Info("Server approved for maintenance", "Server", server.Name)
 			if err = r.updateServerRef(ctx, maintenance, server); err != nil {
 				return ctrl.Result{}, err
@@ -408,11 +403,6 @@ func (r *ServerMaintenanceReconciler) cleanup(ctx context.Context, server *metal
 		return fmt.Errorf("failed to get ServerClaim: %w", err)
 	}
 	serverClaimBase := serverClaim.DeepCopy()
-	metautils.DeleteAnnotations(serverClaim, []string{
-		metalv1alpha1.ServerMaintenanceApprovedLabelKey,
-		metalv1alpha1.ServerMaintenanceNeededLabelKey,
-		metalv1alpha1.ServerMaintenanceReasonAnnotationKey,
-	})
 	metautils.DeleteLabels(serverClaim, []string{
 		metalv1alpha1.ServerMaintenanceApprovedLabelKey,
 		metalv1alpha1.ServerMaintenanceNeededLabelKey,
@@ -502,8 +492,7 @@ func (r *ServerMaintenanceReconciler) enqueueMaintenanceByClaimRefs() handler.Ev
 			return nil
 		}
 
-		annotations := claim.GetAnnotations()
-		if _, ok := annotations[metalv1alpha1.ServerMaintenanceNeededLabelKey]; !ok {
+		if _, ok := claim.Labels[metalv1alpha1.ServerMaintenanceNeededLabelKey]; !ok {
 			return nil
 		}
 

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -180,7 +180,6 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Ensuring that the ServerClaim has the maintenance needed label and annotation")
 		Eventually(Object(serverClaim)).Should(SatisfyAll(
-			HaveField("ObjectMeta.Annotations", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceNeededLabelKey, trueValue)),
 			HaveField("ObjectMeta.Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceNeededLabelKey, trueValue)),
 		))
 
@@ -191,15 +190,9 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Approving the maintenance")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 		})).Should(Succeed())
 
-		maintenanceAnnotations := map[string]string{
-			metalv1alpha1.ServerMaintenanceNeededLabelKey:      trueValue,
-			metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "test-maintenance",
-			metalv1alpha1.ServerMaintenanceApprovedLabelKey:    trueValue,
-		}
 		maintenanceLabels := map[string]string{
 			metalv1alpha1.ServerMaintenanceNeededLabelKey:   trueValue,
 			metalv1alpha1.ServerMaintenanceApprovedLabelKey: trueValue,
@@ -230,7 +223,6 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Checking the ServerClaim has the maintenance labels and annotations")
 		Eventually(Object(serverClaim)).Should(SatisfyAll(
-			HaveField("ObjectMeta.Annotations", maintenanceAnnotations),
 			HaveField("ObjectMeta.Labels", maintenanceLabels),
 		))
 
@@ -251,7 +243,6 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Checking the ServerClaim is cleaned up")
 		Eventually(Object(serverClaim)).Should(SatisfyAll(
-			HaveField("ObjectMeta.Annotations", Not(HaveKey(metalv1alpha1.ServerMaintenanceNeededLabelKey))),
 			HaveField("ObjectMeta.Labels", Not(HaveKey(metalv1alpha1.ServerMaintenanceNeededLabelKey))),
 		))
 
@@ -433,7 +424,6 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Approving maintenance on the ServerClaim")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 		})).Should(Succeed())
 
@@ -448,7 +438,6 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		Eventually(Get(highPriorityMaintenance)).ShouldNot(Succeed())
 		By("Approving lowPriorityMaintenance on the ServerClaim")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 		})).Should(Succeed())
 		By("Ensuring low-priority maintenance can proceed afterwards")
@@ -528,7 +517,6 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Approving maintenance on the ServerClaim")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 		})).Should(Succeed())
 
@@ -543,7 +531,6 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Approving lowPriorityMaintenance on the ServerClaim")
 		Eventually(Update(serverClaim, func() {
-			metautils.SetAnnotation(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
 		})).Should(Succeed())
 


### PR DESCRIPTION
# Proposed Changes

Remove deprecated maintenance annotation based approval logic.

Fixes #616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo in an internal method name.

* **Refactor**
  * Maintenance signaling now consistently uses labels instead of annotations for needed/approved state.
  * Cleanup and enqueue logic updated to operate on labels.

* **Tests**
  * Updated tests to set and assert maintenance state via labels and to remove reliance on annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->