### PR TITLE
Improve logic for the deletion and update restriction

### DIFF
--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ironcore-dev/controller-utils/conditionutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/ironcore-dev/metal-operator/internal/bmcutils"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 const (
@@ -121,7 +122,7 @@ func (r *BIOSSettingsReconciler) shouldDelete(ctx context.Context, settings *met
 		if settings.Spec.ServerMaintenanceRef == nil {
 			return false, nil
 		}
-		return IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*settings.Spec.ServerMaintenanceRef})
+		return metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*settings.Spec.ServerMaintenanceRef})
 	}
 	return shouldProceedWithDeletion(ctx, settings, BIOSSettingsFinalizer, isProgressing)
 }

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -109,29 +109,21 @@ func (r *BIOSSettingsReconciler) reconcileExists(ctx context.Context, settings *
 }
 
 func (r *BIOSSettingsReconciler) shouldDelete(ctx context.Context, settings *metalv1alpha1.BIOSSettings) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
-	if settings.DeletionTimestamp.IsZero() {
-		return false, nil
-	}
-	log.V(1).Info("Reconciling BIOSSettings")
-
-	if controllerutil.ContainsFinalizer(settings, BIOSSettingsFinalizer) && settings.Spec.ServerMaintenanceRef != nil {
-		if settings.Spec.ServerRef != nil {
-			if _, err := GetServerByName(ctx, r.Client, settings.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
-				log.V(1).Info("Server not found, proceeding with deletion", "Server", settings.Spec.ServerRef.Name)
-				return true, nil
-			}
-		}
-		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*settings.Spec.ServerMaintenanceRef})
-		if err != nil {
-			return false, fmt.Errorf("failed to check maintenance state: %w", err)
-		}
-		if active {
-			log.V(1).Info("Postponing delete as BIOSSettings is under active maintenance")
+	isProgressing := func() (bool, error) {
+		if settings.Status.State != metalv1alpha1.BIOSSettingsStateInProgress {
 			return false, nil
 		}
+		if settings.Spec.ServerRef != nil {
+			if _, err := GetServerByName(ctx, r.Client, settings.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
+				return false, nil
+			}
+		}
+		if settings.Spec.ServerMaintenanceRef == nil {
+			return false, nil
+		}
+		return IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*settings.Spec.ServerMaintenanceRef})
 	}
-	return true, nil
+	return shouldProceedWithDeletion(ctx, settings, BIOSSettingsFinalizer, isProgressing)
 }
 
 func (r *BIOSSettingsReconciler) delete(ctx context.Context, settings *metalv1alpha1.BIOSSettings) (ctrl.Result, error) {

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -116,9 +116,11 @@ func (r *BIOSSettingsReconciler) shouldDelete(ctx context.Context, settings *met
 	log.V(1).Info("Reconciling BIOSSettings")
 
 	if controllerutil.ContainsFinalizer(settings, BIOSSettingsFinalizer) && settings.Spec.ServerMaintenanceRef != nil {
-		if _, err := GetServerByName(ctx, r.Client, settings.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
-			log.V(1).Info("Server not found, proceeding with deletion", "Server", settings.Spec.ServerRef.Name)
-			return true, nil
+		if settings.Spec.ServerRef != nil {
+			if _, err := GetServerByName(ctx, r.Client, settings.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
+				log.V(1).Info("Server not found, proceeding with deletion", "Server", settings.Spec.ServerRef.Name)
+				return true, nil
+			}
 		}
 		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*settings.Spec.ServerMaintenanceRef})
 		if err != nil {

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -98,29 +98,38 @@ func (r *BIOSSettingsReconciler) Reconcile(ctx context.Context, req ctrl.Request
 }
 
 func (r *BIOSSettingsReconciler) reconcileExists(ctx context.Context, settings *metalv1alpha1.BIOSSettings) (ctrl.Result, error) {
-	if r.shouldDelete(ctx, settings) {
+	ok, err := r.shouldDelete(ctx, settings)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if ok {
 		return r.delete(ctx, settings)
 	}
 	return r.reconcile(ctx, settings)
 }
 
-func (r *BIOSSettingsReconciler) shouldDelete(ctx context.Context, settings *metalv1alpha1.BIOSSettings) bool {
+func (r *BIOSSettingsReconciler) shouldDelete(ctx context.Context, settings *metalv1alpha1.BIOSSettings) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if settings.DeletionTimestamp.IsZero() {
-		return false
+		return false, nil
 	}
 	log.V(1).Info("Reconciling BIOSSettings")
 
-	if controllerutil.ContainsFinalizer(settings, BIOSSettingsFinalizer) &&
-		settings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress {
+	if controllerutil.ContainsFinalizer(settings, BIOSSettingsFinalizer) && settings.Spec.ServerMaintenanceRef != nil {
 		if _, err := GetServerByName(ctx, r.Client, settings.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
 			log.V(1).Info("Server not found, proceeding with deletion", "Server", settings.Spec.ServerRef.Name)
-			return true
+			return true, nil
 		}
-		log.V(1).Info("Postponing delete as BIOSSettings update is in progress")
-		return false
+		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*settings.Spec.ServerMaintenanceRef})
+		if err != nil {
+			return false, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			log.V(1).Info("Postponing delete as BIOSSettings is under active maintenance")
+			return false, nil
+		}
 	}
-	return true
+	return true, nil
 }
 
 func (r *BIOSSettingsReconciler) delete(ctx context.Context, settings *metalv1alpha1.BIOSSettings) (ctrl.Result, error) {

--- a/internal/controller/biossettingsset_controller.go
+++ b/internal/controller/biossettingsset_controller.go
@@ -43,6 +43,7 @@ type BIOSSettingsSetReconciler struct {
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biossettingssets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biossettings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servermaintenances,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -289,7 +290,7 @@ func (r *BIOSSettingsSetReconciler) deleteOrphanBIOSSettings(ctx context.Context
 	var errs []error
 	for _, biosSettings := range settings.Items {
 		if _, ok := serverMap[biosSettings.Spec.ServerRef.Name]; !ok {
-			if biosSettings.Spec.ServerMaintenanceRef != nil {
+			if biosSettings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress && biosSettings.Spec.ServerMaintenanceRef != nil {
 				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosSettings.Spec.ServerMaintenanceRef})
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to check maintenance state for BIOSSettings %s: %w", biosSettings.Name, err))

--- a/internal/controller/biossettingsset_controller.go
+++ b/internal/controller/biossettingsset_controller.go
@@ -82,9 +82,15 @@ func (r *BIOSSettingsSetReconciler) delete(ctx context.Context, set *metalv1alph
 
 	deletableBIOSSettings := map[string]struct{}{}
 	for _, biosSettings := range ownedBIOSSettings.Items {
-		if biosSettings.Status.State != metalv1alpha1.BIOSSettingsStateInProgress {
+		if biosSettings.Spec.ServerMaintenanceRef == nil {
 			deletableBIOSSettings[biosSettings.Name] = struct{}{}
-		} else if biosSettings.Spec.ServerMaintenanceRef == nil {
+			continue
+		}
+		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosSettings.Spec.ServerMaintenanceRef})
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to check maintenance state for BIOSSettings %s: %w", biosSettings.Name, err)
+		}
+		if !active {
 			deletableBIOSSettings[biosSettings.Name] = struct{}{}
 		}
 	}
@@ -283,9 +289,16 @@ func (r *BIOSSettingsSetReconciler) deleteOrphanBIOSSettings(ctx context.Context
 	var errs []error
 	for _, biosSettings := range settings.Items {
 		if _, ok := serverMap[biosSettings.Spec.ServerRef.Name]; !ok {
-			if biosSettings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress {
-				log.V(1).Info("Waiting for BIOSSettings to move out of InProgress state", "BIOSSettings", biosSettings.Name, "Status", biosSettings.Status)
-				continue
+			if biosSettings.Spec.ServerMaintenanceRef != nil {
+				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosSettings.Spec.ServerMaintenanceRef})
+				if err != nil {
+					errs = append(errs, fmt.Errorf("failed to check maintenance state for BIOSSettings %s: %w", biosSettings.Name, err))
+					continue
+				}
+				if active {
+					log.V(1).Info("Waiting for BIOSSettings maintenance to complete before deletion", "BIOSSettings", biosSettings.Name)
+					continue
+				}
 			}
 			if err := r.Delete(ctx, &biosSettings); err != nil {
 				errs = append(errs, err)

--- a/internal/controller/biossettingsset_controller.go
+++ b/internal/controller/biossettingsset_controller.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 const (
@@ -87,7 +88,7 @@ func (r *BIOSSettingsSetReconciler) delete(ctx context.Context, set *metalv1alph
 			deletableBIOSSettings[biosSettings.Name] = struct{}{}
 			continue
 		}
-		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosSettings.Spec.ServerMaintenanceRef})
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosSettings.Spec.ServerMaintenanceRef})
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to check maintenance state for BIOSSettings %s: %w", biosSettings.Name, err)
 		}
@@ -291,7 +292,7 @@ func (r *BIOSSettingsSetReconciler) deleteOrphanBIOSSettings(ctx context.Context
 	for _, biosSettings := range settings.Items {
 		if _, ok := serverMap[biosSettings.Spec.ServerRef.Name]; !ok {
 			if biosSettings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress && biosSettings.Spec.ServerMaintenanceRef != nil {
-				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosSettings.Spec.ServerMaintenanceRef})
+				active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosSettings.Spec.ServerMaintenanceRef})
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to check maintenance state for BIOSSettings %s: %w", biosSettings.Name, err))
 					continue

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -90,9 +90,11 @@ func (r *BIOSVersionReconciler) shouldDelete(ctx context.Context, biosVersion *m
 	}
 
 	if controllerutil.ContainsFinalizer(biosVersion, BIOSVersionFinalizer) && biosVersion.Spec.ServerMaintenanceRef != nil {
-		if _, err := GetServerByName(ctx, r.Client, biosVersion.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
-			log.V(1).Info("Server not found, proceeding with deletion", "Server", biosVersion.Spec.ServerRef.Name)
-			return true, nil
+		if biosVersion.Spec.ServerRef != nil {
+			if _, err := GetServerByName(ctx, r.Client, biosVersion.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
+				log.V(1).Info("Server not found, proceeding with deletion", "Server", biosVersion.Spec.ServerRef.Name)
+				return true, nil
+			}
 		}
 		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
 		if err != nil {
@@ -989,20 +991,21 @@ func (r *BIOSVersionReconciler) enqueueBiosVersionByServerRefs(ctx context.Conte
 	}
 
 	for _, biosVersion := range biosVersionList.Items {
-		if biosVersion.Spec.ServerRef.Name == host.Name {
-			// states where we do not need to requeue for host changes
-			if biosVersion.Spec.ServerMaintenanceRef == nil ||
-				biosVersion.Status.State == metalv1alpha1.BIOSVersionStateCompleted ||
-				biosVersion.Status.State == metalv1alpha1.BIOSVersionStateFailed {
-				return nil
-			}
-			if biosVersion.Spec.ServerMaintenanceRef.Name != host.Spec.ServerMaintenanceRef.Name {
-				return nil
-			}
-			return []ctrl.Request{{
-				NamespacedName: types.NamespacedName{Namespace: biosVersion.Namespace, Name: biosVersion.Name},
-			}}
+		if biosVersion.Spec.ServerRef == nil || biosVersion.Spec.ServerRef.Name != host.Name {
+			continue
 		}
+		// states where we do not need to requeue for host changes
+		if biosVersion.Spec.ServerMaintenanceRef == nil ||
+			biosVersion.Status.State == metalv1alpha1.BIOSVersionStateCompleted ||
+			biosVersion.Status.State == metalv1alpha1.BIOSVersionStateFailed {
+			return nil
+		}
+		if biosVersion.Spec.ServerMaintenanceRef.Name != host.Spec.ServerMaintenanceRef.Name {
+			return nil
+		}
+		return []ctrl.Request{{
+			NamespacedName: types.NamespacedName{Namespace: biosVersion.Namespace, Name: biosVersion.Name},
+		}}
 	}
 	return nil
 }
@@ -1028,6 +1031,9 @@ func (r *BIOSVersionReconciler) enqueueBiosSettingsByBMC(ctx context.Context, ob
 	biosVersionList := &metalv1alpha1.BIOSVersionList{}
 	if err := clientutils.ListAndFilter(ctx, r.Client, biosVersionList, func(object client.Object) (bool, error) {
 		biosVersion := object.(*metalv1alpha1.BIOSVersion)
+		if biosVersion.Spec.ServerRef == nil {
+			return false, nil
+		}
 		if _, exists := serverMap[biosVersion.Spec.ServerRef.Name]; !exists {
 			return false, nil
 		}

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -14,6 +14,7 @@ import (
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/ironcore-dev/metal-operator/bmc"
 	"github.com/ironcore-dev/metal-operator/internal/bmcutils"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/schemas"
 	corev1 "k8s.io/api/core/v1"
@@ -96,7 +97,7 @@ func (r *BIOSVersionReconciler) shouldDelete(ctx context.Context, biosVersion *m
 		if biosVersion.Spec.ServerMaintenanceRef == nil {
 			return false, nil
 		}
-		return IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
+		return metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
 	}
 	return shouldProceedWithDeletion(ctx, biosVersion, BIOSVersionFinalizer, isProgressing)
 }

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -73,29 +73,38 @@ func (r *BIOSVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 func (r *BIOSVersionReconciler) reconcileExists(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) (ctrl.Result, error) {
-	if r.shouldDelete(ctx, biosVersion) {
+	ok, err := r.shouldDelete(ctx, biosVersion)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if ok {
 		return r.delete(ctx, biosVersion)
 	}
 	return r.reconcile(ctx, biosVersion)
 }
 
-func (r *BIOSVersionReconciler) shouldDelete(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) bool {
+func (r *BIOSVersionReconciler) shouldDelete(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if biosVersion.DeletionTimestamp.IsZero() {
-		return false
+		return false, nil
 	}
 
-	if controllerutil.ContainsFinalizer(biosVersion, BIOSVersionFinalizer) &&
-		biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
+	if controllerutil.ContainsFinalizer(biosVersion, BIOSVersionFinalizer) && biosVersion.Spec.ServerMaintenanceRef != nil {
 		if _, err := GetServerByName(ctx, r.Client, biosVersion.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
 			log.V(1).Info("Server not found, proceeding with deletion", "Server", biosVersion.Spec.ServerRef.Name)
-			return true
+			return true, nil
 		}
-		log.V(1).Info("Postponing deletion as BIOS version update is in progress")
-		return false
+		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
+		if err != nil {
+			return false, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			log.V(1).Info("Postponing deletion as BIOSVersion is under active maintenance")
+			return false, nil
+		}
 	}
 
-	return true
+	return true, nil
 }
 
 func (r *BIOSVersionReconciler) delete(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) (ctrl.Result, error) {

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -84,29 +84,21 @@ func (r *BIOSVersionReconciler) reconcileExists(ctx context.Context, biosVersion
 }
 
 func (r *BIOSVersionReconciler) shouldDelete(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
-	if biosVersion.DeletionTimestamp.IsZero() {
-		return false, nil
-	}
-
-	if controllerutil.ContainsFinalizer(biosVersion, BIOSVersionFinalizer) && biosVersion.Spec.ServerMaintenanceRef != nil {
-		if biosVersion.Spec.ServerRef != nil {
-			if _, err := GetServerByName(ctx, r.Client, biosVersion.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
-				log.V(1).Info("Server not found, proceeding with deletion", "Server", biosVersion.Spec.ServerRef.Name)
-				return true, nil
-			}
-		}
-		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
-		if err != nil {
-			return false, fmt.Errorf("failed to check maintenance state: %w", err)
-		}
-		if active {
-			log.V(1).Info("Postponing deletion as BIOSVersion is under active maintenance")
+	isProgressing := func() (bool, error) {
+		if biosVersion.Status.State != metalv1alpha1.BIOSVersionStateInProgress {
 			return false, nil
 		}
+		if biosVersion.Spec.ServerRef != nil {
+			if _, err := GetServerByName(ctx, r.Client, biosVersion.Spec.ServerRef.Name); apierrors.IsNotFound(err) {
+				return false, nil
+			}
+		}
+		if biosVersion.Spec.ServerMaintenanceRef == nil {
+			return false, nil
+		}
+		return IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
 	}
-
-	return true, nil
+	return shouldProceedWithDeletion(ctx, biosVersion, BIOSVersionFinalizer, isProgressing)
 }
 
 func (r *BIOSVersionReconciler) delete(ctx context.Context, biosVersion *metalv1alpha1.BIOSVersion) (ctrl.Result, error) {

--- a/internal/controller/biosversionset_controller.go
+++ b/internal/controller/biosversionset_controller.go
@@ -41,6 +41,7 @@ type BIOSVersionSetReconciler struct {
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversionsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servermaintenances,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -241,7 +242,7 @@ func (r *BIOSVersionSetReconciler) deleteOrphanBIOSVersions(ctx context.Context,
 	var errs []error
 	for _, biosVersion := range versions.Items {
 		if !serverMap[biosVersion.Spec.ServerRef.Name] {
-			if biosVersion.Spec.ServerMaintenanceRef != nil {
+			if biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress && biosVersion.Spec.ServerMaintenanceRef != nil {
 				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to check maintenance state for BIOSVersion %s: %w", biosVersion.Name, err))

--- a/internal/controller/biosversionset_controller.go
+++ b/internal/controller/biosversionset_controller.go
@@ -241,9 +241,16 @@ func (r *BIOSVersionSetReconciler) deleteOrphanBIOSVersions(ctx context.Context,
 	var errs []error
 	for _, biosVersion := range versions.Items {
 		if !serverMap[biosVersion.Spec.ServerRef.Name] {
-			if biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
-				log.V(1).Info("Waiting for BIOSVersion to move out of InProgress state", "BIOSVersion", biosVersion.Name, "Status", biosVersion.Status)
-				continue
+			if biosVersion.Spec.ServerMaintenanceRef != nil {
+				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
+				if err != nil {
+					errs = append(errs, fmt.Errorf("failed to check maintenance state for BIOSVersion %s: %w", biosVersion.Name, err))
+					continue
+				}
+				if active {
+					log.V(1).Info("Waiting for BIOSVersion maintenance to complete before deletion", "BIOSVersion", biosVersion.Name, "Status", biosVersion.Status)
+					continue
+				}
 			}
 			if err := r.Delete(ctx, &biosVersion); err != nil {
 				errs = append(errs, err)

--- a/internal/controller/biosversionset_controller.go
+++ b/internal/controller/biosversionset_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 const (
@@ -243,7 +244,7 @@ func (r *BIOSVersionSetReconciler) deleteOrphanBIOSVersions(ctx context.Context,
 	for _, biosVersion := range versions.Items {
 		if !serverMap[biosVersion.Spec.ServerRef.Name] {
 			if biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress && biosVersion.Spec.ServerMaintenanceRef != nil {
-				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
+				active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to check maintenance state for BIOSVersion %s: %w", biosVersion.Name, err))
 					continue

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -100,15 +100,12 @@ func (r *BMCSettingsReconciler) reconcileExists(ctx context.Context, settings *m
 }
 
 func (r *BMCSettingsReconciler) shouldDelete(ctx context.Context, bmcSetting *metalv1alpha1.BMCSettings) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
-	if bmcSetting.DeletionTimestamp.IsZero() {
-		return false, nil
-	}
-
-	if controllerutil.ContainsFinalizer(bmcSetting, BMCSettingFinalizer) && len(bmcSetting.Spec.ServerMaintenanceRefs) > 0 {
+	isProgressing := func() (bool, error) {
+		if bmcSetting.Status.State != metalv1alpha1.BMCSettingsStateInProgress {
+			return false, nil
+		}
 		if _, err := r.getBMC(ctx, bmcSetting); apierrors.IsNotFound(err) {
-			log.V(1).Info("BMC not found, proceeding with deletion", "BMC", bmcSetting.Spec.BMCRef.Name)
-			return true, nil
+			return false, nil
 		}
 		refs := make([]metalv1alpha1.ObjectReference, 0, len(bmcSetting.Spec.ServerMaintenanceRefs))
 		for _, item := range bmcSetting.Spec.ServerMaintenanceRefs {
@@ -116,16 +113,9 @@ func (r *BMCSettingsReconciler) shouldDelete(ctx context.Context, bmcSetting *me
 				refs = append(refs, *item.ServerMaintenanceRef)
 			}
 		}
-		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, refs)
-		if err != nil {
-			return false, fmt.Errorf("failed to check maintenance state: %w", err)
-		}
-		if active {
-			log.V(1).Info("Postponing delete as BMCSettings is under active maintenance")
-			return false, nil
-		}
+		return IsAnyServerMaintenanceActive(ctx, r.Client, refs)
 	}
-	return true, nil
+	return shouldProceedWithDeletion(ctx, bmcSetting, BMCSettingFinalizer, isProgressing)
 }
 
 func (r *BMCSettingsReconciler) delete(ctx context.Context, settings *metalv1alpha1.BMCSettings) (ctrl.Result, error) {

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -25,6 +25,7 @@ import (
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/ironcore-dev/metal-operator/bmc"
 	"github.com/ironcore-dev/metal-operator/internal/bmcutils"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 	"github.com/stmcginnis/gofish/schemas"
 )
 
@@ -113,7 +114,7 @@ func (r *BMCSettingsReconciler) shouldDelete(ctx context.Context, bmcSetting *me
 				refs = append(refs, *item.ServerMaintenanceRef)
 			}
 		}
-		return IsAnyServerMaintenanceActive(ctx, r.Client, refs)
+		return metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, refs)
 	}
 	return shouldProceedWithDeletion(ctx, bmcSetting, BMCSettingFinalizer, isProgressing)
 }

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -87,7 +87,11 @@ func (r *BMCSettingsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // - the referred BMC references another BMCSettings object with a lower version
 func (r *BMCSettingsReconciler) reconcileExists(ctx context.Context, settings *metalv1alpha1.BMCSettings) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	if r.shouldDelete(ctx, settings) {
+	ok, err := r.shouldDelete(ctx, settings)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if ok {
 		log.V(1).Info("Object is being deleted")
 		return r.delete(ctx, settings)
 	}
@@ -95,22 +99,33 @@ func (r *BMCSettingsReconciler) reconcileExists(ctx context.Context, settings *m
 	return r.reconcile(ctx, settings)
 }
 
-func (r *BMCSettingsReconciler) shouldDelete(ctx context.Context, bmcSetting *metalv1alpha1.BMCSettings) bool {
+func (r *BMCSettingsReconciler) shouldDelete(ctx context.Context, bmcSetting *metalv1alpha1.BMCSettings) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if bmcSetting.DeletionTimestamp.IsZero() {
-		return false
+		return false, nil
 	}
 
-	if controllerutil.ContainsFinalizer(bmcSetting, BMCSettingFinalizer) &&
-		bmcSetting.Status.State == metalv1alpha1.BMCSettingsStateInProgress {
+	if controllerutil.ContainsFinalizer(bmcSetting, BMCSettingFinalizer) && len(bmcSetting.Spec.ServerMaintenanceRefs) > 0 {
 		if _, err := r.getBMC(ctx, bmcSetting); apierrors.IsNotFound(err) {
 			log.V(1).Info("BMC not found, proceeding with deletion", "BMC", bmcSetting.Spec.BMCRef.Name)
-			return true
+			return true, nil
 		}
-		log.V(1).Info("Postponing delete as Settings update is in progress")
-		return false
+		refs := make([]metalv1alpha1.ObjectReference, 0, len(bmcSetting.Spec.ServerMaintenanceRefs))
+		for _, item := range bmcSetting.Spec.ServerMaintenanceRefs {
+			if item.ServerMaintenanceRef != nil {
+				refs = append(refs, *item.ServerMaintenanceRef)
+			}
+		}
+		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, refs)
+		if err != nil {
+			return false, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			log.V(1).Info("Postponing delete as BMCSettings is under active maintenance")
+			return false, nil
+		}
 	}
-	return true
+	return true, nil
 }
 
 func (r *BMCSettingsReconciler) delete(ctx context.Context, settings *metalv1alpha1.BMCSettings) (ctrl.Result, error) {

--- a/internal/controller/bmcsettingsset_controller.go
+++ b/internal/controller/bmcsettingsset_controller.go
@@ -341,7 +341,7 @@ func (r *BMCSettingsSetReconciler) deleteOrphanedBMCSettings(
 	var errs []error
 	for _, bmcSettings := range bmcSettingsList.Items {
 		if _, ok := bmcMap[bmcSettings.Spec.BMCRef.Name]; !ok {
-			if len(bmcSettings.Spec.ServerMaintenanceRefs) > 0 {
+			if bmcSettings.Status.State == metalv1alpha1.BMCSettingsStateInProgress && len(bmcSettings.Spec.ServerMaintenanceRefs) > 0 {
 				refs := make([]metalv1alpha1.ObjectReference, 0, len(bmcSettings.Spec.ServerMaintenanceRefs))
 				for _, item := range bmcSettings.Spec.ServerMaintenanceRefs {
 					if item.ServerMaintenanceRef != nil {

--- a/internal/controller/bmcsettingsset_controller.go
+++ b/internal/controller/bmcsettingsset_controller.go
@@ -107,9 +107,21 @@ func (r *BMCSettingsSetReconciler) delete(
 	}
 	delTableBMCSettings := map[string]struct{}{}
 	for _, bmcSettings := range ownedBMCSettings.Items {
-
-		if bmcSettings.Status.State != metalv1alpha1.BMCSettingsStateInProgress || len(bmcSettings.Spec.ServerMaintenanceRefs) == 0 {
-			// If no ServerMaintenanceRefs is set, the BMCSettings is not actively being processed
+		if len(bmcSettings.Spec.ServerMaintenanceRefs) == 0 {
+			delTableBMCSettings[bmcSettings.Name] = struct{}{}
+			continue
+		}
+		refs := make([]metalv1alpha1.ObjectReference, 0, len(bmcSettings.Spec.ServerMaintenanceRefs))
+		for _, item := range bmcSettings.Spec.ServerMaintenanceRefs {
+			if item.ServerMaintenanceRef != nil {
+				refs = append(refs, *item.ServerMaintenanceRef)
+			}
+		}
+		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, refs)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to check maintenance state for BMCSettings %s: %w", bmcSettings.Name, err)
+		}
+		if !active {
 			delTableBMCSettings[bmcSettings.Name] = struct{}{}
 		}
 	}
@@ -329,10 +341,23 @@ func (r *BMCSettingsSetReconciler) deleteOrphanedBMCSettings(
 	var errs []error
 	for _, bmcSettings := range bmcSettingsList.Items {
 		if _, ok := bmcMap[bmcSettings.Spec.BMCRef.Name]; !ok {
-			if bmcSettings.Status.State == metalv1alpha1.BMCSettingsStateInProgress {
-				log.V(1).Info("Waiting for BMCSettings to move out of InProgress state",
-					"BMCSettings", bmcSettings.Name, "status", bmcSettings.Status)
-				continue
+			if len(bmcSettings.Spec.ServerMaintenanceRefs) > 0 {
+				refs := make([]metalv1alpha1.ObjectReference, 0, len(bmcSettings.Spec.ServerMaintenanceRefs))
+				for _, item := range bmcSettings.Spec.ServerMaintenanceRefs {
+					if item.ServerMaintenanceRef != nil {
+						refs = append(refs, *item.ServerMaintenanceRef)
+					}
+				}
+				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, refs)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("failed to check maintenance state for BMCSettings %s: %w", bmcSettings.Name, err))
+					continue
+				}
+				if active {
+					log.V(1).Info("Waiting for BMCSettings maintenance to complete before deletion",
+						"BMCSettings", bmcSettings.Name, "status", bmcSettings.Status)
+					continue
+				}
 			}
 			if err := r.Delete(ctx, &bmcSettings); err != nil {
 				errs = append(errs, err)

--- a/internal/controller/bmcsettingsset_controller.go
+++ b/internal/controller/bmcsettingsset_controller.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -117,7 +118,7 @@ func (r *BMCSettingsSetReconciler) delete(
 				refs = append(refs, *item.ServerMaintenanceRef)
 			}
 		}
-		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, refs)
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, refs)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to check maintenance state for BMCSettings %s: %w", bmcSettings.Name, err)
 		}
@@ -348,7 +349,7 @@ func (r *BMCSettingsSetReconciler) deleteOrphanedBMCSettings(
 						refs = append(refs, *item.ServerMaintenanceRef)
 					}
 				}
-				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, refs)
+				active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, refs)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to check maintenance state for BMCSettings %s: %w", bmcSettings.Name, err))
 					continue

--- a/internal/controller/bmcsettingsset_controller_test.go
+++ b/internal/controller/bmcsettingsset_controller_test.go
@@ -733,6 +733,14 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 			HaveField("Status.FailedAttempts", Equal(int32(failedAutoRetryCount))),
 		))
 
+		By("Ensuring BMCSettingsSet has a stable view of bmc01 before triggering retry")
+		Eventually(Object(bmcSettingsSet)).Should(
+			HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 1)),
+		)
+		Consistently(Object(bmcSettingsSet), "200ms").Should(
+			HaveField("Status.FullyLabeledBMCs", BeNumerically("==", 1)),
+		)
+
 		By("Updating the BMCSettingsSet with retry annotation")
 		Eventually(Update(bmcSettingsSet, func() {
 			bmcSettingsSet.Annotations = map[string]string{

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -14,6 +14,7 @@ import (
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/ironcore-dev/metal-operator/bmc"
 	"github.com/ironcore-dev/metal-operator/internal/bmcutils"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/schemas"
 	corev1 "k8s.io/api/core/v1"
@@ -86,7 +87,7 @@ func (r *BMCVersionReconciler) shouldDelete(ctx context.Context, bmcVersion *met
 		if _, err := r.getBMCFromBMCVersion(ctx, bmcVersion); apierrors.IsNotFound(err) {
 			return false, nil
 		}
-		return IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
+		return metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
 	}
 	return shouldProceedWithDeletion(ctx, bmcVersion, bmcVersionFinalizer, isProgressing)
 }
@@ -99,7 +100,7 @@ func (r *BMCVersionReconciler) delete(ctx context.Context, bmcVersion *metalv1al
 	}
 
 	if len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
-		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to check maintenance state: %w", err)
 		}

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -68,28 +68,37 @@ func (r *BMCVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 }
 
 func (r *BMCVersionReconciler) reconcileExists(ctx context.Context, bmcVersion *metalv1alpha1.BMCVersion) (ctrl.Result, error) {
-	if r.shouldDelete(ctx, bmcVersion) {
+	ok, err := r.shouldDelete(ctx, bmcVersion)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if ok {
 		return r.delete(ctx, bmcVersion)
 	}
 	return r.reconcile(ctx, bmcVersion)
 }
 
-func (r *BMCVersionReconciler) shouldDelete(ctx context.Context, bmcVersion *metalv1alpha1.BMCVersion) bool {
+func (r *BMCVersionReconciler) shouldDelete(ctx context.Context, bmcVersion *metalv1alpha1.BMCVersion) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if bmcVersion.DeletionTimestamp.IsZero() {
-		return false
+		return false, nil
 	}
 
-	if controllerutil.ContainsFinalizer(bmcVersion, bmcVersionFinalizer) &&
-		bmcVersion.Status.State == metalv1alpha1.BMCVersionStateInProgress {
+	if controllerutil.ContainsFinalizer(bmcVersion, bmcVersionFinalizer) && len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
 		if _, err := r.getBMCFromBMCVersion(ctx, bmcVersion); apierrors.IsNotFound(err) {
 			log.V(1).Info("BMC not found, proceeding with deletion", "BMC", bmcVersion.Spec.BMCRef.Name)
-			return true
+			return true, nil
 		}
-		log.V(1).Info("Postponing deletion as BMC version update is in progress")
-		return false
+		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
+		if err != nil {
+			return false, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			log.V(1).Info("Postponing deletion as BMCVersion is under active maintenance")
+			return false, nil
+		}
 	}
-	return true
+	return true, nil
 }
 
 func (r *BMCVersionReconciler) delete(ctx context.Context, bmcVersion *metalv1alpha1.BMCVersion) (ctrl.Result, error) {
@@ -99,9 +108,15 @@ func (r *BMCVersionReconciler) delete(ctx context.Context, bmcVersion *metalv1al
 		return ctrl.Result{}, nil
 	}
 
-	if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateInProgress {
-		log.V(1).Info("Skipping delete as version update is in progress")
-		return r.reconcile(ctx, bmcVersion)
+	if len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
+		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			log.V(1).Info("Skipping delete as BMCVersion is under active maintenance")
+			return r.reconcile(ctx, bmcVersion)
+		}
 	}
 
 	log.V(1).Info("Ensuring that the finalizer is removed")

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -79,26 +79,16 @@ func (r *BMCVersionReconciler) reconcileExists(ctx context.Context, bmcVersion *
 }
 
 func (r *BMCVersionReconciler) shouldDelete(ctx context.Context, bmcVersion *metalv1alpha1.BMCVersion) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
-	if bmcVersion.DeletionTimestamp.IsZero() {
-		return false, nil
-	}
-
-	if controllerutil.ContainsFinalizer(bmcVersion, bmcVersionFinalizer) && len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
-		if _, err := r.getBMCFromBMCVersion(ctx, bmcVersion); apierrors.IsNotFound(err) {
-			log.V(1).Info("BMC not found, proceeding with deletion", "BMC", bmcVersion.Spec.BMCRef.Name)
-			return true, nil
-		}
-		active, err := IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
-		if err != nil {
-			return false, fmt.Errorf("failed to check maintenance state: %w", err)
-		}
-		if active {
-			log.V(1).Info("Postponing deletion as BMCVersion is under active maintenance")
+	isProgressing := func() (bool, error) {
+		if bmcVersion.Status.State != metalv1alpha1.BMCVersionStateInProgress {
 			return false, nil
 		}
+		if _, err := r.getBMCFromBMCVersion(ctx, bmcVersion); apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
 	}
-	return true, nil
+	return shouldProceedWithDeletion(ctx, bmcVersion, bmcVersionFinalizer, isProgressing)
 }
 
 func (r *BMCVersionReconciler) delete(ctx context.Context, bmcVersion *metalv1alpha1.BMCVersion) (ctrl.Result, error) {

--- a/internal/controller/bmcversionset_controller.go
+++ b/internal/controller/bmcversionset_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 const (
@@ -261,7 +262,7 @@ func (r *BMCVersionSetReconciler) deleteOrphanBMCVersions(
 	for _, bmcVersion := range bmcVersionList.Items {
 		if _, ok := bmcMap[bmcVersion.Spec.BMCRef.Name]; !ok {
 			if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateInProgress && len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
-				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
+				active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to check maintenance state for BMCVersion %s: %w", bmcVersion.Name, err))
 					continue

--- a/internal/controller/bmcversionset_controller.go
+++ b/internal/controller/bmcversionset_controller.go
@@ -41,6 +41,7 @@ type BMCVersionSetReconciler struct {
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcversionsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcs,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcversions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servermaintenances,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -259,7 +260,7 @@ func (r *BMCVersionSetReconciler) deleteOrphanBMCVersions(
 	var warnings []string
 	for _, bmcVersion := range bmcVersionList.Items {
 		if _, ok := bmcMap[bmcVersion.Spec.BMCRef.Name]; !ok {
-			if len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
+			if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateInProgress && len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
 				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to check maintenance state for BMCVersion %s: %w", bmcVersion.Name, err))

--- a/internal/controller/bmcversionset_controller.go
+++ b/internal/controller/bmcversionset_controller.go
@@ -259,10 +259,17 @@ func (r *BMCVersionSetReconciler) deleteOrphanBMCVersions(
 	var warnings []string
 	for _, bmcVersion := range bmcVersionList.Items {
 		if _, ok := bmcMap[bmcVersion.Spec.BMCRef.Name]; !ok {
-			if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateInProgress {
-				log.V(1).Info("Waiting for BMCVersion to move out of InProgress state", "BMCVersion", bmcVersion.Name, "status", bmcVersion.Status)
-				warnings = append(warnings, fmt.Sprintf("BMCVersion %s is still in progress, skipping deletion", bmcVersion.Name))
-				continue
+			if len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
+				active, err := IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("failed to check maintenance state for BMCVersion %s: %w", bmcVersion.Name, err))
+					continue
+				}
+				if active {
+					log.V(1).Info("Waiting for BMCVersion maintenance to complete before deletion", "BMCVersion", bmcVersion.Name, "status", bmcVersion.Status)
+					warnings = append(warnings, fmt.Sprintf("BMCVersion %s is under active maintenance, skipping deletion", bmcVersion.Name))
+					continue
+				}
 			}
 			if err := r.Delete(ctx, &bmcVersion); err != nil {
 				errs = append(errs, err)

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ironcore-dev/metal-operator/third_party/expansion"
 	"github.com/stmcginnis/gofish/schemas"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -64,6 +65,28 @@ func GetServerMaintenanceForObjectReference(ctx context.Context, c client.Client
 	}
 
 	return maintenance, nil
+}
+
+// IsAnyServerMaintenanceActive returns true if any of the referenced ServerMaintenance
+// objects has State == InMaintenance. References whose objects are not found or are
+// being deleted are skipped (treated as inactive).
+func IsAnyServerMaintenanceActive(ctx context.Context, c client.Client, refs []metalv1alpha1.ObjectReference) (bool, error) {
+	for _, ref := range refs {
+		sm := &metalv1alpha1.ServerMaintenance{}
+		if err := c.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, sm); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return false, fmt.Errorf("failed to get ServerMaintenance %s/%s: %w", ref.Namespace, ref.Name, err)
+		}
+		if !sm.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if sm.Status.State == metalv1alpha1.ServerMaintenanceStateInMaintenance {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // GetCondition finds a condition in a condition slice.

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ironcore-dev/metal-operator/third_party/expansion"
 	"github.com/stmcginnis/gofish/schemas"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -93,28 +92,6 @@ func shouldProceedWithDeletion(
 	}
 	log.V(1).Info("Proceeding with deletion")
 	return true, nil
-}
-
-// IsAnyServerMaintenanceActive returns true if any of the referenced ServerMaintenance
-// objects has State == InMaintenance. References whose objects are not found or are
-// being deleted are skipped (treated as inactive).
-func IsAnyServerMaintenanceActive(ctx context.Context, c client.Client, refs []metalv1alpha1.ObjectReference) (bool, error) {
-	for _, ref := range refs {
-		sm := &metalv1alpha1.ServerMaintenance{}
-		if err := c.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, sm); err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			return false, fmt.Errorf("failed to get ServerMaintenance %s/%s: %w", ref.Namespace, ref.Name, err)
-		}
-		if !sm.DeletionTimestamp.IsZero() {
-			continue
-		}
-		if sm.Status.State == metalv1alpha1.ServerMaintenanceStateInMaintenance {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // GetCondition finds a condition in a condition slice.

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -67,6 +67,34 @@ func GetServerMaintenanceForObjectReference(ctx context.Context, c client.Client
 	return maintenance, nil
 }
 
+// shouldProceedWithDeletion returns true when obj should proceed with deletion.
+// isProgressing is called only when the object has the finalizer; it returns true
+// when deletion should be postponed (e.g. actively progressing under maintenance).
+// Callers own all state/ref/owner logic inside isProgressing.
+func shouldProceedWithDeletion(
+	ctx context.Context,
+	obj client.Object,
+	finalizer string,
+	isProgressing func() (bool, error),
+) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	if obj.GetDeletionTimestamp().IsZero() {
+		return false, nil
+	}
+	if controllerutil.ContainsFinalizer(obj, finalizer) {
+		progressing, err := isProgressing()
+		if err != nil {
+			return false, err
+		}
+		if progressing {
+			log.V(1).Info("Postponing deletion: resource is progressing under active maintenance")
+			return false, nil
+		}
+	}
+	log.V(1).Info("Proceeding with deletion")
+	return true, nil
+}
+
 // IsAnyServerMaintenanceActive returns true if any of the referenced ServerMaintenance
 // objects has State == InMaintenance. References whose objects are not found or are
 // being deleted are skipped (treated as inactive).

--- a/internal/util/helper.go
+++ b/internal/util/helper.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsAnyServerMaintenanceActive returns true if any of the referenced ServerMaintenance objects
+// is currently in the InMaintenance state.
+func IsAnyServerMaintenanceActive(ctx context.Context, c client.Client, refs []metalv1alpha1.ObjectReference) (bool, error) {
+	for _, ref := range refs {
+		sm := &metalv1alpha1.ServerMaintenance{}
+		if err := c.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, sm); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return false, fmt.Errorf("failed to get ServerMaintenance %s/%s: %w", ref.Namespace, ref.Name, err)
+		}
+		if !sm.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if sm.Status.State == metalv1alpha1.ServerMaintenanceStateInMaintenance {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/webhook/v1alpha1/biossettings_webhook.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook.go
@@ -54,13 +54,18 @@ func (v *BIOSSettingsCustomValidator) ValidateCreate(ctx context.Context, obj *m
 func (v *BIOSSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *metalv1alpha1.BIOSSettings) (admission.Warnings, error) {
 	settingsLog.Info("Validation for BIOSSettings upon update", "name", newObj.GetName())
 
-	// we do not allow Updates to BIOSSettings post server Maintenance creation
-	if oldObj.Status.State == metalv1alpha1.BIOSSettingsStateInProgress &&
-		!ShouldAllowForceUpdateInProgress(newObj) && oldObj.Spec.ServerMaintenanceRef != nil {
-		err := fmt.Errorf("BIOSSettings (%s) is in progress, unable to update %s", oldObj.Name, newObj.Name)
-		return nil, apierrors.NewInvalid(
-			schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind},
-			newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), err.Error())})
+	// Block updates while the referenced ServerMaintenance is InMaintenance.
+	if !ShouldAllowForceUpdateInProgress(newObj) && oldObj.Spec.ServerMaintenanceRef != nil {
+		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*oldObj.Spec.ServerMaintenanceRef})
+		if err != nil {
+			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			msg := fmt.Errorf("BIOSSettings %s is under active maintenance, unable to update", oldObj.Name)
+			return nil, apierrors.NewInvalid(
+				schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind},
+				newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), msg.Error())})
+		}
 	}
 
 	settingsList := &metalv1alpha1.BIOSSettingsList{}
@@ -72,11 +77,18 @@ func (v *BIOSSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type BIOSSettings.
-func (v *BIOSSettingsCustomValidator) ValidateDelete(_ context.Context, obj *metalv1alpha1.BIOSSettings) (admission.Warnings, error) {
+func (v *BIOSSettingsCustomValidator) ValidateDelete(ctx context.Context, obj *metalv1alpha1.BIOSSettings) (admission.Warnings, error) {
 	settingsLog.Info("Validation for BIOSSettings upon deletion", "name", obj.GetName())
 
-	if obj.Status.State == metalv1alpha1.BIOSSettingsStateInProgress && !ShouldAllowForceDeleteInProgress(obj) {
-		return nil, apierrors.NewBadRequest("The bios settings in progress, unable to delete")
+	// Block deletion while the referenced ServerMaintenance is InMaintenance.
+	if !ShouldAllowForceDeleteInProgress(obj) && obj.Spec.ServerMaintenanceRef != nil {
+		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*obj.Spec.ServerMaintenanceRef})
+		if err != nil {
+			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			return nil, apierrors.NewBadRequest("BIOSSettings is under active maintenance, unable to delete")
+		}
 	}
 
 	return nil, nil

--- a/internal/webhook/v1alpha1/biossettings_webhook.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 // log is for logging in this package.
@@ -56,7 +57,7 @@ func (v *BIOSSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj
 
 	// Block updates while the referenced ServerMaintenance is InMaintenance.
 	if !ShouldAllowForceUpdateInProgress(newObj) && oldObj.Spec.ServerMaintenanceRef != nil {
-		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*oldObj.Spec.ServerMaintenanceRef})
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*oldObj.Spec.ServerMaintenanceRef})
 		if err != nil {
 			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
 		}
@@ -82,7 +83,7 @@ func (v *BIOSSettingsCustomValidator) ValidateDelete(ctx context.Context, obj *m
 
 	// Block deletion while the referenced ServerMaintenance is InMaintenance.
 	if !ShouldAllowForceDeleteInProgress(obj) && obj.Spec.ServerMaintenanceRef != nil {
-		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*obj.Spec.ServerMaintenanceRef})
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*obj.Spec.ServerMaintenanceRef})
 		if err != nil {
 			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
 		}

--- a/internal/webhook/v1alpha1/biossettings_webhook_test.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook_test.go
@@ -176,6 +176,22 @@ var _ = Describe("BIOSSettings Webhook", func() {
 	})
 
 	It("should not allow update of BIOSSettings which are in-progress, but should allow forcefully deleting it", func() {
+		By("Creating a ServerMaintenance in InMaintenance state")
+		sm := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-sm-",
+				Namespace:    metav1.NamespaceDefault,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				Policy:    metalv1alpha1.ServerMaintenancePolicyEnforced,
+				ServerRef: &v1.LocalObjectReference{Name: "foo"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, sm)).To(Succeed())
+		Eventually(UpdateStatus(sm, func() {
+			sm.Status.State = metalv1alpha1.ServerMaintenanceStateInMaintenance
+		})).Should(Succeed())
+
 		By("Patching the BIOSSettings V1 to InProgress state")
 		Eventually(UpdateStatus(biosSettingsV1, func() {
 			biosSettingsV1.Status.State = metalv1alpha1.BIOSSettingsStateInProgress
@@ -183,7 +199,7 @@ var _ = Describe("BIOSSettings Webhook", func() {
 
 		By("Mocking a corresponding ServerMaintenance for the BIOSSettings V1")
 		Eventually(Update(biosSettingsV1, func() {
-			biosSettingsV1.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{Name: "maintenance"}
+			biosSettingsV1.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{Name: sm.Name, Namespace: sm.Namespace}
 		})).Should(Succeed())
 
 		By("Denying the spec update of an in-progress BIOSSettings")
@@ -199,12 +215,37 @@ var _ = Describe("BIOSSettings Webhook", func() {
 		Eventually(UpdateStatus(biosSettingsV1, func() {
 			biosSettingsV1.Status.State = metalv1alpha1.BIOSSettingsStateApplied
 		})).Should(Succeed())
+
+		Eventually(UpdateStatus(sm, func() {
+			sm.Status.State = metalv1alpha1.ServerMaintenanceStatePending
+		})).Should(Succeed())
 	})
 
 	It("should deny deletion of an in-progress BIOSSettings", func() {
+		By("Creating a ServerMaintenance in InMaintenance state")
+		sm := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-sm-",
+				Namespace:    metav1.NamespaceDefault,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				Policy:    metalv1alpha1.ServerMaintenancePolicyEnforced,
+				ServerRef: &v1.LocalObjectReference{Name: "foo"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, sm)).To(Succeed())
+		Eventually(UpdateStatus(sm, func() {
+			sm.Status.State = metalv1alpha1.ServerMaintenanceStateInMaintenance
+		})).Should(Succeed())
+
 		By("Patching the BIOSSettings V1 to InProgress state")
 		Eventually(UpdateStatus(biosSettingsV1, func() {
 			biosSettingsV1.Status.State = metalv1alpha1.BIOSSettingsStateInProgress
+		})).Should(Succeed())
+
+		By("Setting ServerMaintenanceRef on BIOSSettings V1")
+		Eventually(Update(biosSettingsV1, func() {
+			biosSettingsV1.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{Name: sm.Name, Namespace: sm.Namespace}
 		})).Should(Succeed())
 
 		By("Denying the deletion of an in-progress BIOSSettings")
@@ -213,6 +254,10 @@ var _ = Describe("BIOSSettings Webhook", func() {
 		By("Ensuring the BIOSSettings V1 is back to Applied state")
 		Eventually(UpdateStatus(biosSettingsV1, func() {
 			biosSettingsV1.Status.State = metalv1alpha1.BIOSSettingsStateApplied
+		})).Should(Succeed())
+
+		Eventually(UpdateStatus(sm, func() {
+			sm.Status.State = metalv1alpha1.ServerMaintenanceStatePending
 		})).Should(Succeed())
 	})
 })

--- a/internal/webhook/v1alpha1/biossettings_webhook_test.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
@@ -47,7 +48,10 @@ var _ = Describe("BIOSSettings Webhook", func() {
 	AfterEach(func(ctx SpecContext) {
 		By("Deleting the BIOSSettings and Server resources")
 		Expect(k8sClient.DeleteAllOf(ctx, &metalv1alpha1.BIOSSettings{})).To(Succeed())
-		Expect(k8sClient.DeleteAllOf(ctx, &metalv1alpha1.Server{})).To(Succeed())
+		By("Deleting Server resources if created")
+		Expect(client.IgnoreNotFound(k8sClient.DeleteAllOf(ctx, &metalv1alpha1.Server{}))).To(Succeed())
+		By("Deleting ServerMaintenance resources if created")
+		Expect(client.IgnoreNotFound(k8sClient.DeleteAllOf(ctx, &metalv1alpha1.ServerMaintenance{}))).To(Succeed())
 	})
 
 	It("should deny creation if a Server already has a BIOSSettings", func(ctx SpecContext) {

--- a/internal/webhook/v1alpha1/biosversion_webhook.go
+++ b/internal/webhook/v1alpha1/biosversion_webhook.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 // nolint:unused
@@ -56,7 +57,7 @@ func (v *BIOSVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 
 	// Block updates while the referenced ServerMaintenance is InMaintenance.
 	if !ShouldAllowForceUpdateInProgress(newObj) && oldObj.Spec.ServerMaintenanceRef != nil {
-		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*oldObj.Spec.ServerMaintenanceRef})
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*oldObj.Spec.ServerMaintenanceRef})
 		if err != nil {
 			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
 		}
@@ -82,7 +83,7 @@ func (v *BIOSVersionCustomValidator) ValidateDelete(ctx context.Context, obj *me
 
 	// Block deletion while the referenced ServerMaintenance is InMaintenance.
 	if !ShouldAllowForceDeleteInProgress(obj) && obj.Spec.ServerMaintenanceRef != nil {
-		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*obj.Spec.ServerMaintenanceRef})
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*obj.Spec.ServerMaintenanceRef})
 		if err != nil {
 			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
 		}

--- a/internal/webhook/v1alpha1/biosversion_webhook.go
+++ b/internal/webhook/v1alpha1/biosversion_webhook.go
@@ -54,14 +54,18 @@ func (v *BIOSVersionCustomValidator) ValidateCreate(ctx context.Context, obj *me
 func (v *BIOSVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *metalv1alpha1.BIOSVersion) (admission.Warnings, error) {
 	versionLog.Info("Validation for BIOSVersion upon update", "name", newObj.GetName())
 
-	if oldObj.Status.State == metalv1alpha1.BIOSVersionStateInProgress &&
-		!ShouldAllowForceUpdateInProgress(newObj) && oldObj.Spec.ServerMaintenanceRef != nil {
-		err := fmt.Errorf("BIOSVersion (%v) is in progress, unable to update %v",
-			oldObj.Name,
-			newObj.Name)
-		return nil, apierrors.NewInvalid(
-			schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind},
-			newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), err.Error())})
+	// Block updates while the referenced ServerMaintenance is InMaintenance.
+	if !ShouldAllowForceUpdateInProgress(newObj) && oldObj.Spec.ServerMaintenanceRef != nil {
+		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*oldObj.Spec.ServerMaintenanceRef})
+		if err != nil {
+			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			msg := fmt.Errorf("BIOSVersion %s is under active maintenance, unable to update", oldObj.Name)
+			return nil, apierrors.NewInvalid(
+				schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind},
+				newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), msg.Error())})
+		}
 	}
 
 	versions := &metalv1alpha1.BIOSVersionList{}
@@ -76,8 +80,15 @@ func (v *BIOSVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 func (v *BIOSVersionCustomValidator) ValidateDelete(ctx context.Context, obj *metalv1alpha1.BIOSVersion) (admission.Warnings, error) {
 	versionLog.Info("Validation for BIOSVersion upon deletion", "name", obj.GetName())
 
-	if obj.Status.State == metalv1alpha1.BIOSVersionStateInProgress && !ShouldAllowForceDeleteInProgress(obj) {
-		return nil, apierrors.NewBadRequest("The BIOS version is in progress and cannot be deleted")
+	// Block deletion while the referenced ServerMaintenance is InMaintenance.
+	if !ShouldAllowForceDeleteInProgress(obj) && obj.Spec.ServerMaintenanceRef != nil {
+		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, []metalv1alpha1.ObjectReference{*obj.Spec.ServerMaintenanceRef})
+		if err != nil {
+			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			return nil, apierrors.NewBadRequest("BIOSVersion is under active maintenance, unable to delete")
+		}
 	}
 	return nil, nil
 }

--- a/internal/webhook/v1alpha1/biosversion_webhook_test.go
+++ b/internal/webhook/v1alpha1/biosversion_webhook_test.go
@@ -149,6 +149,22 @@ var _ = Describe("BIOSVersion Webhook", func() {
 	})
 
 	It("should not allow update when BIOSVersion is in progress, but should allow force update", func() {
+		By("Creating a ServerMaintenance in InMaintenance state")
+		sm := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-sm-",
+				Namespace:    metav1.NamespaceDefault,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				Policy:    metalv1alpha1.ServerMaintenancePolicyEnforced,
+				ServerRef: &v1.LocalObjectReference{Name: "foo"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, sm)).To(Succeed())
+		Eventually(UpdateStatus(sm, func() {
+			sm.Status.State = metalv1alpha1.ServerMaintenanceStateInMaintenance
+		})).Should(Succeed())
+
 		By("Patching the BIOSVersion V1 to in-progress state")
 		Eventually(UpdateStatus(biosVersionV1, func() {
 			biosVersionV1.Status.State = metalv1alpha1.BIOSVersionStateInProgress
@@ -156,15 +172,15 @@ var _ = Describe("BIOSVersion Webhook", func() {
 
 		By("Adding ServerMaintenance reference")
 		Eventually(Update(biosVersionV1, func() {
-			biosVersionV1.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{Name: "maintenance"}
+			biosVersionV1.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{Name: sm.Name, Namespace: sm.Namespace}
 		})).Should(Succeed())
 
-		By("Updating the BIOSVersion V1 spec should fail to update when in InProgress state")
+		By("Updating the BIOSVersion V1 spec should fail to update while maintenance is active")
 		biosVersionV1Updated := biosVersionV1.DeepCopy()
 		biosVersionV1Updated.Spec.Version = "P712"
 		Expect(validator.ValidateUpdate(ctx, biosVersionV1, biosVersionV1Updated)).Error().To(HaveOccurred())
 
-		By("Updating BIOSVersion V1 spec should succeed when InProgress with ForceUpdateInProgress annotation")
+		By("Updating BIOSVersion V1 spec should succeed with ForceUpdateInProgress annotation")
 		biosVersionV1Updated.Annotations = map[string]string{metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationForceUpdateInProgress}
 		Expect(validator.ValidateUpdate(ctx, biosVersionV1, biosVersionV1Updated)).Error().ToNot(HaveOccurred())
 
@@ -172,19 +188,43 @@ var _ = Describe("BIOSVersion Webhook", func() {
 		Eventually(UpdateStatus(biosVersionV1, func() {
 			biosVersionV1.Status.State = metalv1alpha1.BIOSVersionStateCompleted
 		})).Should(Succeed())
+
+		Eventually(UpdateStatus(sm, func() {
+			sm.Status.State = metalv1alpha1.ServerMaintenanceStatePending
+		})).Should(Succeed())
 	})
 
-	It("should refuse to delete if InProgress", func() {
-		By("Patching the BIOSVersion V1 to InProgress state")
-		Eventually(UpdateStatus(biosVersionV1, func() {
-			biosVersionV1.Status.State = metalv1alpha1.BIOSVersionStateInProgress
+	It("should refuse to delete while ServerMaintenance is active", func() {
+		By("Creating a ServerMaintenance in InMaintenance state")
+		sm := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-sm-",
+				Namespace:    metav1.NamespaceDefault,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				Policy:    metalv1alpha1.ServerMaintenancePolicyEnforced,
+				ServerRef: &v1.LocalObjectReference{Name: "foo"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, sm)).To(Succeed())
+		Eventually(UpdateStatus(sm, func() {
+			sm.Status.State = metalv1alpha1.ServerMaintenanceStateInMaintenance
 		})).Should(Succeed())
 
-		By("Validating deletion of BIOSVersion V1 should fail")
+		By("Setting ServerMaintenanceRef on BIOSVersion V1")
+		Eventually(Update(biosVersionV1, func() {
+			biosVersionV1.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{Name: sm.Name, Namespace: sm.Namespace}
+		})).Should(Succeed())
+
+		By("Validating deletion of BIOSVersion V1 should fail while maintenance is active")
 		Expect(validator.ValidateDelete(ctx, biosVersionV1)).Error().To(HaveOccurred())
 
-		Eventually(UpdateStatus(biosVersionV1, func() {
-			biosVersionV1.Status.State = metalv1alpha1.BIOSVersionStateCompleted
+		By("Deactivating the ServerMaintenance")
+		Eventually(UpdateStatus(sm, func() {
+			sm.Status.State = metalv1alpha1.ServerMaintenanceStatePending
 		})).Should(Succeed())
+
+		By("Validating deletion of BIOSVersion V1 should succeed once maintenance is inactive")
+		Expect(validator.ValidateDelete(ctx, biosVersionV1)).Error().ToNot(HaveOccurred())
 	})
 })

--- a/internal/webhook/v1alpha1/bmcsettings_webhook.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook.go
@@ -56,14 +56,24 @@ func (v *BMCSettingsCustomValidator) ValidateCreate(ctx context.Context, obj *me
 func (v *BMCSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *metalv1alpha1.BMCSettings) (admission.Warnings, error) {
 	bmcsettingslog.Info("Validation for BMCSettings upon update", "name", newObj.GetName())
 
-	if oldObj.Status.State == metalv1alpha1.BMCSettingsStateInProgress &&
-		!ShouldAllowForceUpdateInProgress(newObj) && oldObj.Spec.ServerMaintenanceRefs != nil {
-		err := fmt.Errorf("BMCSettings (%s) is in progress, unable to update %s",
-			oldObj.Name,
-			newObj.Name)
-		return nil, apierrors.NewInvalid(
-			schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: oldObj.Kind},
-			newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), err.Error())})
+	// Block updates while any referenced ServerMaintenance is InMaintenance.
+	if !ShouldAllowForceUpdateInProgress(newObj) && len(oldObj.Spec.ServerMaintenanceRefs) > 0 {
+		refs := make([]metalv1alpha1.ObjectReference, 0, len(oldObj.Spec.ServerMaintenanceRefs))
+		for _, item := range oldObj.Spec.ServerMaintenanceRefs {
+			if item.ServerMaintenanceRef != nil {
+				refs = append(refs, *item.ServerMaintenanceRef)
+			}
+		}
+		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, refs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			msg := fmt.Errorf("BMCSettings %s is under active maintenance, unable to update", oldObj.Name)
+			return nil, apierrors.NewInvalid(
+				schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: oldObj.Kind},
+				newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), msg.Error())})
+		}
 	}
 
 	bmcSettingsList := &metalv1alpha1.BMCSettingsList{}
@@ -77,8 +87,21 @@ func (v *BMCSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 func (v *BMCSettingsCustomValidator) ValidateDelete(ctx context.Context, obj *metalv1alpha1.BMCSettings) (admission.Warnings, error) {
 	bmcsettingslog.Info("Validation for BMCSettings upon deletion", "name", obj.GetName())
 
-	if obj.Status.State == metalv1alpha1.BMCSettingsStateInProgress && !ShouldAllowForceDeleteInProgress(obj) {
-		return nil, apierrors.NewBadRequest("The BMC settings in progress, unable to delete")
+	// Block deletion while any referenced ServerMaintenance is InMaintenance.
+	if !ShouldAllowForceDeleteInProgress(obj) && len(obj.Spec.ServerMaintenanceRefs) > 0 {
+		refs := make([]metalv1alpha1.ObjectReference, 0, len(obj.Spec.ServerMaintenanceRefs))
+		for _, item := range obj.Spec.ServerMaintenanceRefs {
+			if item.ServerMaintenanceRef != nil {
+				refs = append(refs, *item.ServerMaintenanceRef)
+			}
+		}
+		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, refs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			return nil, apierrors.NewBadRequest("BMCSettings is under active maintenance, unable to delete")
+		}
 	}
 
 	return nil, nil

--- a/internal/webhook/v1alpha1/bmcsettings_webhook.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 // log is for logging in this package.
@@ -64,7 +65,7 @@ func (v *BMCSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 				refs = append(refs, *item.ServerMaintenanceRef)
 			}
 		}
-		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, refs)
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, v.Client, refs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
 		}
@@ -95,7 +96,7 @@ func (v *BMCSettingsCustomValidator) ValidateDelete(ctx context.Context, obj *me
 				refs = append(refs, *item.ServerMaintenanceRef)
 			}
 		}
-		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, refs)
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, v.Client, refs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
 		}

--- a/internal/webhook/v1alpha1/bmcsettings_webhook_test.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook_test.go
@@ -24,7 +24,6 @@ var _ = Describe("BMCSettings Webhook", func() {
 	BeforeEach(func() {
 		BMCSettingsV1 = &metalv1alpha1.BMCSettings{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    "ns.Name",
 				GenerateName: "test-",
 			},
 			Spec: metalv1alpha1.BMCSettingsSpec{
@@ -43,7 +42,7 @@ var _ = Describe("BMCSettings Webhook", func() {
 	})
 
 	AfterEach(func() {
-		By("Deleting BMCSettings")
+		By("Deleting BMCSettings resources")
 		Expect(k8sClient.DeleteAllOf(ctx, &metalv1alpha1.BMCSettings{})).To(Succeed())
 	})
 
@@ -53,7 +52,6 @@ var _ = Describe("BMCSettings Webhook", func() {
 			By("Creating another BMCSettings with reference to existing referred BMC")
 			BMCSettingsV2 := &metalv1alpha1.BMCSettings{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:    "ns.Name",
 					GenerateName: "test-bmc-",
 				},
 				Spec: metalv1alpha1.BMCSettingsSpec{
@@ -71,7 +69,6 @@ var _ = Describe("BMCSettings Webhook", func() {
 			By("Creating another BMCSetting for different BMCRef")
 			BMCSettingsV2 := &metalv1alpha1.BMCSettings{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:    "ns.Name",
 					GenerateName: "test-",
 				},
 				Spec: metalv1alpha1.BMCSettingsSpec{
@@ -89,7 +86,6 @@ var _ = Describe("BMCSettings Webhook", func() {
 			By("Creating another BMCSetting with different BMCRef")
 			BMCSettingsV2 := &metalv1alpha1.BMCSettings{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:    "ns.Name",
 					GenerateName: "test-",
 				},
 				Spec: metalv1alpha1.BMCSettingsSpec{
@@ -112,7 +108,6 @@ var _ = Describe("BMCSettings Webhook", func() {
 			By("Creating another BMCSetting with different BMCref")
 			BMCSettingsV2 := &metalv1alpha1.BMCSettings{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:    "ns.Name",
 					GenerateName: "test-",
 				},
 				Spec: metalv1alpha1.BMCSettingsSpec{
@@ -132,20 +127,39 @@ var _ = Describe("BMCSettings Webhook", func() {
 		})
 
 		It("should not allow update when settings are in progress, but should allow forcing it", func() {
+			By("Creating a ServerMaintenance in InMaintenance state")
+			sm := &metalv1alpha1.ServerMaintenance{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-sm-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: metalv1alpha1.ServerMaintenanceSpec{
+					Policy:    metalv1alpha1.ServerMaintenancePolicyEnforced,
+					ServerRef: &v1.LocalObjectReference{Name: "foo"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sm)).To(Succeed())
+			Eventually(UpdateStatus(sm, func() {
+				sm.Status.State = metalv1alpha1.ServerMaintenanceStateInMaintenance
+			})).Should(Succeed())
+
 			By("Patching the BMCSettings V1 to InProgress state")
 			Eventually(UpdateStatus(BMCSettingsV1, func() {
 				BMCSettingsV1.Status.State = metalv1alpha1.BMCSettingsStateInProgress
 			})).Should(Succeed())
-			By("mock servermaintenance Creation maintenance")
+
+			By("Setting ServerMaintenance reference on BMCSettings V1")
 			Eventually(Update(BMCSettingsV1, func() {
 				BMCSettingsV1.Spec.ServerMaintenanceRefs = []metalv1alpha1.ServerMaintenanceRefItem{
-					{ServerMaintenanceRef: &metalv1alpha1.ObjectReference{Name: "foobar-Maintenance"}},
+					{ServerMaintenanceRef: &metalv1alpha1.ObjectReference{Name: sm.Name, Namespace: sm.Namespace}},
 				}
 			})).Should(Succeed())
+
 			By("Updating an bmcSettings V1 spec, should fail to update when inProgress")
 			bmcSettingsV1Updated := BMCSettingsV1.DeepCopy()
 			bmcSettingsV1Updated.Spec.SettingsMap = map[string]string{"test": "value"}
 			Expect(validator.ValidateUpdate(ctx, BMCSettingsV1, bmcSettingsV1Updated)).Error().To(HaveOccurred())
+
 			By("Updating an bmcSettings V1 spec, should pass to update when inProgress with ForceUpdateResource finalizer")
 			bmcSettingsV1Updated.Annotations = map[string]string{metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationForceUpdateInProgress}
 			Expect(validator.ValidateUpdate(ctx, BMCSettingsV1, bmcSettingsV1Updated)).Error().ToNot(HaveOccurred())
@@ -153,12 +167,33 @@ var _ = Describe("BMCSettings Webhook", func() {
 			Eventually(UpdateStatus(BMCSettingsV1, func() {
 				BMCSettingsV1.Status.State = metalv1alpha1.BMCSettingsStateApplied
 			})).Should(Succeed())
+			Eventually(UpdateStatus(sm, func() {
+				sm.Status.State = metalv1alpha1.ServerMaintenanceStatePending
+			})).Should(Succeed())
 		})
 
-		It("should refuse to delete if InProgress", func() {
-			By("Patching the BMCSettings V1 to a InProgress state")
-			Eventually(UpdateStatus(BMCSettingsV1, func() {
-				BMCSettingsV1.Status.State = metalv1alpha1.BMCSettingsStateInProgress
+		It("should refuse to delete while ServerMaintenance is active", func() {
+			By("Creating a ServerMaintenance in InMaintenance state")
+			sm := &metalv1alpha1.ServerMaintenance{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-sm-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: metalv1alpha1.ServerMaintenanceSpec{
+					Policy:    metalv1alpha1.ServerMaintenancePolicyEnforced,
+					ServerRef: &v1.LocalObjectReference{Name: "foo"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sm)).To(Succeed())
+			Eventually(UpdateStatus(sm, func() {
+				sm.Status.State = metalv1alpha1.ServerMaintenanceStateInMaintenance
+			})).Should(Succeed())
+
+			By("Setting ServerMaintenance reference on BMCSettings V1")
+			Eventually(Update(BMCSettingsV1, func() {
+				BMCSettingsV1.Spec.ServerMaintenanceRefs = []metalv1alpha1.ServerMaintenanceRefItem{
+					{ServerMaintenanceRef: &metalv1alpha1.ObjectReference{Name: sm.Name, Namespace: sm.Namespace}},
+				}
 			})).Should(Succeed())
 
 			By("Deleting the BMCSettings V1 should fail")
@@ -166,6 +201,10 @@ var _ = Describe("BMCSettings Webhook", func() {
 
 			Eventually(UpdateStatus(BMCSettingsV1, func() {
 				BMCSettingsV1.Status.State = metalv1alpha1.BMCSettingsStateApplied
+			})).Should(Succeed())
+
+			Eventually(UpdateStatus(sm, func() {
+				sm.Status.State = metalv1alpha1.ServerMaintenanceStatePending
 			})).Should(Succeed())
 		})
 	})

--- a/internal/webhook/v1alpha1/bmcsettings_webhook_test.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
@@ -44,6 +45,8 @@ var _ = Describe("BMCSettings Webhook", func() {
 	AfterEach(func() {
 		By("Deleting BMCSettings resources")
 		Expect(k8sClient.DeleteAllOf(ctx, &metalv1alpha1.BMCSettings{})).To(Succeed())
+		By("Deleting ServerMaintenance resources if created")
+		Expect(client.IgnoreNotFound(k8sClient.DeleteAllOf(ctx, &metalv1alpha1.ServerMaintenance{}))).To(Succeed())
 	})
 
 	Context("When creating or updating BMCSettings under Validating Webhook", func() {

--- a/internal/webhook/v1alpha1/bmcversion_webhook.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 // log is for logging in this package.
@@ -55,7 +56,7 @@ func (v *BMCVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj, 
 
 	// Block updates while any referenced ServerMaintenance is InMaintenance.
 	if !ShouldAllowForceUpdateInProgress(newObj) && len(oldObj.Spec.ServerMaintenanceRefs) > 0 {
-		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, oldObj.Spec.ServerMaintenanceRefs)
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, v.Client, oldObj.Spec.ServerMaintenanceRefs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
 		}
@@ -81,7 +82,7 @@ func (v *BMCVersionCustomValidator) ValidateDelete(ctx context.Context, obj *met
 
 	// Block deletion while any referenced ServerMaintenance is InMaintenance.
 	if !ShouldAllowForceDeleteInProgress(obj) && len(obj.Spec.ServerMaintenanceRefs) > 0 {
-		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, obj.Spec.ServerMaintenanceRefs)
+		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, v.Client, obj.Spec.ServerMaintenanceRefs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
 		}

--- a/internal/webhook/v1alpha1/bmcversion_webhook.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook.go
@@ -53,14 +53,18 @@ func (v *BMCVersionCustomValidator) ValidateCreate(ctx context.Context, obj *met
 func (v *BMCVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *metalv1alpha1.BMCVersion) (admission.Warnings, error) {
 	bmcversionlog.Info("Validation for BMCVersion upon update", "name", newObj.GetName())
 
-	if oldObj.Status.State == metalv1alpha1.BMCVersionStateInProgress &&
-		!ShouldAllowForceUpdateInProgress(newObj) && oldObj.Spec.ServerMaintenanceRefs != nil {
-		err := fmt.Errorf("BMCVersion (%v) is in progress, unable to update %v",
-			oldObj.Name,
-			newObj.Name)
-		return nil, apierrors.NewInvalid(
-			schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind},
-			newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), err.Error())})
+	// Block updates while any referenced ServerMaintenance is InMaintenance.
+	if !ShouldAllowForceUpdateInProgress(newObj) && len(oldObj.Spec.ServerMaintenanceRefs) > 0 {
+		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, oldObj.Spec.ServerMaintenanceRefs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			msg := fmt.Errorf("BMCVersion %s is under active maintenance, unable to update", oldObj.Name)
+			return nil, apierrors.NewInvalid(
+				schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind},
+				newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), msg.Error())})
+		}
 	}
 
 	bmcVersionList := &metalv1alpha1.BMCVersionList{}
@@ -75,17 +79,15 @@ func (v *BMCVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj, 
 func (v *BMCVersionCustomValidator) ValidateDelete(ctx context.Context, obj *metalv1alpha1.BMCVersion) (admission.Warnings, error) {
 	bmcversionlog.Info("Validation for BMCVersion upon deletion", "name", obj.GetName())
 
-	bv := &metalv1alpha1.BMCVersion{}
-	err := v.Client.Get(ctx, client.ObjectKey{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-	}, bv)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get BMCVersion: %w", err)
-	}
-
-	if bv.Status.State == metalv1alpha1.BMCVersionStateInProgress && !ShouldAllowForceDeleteInProgress(obj) {
-		return nil, apierrors.NewBadRequest("Unable to delete BMCVersion as it is in progress")
+	// Block deletion while any referenced ServerMaintenance is InMaintenance.
+	if !ShouldAllowForceDeleteInProgress(obj) && len(obj.Spec.ServerMaintenanceRefs) > 0 {
+		active, err := IsAnyServerMaintenanceActive(ctx, v.Client, obj.Spec.ServerMaintenanceRefs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check maintenance state: %w", err)
+		}
+		if active {
+			return nil, apierrors.NewBadRequest("BMCVersion is under active maintenance, unable to delete")
+		}
 	}
 
 	return nil, nil

--- a/internal/webhook/v1alpha1/bmcversion_webhook_test.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
@@ -45,6 +46,8 @@ var _ = Describe("BMCVersion Webhook", func() {
 	AfterEach(func() {
 		By("Deleting BMCVersion resources")
 		Expect(k8sClient.DeleteAllOf(ctx, &metalv1alpha1.BMCVersion{})).To(Succeed())
+		By("Deleting ServerMaintenance resources if created")
+		Expect(client.IgnoreNotFound(k8sClient.DeleteAllOf(ctx, &metalv1alpha1.ServerMaintenance{}))).To(Succeed())
 	})
 
 	Context("When creating or updating BMCVersion under Validating Webhook", func() {

--- a/internal/webhook/v1alpha1/bmcversion_webhook_test.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook_test.go
@@ -26,7 +26,6 @@ var _ = Describe("BMCVersion Webhook", func() {
 
 		BMCVersionV1 = &metalv1alpha1.BMCVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    "ns.Name",
 				GenerateName: "test-bmc-ver",
 			},
 			Spec: metalv1alpha1.BMCVersionSpec{
@@ -44,7 +43,7 @@ var _ = Describe("BMCVersion Webhook", func() {
 	})
 
 	AfterEach(func() {
-		By("Deleting BMCVersion")
+		By("Deleting BMCVersion resources")
 		Expect(k8sClient.DeleteAllOf(ctx, &metalv1alpha1.BMCVersion{})).To(Succeed())
 	})
 
@@ -53,7 +52,6 @@ var _ = Describe("BMCVersion Webhook", func() {
 			By("Creating another BMCVersion with reference to existing referred BMC")
 			BMCVersionV2 := &metalv1alpha1.BMCVersion{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:    "ns.Name",
 					GenerateName: "test-bmc-ver",
 				},
 				Spec: metalv1alpha1.BMCVersionSpec{
@@ -72,7 +70,6 @@ var _ = Describe("BMCVersion Webhook", func() {
 			By("Creating another BMCVersion for different BMCRef")
 			BMCVersionV2 := &metalv1alpha1.BMCVersion{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:    "ns.Name",
 					GenerateName: "test-bmc-ver",
 				},
 				Spec: metalv1alpha1.BMCVersionSpec{
@@ -91,7 +88,6 @@ var _ = Describe("BMCVersion Webhook", func() {
 			By("Creating another BMCVersion with different BMCRef")
 			BMCVersionV2 := &metalv1alpha1.BMCVersion{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:    "ns.Name",
 					GenerateName: "test-bmc-ver",
 				},
 				Spec: metalv1alpha1.BMCVersionSpec{
@@ -115,7 +111,6 @@ var _ = Describe("BMCVersion Webhook", func() {
 			By("Creating another BMCVersion with different BMCref")
 			BMCVersionV2 := &metalv1alpha1.BMCVersion{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:    "ns.Name",
 					GenerateName: "test-bmc-ver",
 				},
 				Spec: metalv1alpha1.BMCVersionSpec{
@@ -136,18 +131,37 @@ var _ = Describe("BMCVersion Webhook", func() {
 		})
 
 		It("should not allow update when settings are in progress, but should allow forcing it", func() {
+			By("Creating a ServerMaintenance in InMaintenance state")
+			sm := &metalv1alpha1.ServerMaintenance{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-sm-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: metalv1alpha1.ServerMaintenanceSpec{
+					Policy:    metalv1alpha1.ServerMaintenancePolicyEnforced,
+					ServerRef: &v1.LocalObjectReference{Name: "foo"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sm)).To(Succeed())
+			Eventually(UpdateStatus(sm, func() {
+				sm.Status.State = metalv1alpha1.ServerMaintenanceStateInMaintenance
+			})).Should(Succeed())
+
 			By("Patching the BMCVersion V1 to InProgress state")
 			Eventually(UpdateStatus(BMCVersionV1, func() {
 				BMCVersionV1.Status.State = metalv1alpha1.BMCVersionStateInProgress
 			})).Should(Succeed())
-			By("mock servermaintenance Creation maintenance")
+
+			By("Setting ServerMaintenance reference on BMCVersion V1")
 			Eventually(Update(BMCVersionV1, func() {
-				BMCVersionV1.Spec.ServerMaintenanceRefs = []metalv1alpha1.ObjectReference{{Name: "foobar-Maintenance"}}
+				BMCVersionV1.Spec.ServerMaintenanceRefs = []metalv1alpha1.ObjectReference{{Name: sm.Name, Namespace: sm.Namespace}}
 			})).Should(Succeed())
+
 			By("Updating an biosSettingsV1 spec, should fail to update when inProgress")
 			BMCVersionV1Updated := BMCVersionV1.DeepCopy()
 			BMCVersionV1Updated.Spec.Version = "P72"
 			Expect(validator.ValidateUpdate(ctx, BMCVersionV1, BMCVersionV1Updated)).Error().To(HaveOccurred())
+
 			By("Updating an biosSettingsV1 spec, should pass to update when inProgress with ForceUpdateResource finalizer")
 			BMCVersionV1Updated.Annotations = map[string]string{metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationForceUpdateInProgress}
 			Expect(validator.ValidateUpdate(ctx, BMCVersionV1, BMCVersionV1Updated)).Error().ToNot(HaveOccurred())
@@ -155,12 +169,33 @@ var _ = Describe("BMCVersion Webhook", func() {
 			Eventually(UpdateStatus(BMCVersionV1, func() {
 				BMCVersionV1.Status.State = metalv1alpha1.BMCVersionStateCompleted
 			})).Should(Succeed())
+
+			By("Deactivating the ServerMaintenance")
+			Eventually(UpdateStatus(sm, func() {
+				sm.Status.State = metalv1alpha1.ServerMaintenanceStatePending
+			})).Should(Succeed())
 		})
 
-		It("should refuse to delete if InProgress", func() {
-			By("Patching the BMCVersion V1 to an InProgress state")
-			Eventually(UpdateStatus(BMCVersionV1, func() {
-				BMCVersionV1.Status.State = metalv1alpha1.BMCVersionStateInProgress
+		It("should refuse to delete while ServerMaintenance is active", func() {
+			By("Creating a ServerMaintenance in InMaintenance state")
+			sm := &metalv1alpha1.ServerMaintenance{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-sm-",
+					Namespace:    metav1.NamespaceDefault,
+				},
+				Spec: metalv1alpha1.ServerMaintenanceSpec{
+					Policy:    metalv1alpha1.ServerMaintenancePolicyEnforced,
+					ServerRef: &v1.LocalObjectReference{Name: "foo"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sm)).To(Succeed())
+			Eventually(UpdateStatus(sm, func() {
+				sm.Status.State = metalv1alpha1.ServerMaintenanceStateInMaintenance
+			})).Should(Succeed())
+
+			By("Setting ServerMaintenance reference on BMCVersion V1")
+			Eventually(Update(BMCVersionV1, func() {
+				BMCVersionV1.Spec.ServerMaintenanceRefs = []metalv1alpha1.ObjectReference{{Name: sm.Name, Namespace: sm.Namespace}}
 			})).Should(Succeed())
 
 			By("Deleting the BMCVersionV1 should fail")
@@ -168,6 +203,11 @@ var _ = Describe("BMCVersion Webhook", func() {
 
 			Eventually(UpdateStatus(BMCVersionV1, func() {
 				BMCVersionV1.Status.State = metalv1alpha1.BMCVersionStateCompleted
+			})).Should(Succeed())
+
+			By("Deactivating the ServerMaintenance")
+			Eventually(UpdateStatus(sm, func() {
+				sm.Status.State = metalv1alpha1.ServerMaintenanceStatePending
 			})).Should(Succeed())
 		})
 	})

--- a/internal/webhook/v1alpha1/helper.go
+++ b/internal/webhook/v1alpha1/helper.go
@@ -4,35 +4,9 @@
 package v1alpha1
 
 import (
-	"context"
-	"fmt"
-
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// IsAnyServerMaintenanceActive returns true if any of the referenced ServerMaintenance
-// objects has State == InMaintenance. References whose objects are not found or are
-// being deleted are skipped (treated as inactive).
-func IsAnyServerMaintenanceActive(ctx context.Context, c client.Client, refs []metalv1alpha1.ObjectReference) (bool, error) {
-	for _, ref := range refs {
-		sm := &metalv1alpha1.ServerMaintenance{}
-		if err := c.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, sm); err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			return false, fmt.Errorf("failed to get ServerMaintenance %s/%s: %w", ref.Namespace, ref.Name, err)
-		}
-		if !sm.DeletionTimestamp.IsZero() {
-			continue
-		}
-		if sm.Status.State == metalv1alpha1.ServerMaintenanceStateInMaintenance {
-			return true, nil
-		}
-	}
-	return false, nil
-}
 
 // ShouldAllowForceUpdateInProgress checks if the object should force allow update.
 func ShouldAllowForceUpdateInProgress(obj client.Object) bool {

--- a/internal/webhook/v1alpha1/helper.go
+++ b/internal/webhook/v1alpha1/helper.go
@@ -4,9 +4,35 @@
 package v1alpha1
 
 import (
+	"context"
+	"fmt"
+
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// IsAnyServerMaintenanceActive returns true if any of the referenced ServerMaintenance
+// objects has State == InMaintenance. References whose objects are not found or are
+// being deleted are skipped (treated as inactive).
+func IsAnyServerMaintenanceActive(ctx context.Context, c client.Client, refs []metalv1alpha1.ObjectReference) (bool, error) {
+	for _, ref := range refs {
+		sm := &metalv1alpha1.ServerMaintenance{}
+		if err := c.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, sm); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return false, fmt.Errorf("failed to get ServerMaintenance %s/%s: %w", ref.Namespace, ref.Name, err)
+		}
+		if !sm.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if sm.Status.State == metalv1alpha1.ServerMaintenanceStateInMaintenance {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 // ShouldAllowForceUpdateInProgress checks if the object should force allow update.
 func ShouldAllowForceUpdateInProgress(obj client.Object) bool {


### PR DESCRIPTION

# Proposed Changes
BIOS/BMC Settings/Version CRD, improve logic to relax the restriction on the update and delete operations.
consolidate the method with a helper to improve maintainability 

Fixes #942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updates and deletions now honor active server maintenance by referencing the associated maintenance resource, preventing changes during active maintenance windows for BIOS and BMC-related resources.

* **Bug Fixes**
  * Improved dependent and orphan resource deletion behavior to defer only when maintenance is actively in progress (and proceed otherwise), including more accurate finalizer handling.
  * Webhook validation updated to block operations based on active maintenance rather than “in-progress” status.
  * Requeue behavior refined to ignore objects missing required server references.

* **Tests**
  * Updated and expanded webhook/deletion scenarios to cover maintenance-driven behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->