### PR TITLE
ServerMaintenance: optionally turn on Locator LED

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/servermaintenancespec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/servermaintenancespec.go
@@ -21,6 +21,9 @@ type ServerMaintenanceSpecApplyConfiguration struct {
 	ServerRef *v1.LocalObjectReference `json:"serverRef,omitempty"`
 	// ServerPower specifies the power state of the server during maintenance.
 	ServerPower *apiv1alpha1.Power `json:"serverPower,omitempty"`
+	// LocatorLED specifies the desired state of the server's locator LED during maintenance.
+	// When maintenance ends, the locator LED is turned off.
+	LocatorLED *apiv1alpha1.IndicatorLED `json:"locatorLED,omitempty"`
 	// Priority determines ordering when multiple ServerMaintenance resources target the same server.
 	// Higher values are processed first. If priorities are equal, older resources are processed first.
 	// If omitted, priority is treated as 0.
@@ -56,6 +59,14 @@ func (b *ServerMaintenanceSpecApplyConfiguration) WithServerRef(value v1.LocalOb
 // If called multiple times, the ServerPower field is set to the value of the last call.
 func (b *ServerMaintenanceSpecApplyConfiguration) WithServerPower(value apiv1alpha1.Power) *ServerMaintenanceSpecApplyConfiguration {
 	b.ServerPower = &value
+	return b
+}
+
+// WithLocatorLED sets the LocatorLED field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the LocatorLED field is set to the value of the last call.
+func (b *ServerMaintenanceSpecApplyConfiguration) WithLocatorLED(value apiv1alpha1.IndicatorLED) *ServerMaintenanceSpecApplyConfiguration {
+	b.LocatorLED = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -1176,6 +1176,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.ServerMaintenanceSpec
   map:
     fields:
+    - name: locatorLED
+      type:
+        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.IndicatorLED
     - name: policy
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.ServerMaintenancePolicy

--- a/api/v1alpha1/servermaintenance_types.go
+++ b/api/v1alpha1/servermaintenance_types.go
@@ -45,6 +45,11 @@ type ServerMaintenanceSpec struct {
 	// +optional
 	ServerPower Power `json:"serverPower,omitempty"`
 
+	// LocatorLED specifies the desired state of the server's locator LED during maintenance.
+	// When maintenance ends, the locator LED is turned off.
+	// +optional
+	LocatorLED IndicatorLED `json:"locatorLED,omitempty"`
+
 	// Priority determines ordering when multiple ServerMaintenance resources target the same server.
 	// Higher values are processed first. If priorities are equal, older resources are processed first.
 	// If omitted, priority is treated as 0.

--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -174,6 +174,12 @@ type AccountManager interface {
 	GetAccountService() (*schemas.AccountService, error)
 }
 
+// IndicatorController controls the physical indicator (locator) LED on a system.
+type IndicatorController interface {
+	// SetIndicatorLED sets the indicator LED state on the system.
+	SetIndicatorLED(ctx context.Context, systemURI string, state schemas.IndicatorLED) error
+}
+
 // EventSubscriber manages Redfish event subscriptions on the BMC.
 type EventSubscriber interface {
 	// CreateEventSubscription creates an event subscription for the manager.
@@ -196,6 +202,7 @@ type BMC interface {
 	FirmwareUpdater
 	ManagerController
 	AccountManager
+	IndicatorController
 	EventSubscriber
 
 	// Logout closes the BMC client connection by logging out.

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -240,6 +240,16 @@ func (r *RedfishBaseBMC) Reset(ctx context.Context, systemURI string, resetType 
 	return nil
 }
 
+// SetIndicatorLED sets the indicator LED state on the system using Redfish.
+func (r *RedfishBaseBMC) SetIndicatorLED(ctx context.Context, systemURI string, state schemas.IndicatorLED) error { //nolint:staticcheck
+	system, err := r.getSystemFromUri(ctx, systemURI)
+	if err != nil {
+		return fmt.Errorf("failed to get system: %w", err)
+	}
+	system.IndicatorLED = state //nolint:staticcheck
+	return system.Update()
+}
+
 // GetSystems get managed systems
 func (r *RedfishBaseBMC) GetSystems(ctx context.Context) ([]Server, error) {
 	service := r.client.GetService()

--- a/config/crd/bases/metal.ironcore.dev_servermaintenances.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servermaintenances.yaml
@@ -63,6 +63,11 @@ spec:
           spec:
             description: ServerMaintenanceSpec defines the desired state of a ServerMaintenance
             properties:
+              locatorLED:
+                description: |-
+                  LocatorLED specifies the desired state of the server's locator LED during maintenance.
+                  When maintenance ends, the locator LED is turned off.
+                type: string
               policy:
                 description: Policy specifies the maintenance policy to be enforced
                   on the server.

--- a/dist/chart/templates/crd/metal.ironcore.dev_servermaintenances.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servermaintenances.yaml
@@ -69,6 +69,11 @@ spec:
           spec:
             description: ServerMaintenanceSpec defines the desired state of a ServerMaintenance
             properties:
+              locatorLED:
+                description: |-
+                  LocatorLED specifies the desired state of the server's locator LED during maintenance.
+                  When maintenance ends, the locator LED is turned off.
+                type: string
               policy:
                 description: Policy specifies the maintenance policy to be enforced
                   on the server.

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1129,6 +1129,7 @@ IndicatorLED represents LED indicator states
 
 
 _Appears in:_
+- [ServerMaintenanceSpec](#servermaintenancespec)
 - [ServerSpec](#serverspec)
 - [ServerStatus](#serverstatus)
 
@@ -1635,6 +1636,7 @@ _Appears in:_
 | `policy` _[ServerMaintenancePolicy](#servermaintenancepolicy)_ | Policy specifies the maintenance policy to be enforced on the server. |  |  |
 | `serverRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | ServerRef is a reference to the server that is to be maintained. |  |  |
 | `serverPower` _[Power](#power)_ | ServerPower specifies the power state of the server during maintenance. |  |  |
+| `locatorLED` _[IndicatorLED](#indicatorled)_ | LocatorLED specifies the desired state of the server's locator LED during maintenance.<br />When maintenance ends, the locator LED is turned off. |  |  |
 | `priority` _integer_ | Priority determines ordering when multiple ServerMaintenance resources target the same server.<br />Higher values are processed first. If priorities are equal, older resources are processed first.<br />If omitted, priority is treated as 0. | 0 |  |
 | `serverBootConfigurationTemplate` _[ServerBootConfigurationTemplate](#serverbootconfigurationtemplate)_ | ServerBootConfigurationTemplate specifies the boot configuration to be applied to the server during maintenance. |  |  |
 

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -449,7 +449,7 @@ func (r *ServerReconciler) handleAvailableState(ctx context.Context, bmcClient b
 	}
 	log.V(1).Info("Ensured initial boot configuration is deleted")
 
-	if err := r.ensureIndicatorLED(ctx, server); err != nil {
+	if err := r.ensureIndicatorLED(ctx, bmcClient, server); err != nil {
 		return false, fmt.Errorf("failed to ensure server indicator led: %w", err)
 	}
 
@@ -538,7 +538,7 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bm
 		return false, fmt.Errorf("failed to ensure server power state: %w", err)
 	}
 
-	if err := r.ensureIndicatorLED(ctx, server); err != nil {
+	if err := r.ensureIndicatorLED(ctx, bmcClient, server); err != nil {
 		return false, fmt.Errorf("failed to ensure server indicator led: %w", err)
 	}
 	log.V(1).Info("Reconciled reserved state")
@@ -1164,9 +1164,16 @@ func (r *ServerReconciler) updatePowerOnCondition(ctx context.Context, server *m
 	return r.Status().Patch(ctx, server, client.MergeFrom(original))
 }
 
-func (r *ServerReconciler) ensureIndicatorLED(ctx context.Context, server *metalv1alpha1.Server) error {
-	// TODO: implement
-	return nil
+func (r *ServerReconciler) ensureIndicatorLED(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) error {
+	if server.Spec.IndicatorLED == "" {
+		return nil
+	}
+	desired := schemas.IndicatorLED(server.Spec.IndicatorLED)   //nolint:staticcheck
+	current := schemas.IndicatorLED(server.Status.IndicatorLED) //nolint:staticcheck
+	if desired == current {
+		return nil
+	}
+	return bmcClient.SetIndicatorLED(ctx, server.Spec.SystemURI, desired)
 }
 
 func (r *ServerReconciler) ensureInitialBootConfigurationIsDeleted(ctx context.Context, server *metalv1alpha1.Server) error {

--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -257,7 +257,7 @@ func (r *ServerMaintenanceReconciler) handleInMaintenanceState(ctx context.Conte
 	log.V(1).Info("Applied ServerBootConfiguration for Server")
 
 	if config == nil {
-		if err := r.setAndPatchServerPowerState(ctx, server, maintenance); err != nil {
+		if err := r.setAndPatchServerState(ctx, server, maintenance); err != nil {
 			return ctrl.Result{}, err
 		}
 		log.V(1).Info("Patched server power state", "Server", server.Name, "Power", maintenance.Spec.ServerPower)
@@ -278,7 +278,7 @@ func (r *ServerMaintenanceReconciler) handleInMaintenanceState(ctx context.Conte
 
 	if config.Status.State == metalv1alpha1.ServerBootConfigurationStateReady {
 		log.V(1).Info("Server maintenance boot configuration is ready", "Server", server.Name)
-		if err := r.setAndPatchServerPowerState(ctx, server, maintenance); err != nil {
+		if err := r.setAndPatchServerState(ctx, server, maintenance); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -320,9 +320,12 @@ func (r *ServerMaintenanceReconciler) applyServerBootConfiguration(ctx context.C
 	return config, nil
 }
 
-func (r *ServerMaintenanceReconciler) setAndPatchServerPowerState(ctx context.Context, server *metalv1alpha1.Server, maintenance *metalv1alpha1.ServerMaintenance) error {
+func (r *ServerMaintenanceReconciler) setAndPatchServerState(ctx context.Context, server *metalv1alpha1.Server, maintenance *metalv1alpha1.ServerMaintenance) error {
 	serverBase := server.DeepCopy()
 	server.Spec.Power = maintenance.Spec.ServerPower
+	if maintenance.Spec.LocatorLED != "" {
+		server.Spec.IndicatorLED = maintenance.Spec.LocatorLED
+	}
 	return r.Patch(ctx, server, client.MergeFrom(serverBase))
 }
 
@@ -391,6 +394,15 @@ func (r *ServerMaintenanceReconciler) cleanup(ctx context.Context, maintenance *
 	}
 
 	if ref := server.Spec.ServerMaintenanceRef; ref != nil && ref.Name == maintenance.Name && ref.Namespace == maintenance.Namespace {
+		if maintenance.Spec.LocatorLED != "" {
+			serverBase := server.DeepCopy()
+			server.Spec.IndicatorLED = metalv1alpha1.OffIndicatorLED
+			if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil && !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to clear LocatorLED on Server: %w", err)
+			}
+			log.V(1).Info("Cleared LocatorLED on Server", "Server", server.Name)
+		}
+
 		if err := r.removeMaintenanceRefFromServer(ctx, server); err != nil {
 			return fmt.Errorf("failed to remove ServerMaintenance ref from Server: %w", err)
 		}

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
@@ -436,7 +437,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		By("Deleting high-priority maintenance")
 		Expect(k8sClient.Delete(ctx, highPriorityMaintenance)).To(Succeed())
 		// check that the high-priority maintenance is deleted before checking the low-priority maintenance
-		Eventually(Get(highPriorityMaintenance)).ShouldNot(Succeed())
+		Eventually(Get(highPriorityMaintenance)).Should(Satisfy(apierrors.IsNotFound))
 		By("Approving lowPriorityMaintenance on the ServerClaim")
 		Eventually(Update(serverClaim, func() {
 			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
@@ -528,7 +529,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Deleting set-priority maintenance")
 		Expect(k8sClient.Delete(ctx, setPriorityMaintenance)).To(Succeed())
-		Eventually(Get(setPriorityMaintenance)).ShouldNot(Succeed())
+		Eventually(Get(setPriorityMaintenance)).Should(Satisfy(apierrors.IsNotFound))
 
 		By("Approving lowPriorityMaintenance on the ServerClaim")
 		Eventually(Update(serverClaim, func() {
@@ -565,13 +566,13 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Deleting the Server before deleting the ServerMaintenance")
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
-		Eventually(Get(server)).ShouldNot(Succeed())
+		Eventually(Get(server)).Should(Satisfy(apierrors.IsNotFound))
 
 		By("Deleting the ServerMaintenance")
 		Expect(k8sClient.Delete(ctx, serverMaintenance)).To(Succeed())
 
 		By("Ensuring the ServerMaintenance is fully deleted despite the Server being gone")
-		Eventually(Get(serverMaintenance)).ShouldNot(Succeed())
+		Eventually(Get(serverMaintenance)).Should(Satisfy(apierrors.IsNotFound))
 	})
 
 	It("should not allow an Enforced maintenance to steal the ref from an already-active maintenance", func(ctx SpecContext) {
@@ -693,6 +694,51 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		Expect(k8sClient.Delete(ctx, serverMaintenance)).To(Succeed())
 
 		By("Ensuring the ServerMaintenance is deleted immediately without cleanup side-effects")
-		Eventually(Get(serverMaintenance)).ShouldNot(Succeed())
+		Eventually(Get(serverMaintenance)).Should(Satisfy(apierrors.IsNotFound))
+	})
+
+	It("should set the LocatorLED on maintenance start and turn it off when maintenance ends", func(ctx SpecContext) {
+		By("Patching server to Available state")
+		Eventually(UpdateStatus(server, func() {
+			server.Status.State = metalv1alpha1.ServerStateAvailable
+		})).Should(Succeed())
+
+		By("Creating a ServerMaintenance with LocatorLED Lit")
+		serverMaintenance := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-server-maintenance-led",
+				Namespace: ns.Name,
+				Annotations: map[string]string{
+					metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "test-led-maintenance",
+				},
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				ServerRef:  &corev1.LocalObjectReference{Name: server.Name},
+				Policy:     metalv1alpha1.ServerMaintenancePolicyEnforced,
+				LocatorLED: metalv1alpha1.LitIndicatorLED,
+			},
+		}
+		Expect(k8sClient.Create(ctx, serverMaintenance)).To(Succeed())
+
+		By("Checking the ServerMaintenance transitions to InMaintenance")
+		Eventually(Object(serverMaintenance)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance),
+		))
+
+		By("Checking that the server LocatorLED is set to Lit")
+		Eventually(Object(server)).Should(SatisfyAll(
+			HaveField("Spec.IndicatorLED", metalv1alpha1.LitIndicatorLED),
+		))
+
+		By("Deleting the ServerMaintenance to end maintenance")
+		Expect(k8sClient.Delete(ctx, serverMaintenance)).To(Succeed())
+
+		By("Checking that the server LocatorLED is cleared to Off")
+		Eventually(Object(server)).Should(SatisfyAll(
+			HaveField("Spec.IndicatorLED", metalv1alpha1.OffIndicatorLED),
+		))
+
+		By("Waiting for ServerMaintenance to be fully removed")
+		Eventually(Get(serverMaintenance)).Should(Satisfy(apierrors.IsNotFound))
 	})
 })

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -9,8 +9,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
@@ -447,6 +447,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Deleting low-priority maintenance")
 		Expect(k8sClient.Delete(ctx, lowPriorityMaintenance)).To(Succeed())
+		Eventually(Get(lowPriorityMaintenance)).Should(Satisfy(apierrors.IsNotFound))
 		Expect(k8sClient.Delete(ctx, serverClaim)).To(Succeed())
 	})
 
@@ -541,6 +542,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Deleting unset-priority maintenance")
 		Expect(k8sClient.Delete(ctx, unsetPriorityMaintenance)).To(Succeed())
+		Eventually(Get(unsetPriorityMaintenance)).Should(Satisfy(apierrors.IsNotFound))
 		Expect(k8sClient.Delete(ctx, serverClaim)).To(Succeed())
 	})
 


### PR DESCRIPTION
Closes #421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `spec.locatorLED` to `ServerMaintenance` to control the server’s locator/indicator LED during maintenance.
  * The LED is applied when maintenance begins and cleared when maintenance ends.
* **Documentation**
  * Updated API reference and CRD schema to include `ServerMaintenanceSpec.spec.locatorLED`.
* **Tests**
  * Strengthened deletion assertions and added end-to-end coverage validating `locatorLED` behavior across maintenance start and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->