### PR TITLE
Fix `ServerMaintenance` deletion logic

### DIFF
--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -356,8 +356,7 @@ func (r *ServerMaintenanceReconciler) delete(ctx context.Context, maintenance *m
 		}
 	} else if apierrors.IsNotFound(err) {
 		// note: if the server is already deleted, we can skip the cleanup and just remove the finalizer
-		// if its transent error of server not found, the servermaintenance will be deleted and server will free up the ref automatically once this is deleted
-		log.V(1).Info("Server not found, continue with cleanup", "Server", maintenance.Spec.ServerRef.Name)
+		log.V(1).Info("Server not found, skipping cleanup", "Server", maintenance.Spec.ServerRef.Name)
 	} else {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -343,16 +343,25 @@ func (r *ServerMaintenanceReconciler) handleFailedState(ctx context.Context, _ *
 func (r *ServerMaintenanceReconciler) delete(ctx context.Context, maintenance *metalv1alpha1.ServerMaintenance) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Deleting ServerMaintenance")
+	if !controllerutil.ContainsFinalizer(maintenance, serverMaintenanceFinalizer) {
+		return ctrl.Result{}, nil
+	}
 	if maintenance.Spec.ServerRef == nil {
 		return ctrl.Result{}, nil
 	}
 	server, err := GetServerByName(ctx, r.Client, maintenance.Spec.ServerRef.Name)
-	if err != nil {
+	if err == nil {
+		if err := r.cleanup(ctx, server); err != nil {
+			return ctrl.Result{}, err
+		}
+	} else if apierrors.IsNotFound(err) {
+		// note: if the server is already deleted, we can skip the cleanup and just remove the finalizer
+		// if its transent error of server not found, the servermaintenance will be deleted and server will free up the ref automatically once this is deleted
+		log.V(1).Info("Server not found, continue with cleanup", "Server", maintenance.Spec.ServerRef.Name)
+	} else {
 		return ctrl.Result{}, err
 	}
-	if err := r.cleanup(ctx, server); err != nil {
-		return ctrl.Result{}, err
-	}
+
 	log.V(1).Info("Removed dependencies")
 
 	log.V(1).Info("Ensuring that the finalizer is removed")

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -541,4 +541,72 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		Expect(k8sClient.Delete(ctx, unsetPriorityMaintenance)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, serverClaim)).To(Succeed())
 	})
+
+	It("should complete deletion when the referenced Server is already gone", func(ctx SpecContext) {
+		By("Creating a ServerMaintenance object")
+		serverMaintenance := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-server-maintenance-server-gone",
+				Namespace: ns.Name,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				ServerRef:   &corev1.LocalObjectReference{Name: server.Name},
+				Policy:      metalv1alpha1.ServerMaintenancePolicyEnforced,
+				ServerPower: metalv1alpha1.PowerOff,
+			},
+		}
+		Expect(k8sClient.Create(ctx, serverMaintenance)).To(Succeed())
+
+		By("Waiting for the ServerMaintenance to reach InMaintenance state")
+		Eventually(Object(serverMaintenance)).Should(
+			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance),
+		)
+
+		By("Deleting the Server before deleting the ServerMaintenance")
+		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
+		Eventually(Get(server)).ShouldNot(Succeed())
+
+		By("Deleting the ServerMaintenance")
+		Expect(k8sClient.Delete(ctx, serverMaintenance)).To(Succeed())
+
+		By("Ensuring the ServerMaintenance is fully deleted despite the Server being gone")
+		Eventually(Get(serverMaintenance)).ShouldNot(Succeed())
+	})
+
+	It("should skip cleanup and remove finalizer when no finalizer is present on deletion", func(ctx SpecContext) {
+		By("Creating a ServerMaintenance object without going through reconciliation (no finalizer)")
+		serverMaintenance := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-server-maintenance-no-finalizer",
+				Namespace: ns.Name,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				ServerRef:   &corev1.LocalObjectReference{Name: server.Name},
+				Policy:      metalv1alpha1.ServerMaintenancePolicyEnforced,
+				ServerPower: metalv1alpha1.PowerOff,
+			},
+		}
+		Expect(k8sClient.Create(ctx, serverMaintenance)).To(Succeed())
+
+		By("Waiting for the finalizer to be added by the reconciler")
+		Eventually(Object(serverMaintenance)).Should(
+			HaveField("Finalizers", ContainElement(serverMaintenanceFinalizer)),
+		)
+
+		By("Manually removing the finalizer to simulate a no-finalizer state")
+		Eventually(Update(serverMaintenance, func() {
+			serverMaintenance.Finalizers = nil
+		})).Should(Succeed())
+
+		By("Deleting the ServerMaintenance")
+		Expect(k8sClient.Delete(ctx, serverMaintenance)).To(Succeed())
+
+		By("Ensuring the ServerMaintenance is deleted immediately without cleanup side-effects")
+		Eventually(Get(serverMaintenance)).ShouldNot(Succeed())
+
+		By("Ensuring the Server was not modified during deletion")
+		Consistently(Object(server)).Should(
+			HaveField("Spec.ServerMaintenanceRef", BeNil()),
+		)
+	})
 })

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
@@ -57,8 +58,8 @@ var _ = Describe("ServerMaintenance Controller", func() {
 	})
 
 	AfterEach(func(ctx SpecContext) {
-		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
-		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, server))).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcSecret))).To(Succeed())
 		EnsureCleanState()
 	})
 
@@ -593,20 +594,23 @@ var _ = Describe("ServerMaintenance Controller", func() {
 			HaveField("Finalizers", ContainElement(serverMaintenanceFinalizer)),
 		)
 
+		By("Setting ignore-reconciliation annotation to prevent the reconciler from re-adding the finalizer")
+		Eventually(Update(serverMaintenance, func() {
+			metav1.SetMetaDataAnnotation(&serverMaintenance.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationIgnore)
+		})).Should(Succeed())
+
 		By("Manually removing the finalizer to simulate a no-finalizer state")
 		Eventually(Update(serverMaintenance, func() {
 			serverMaintenance.Finalizers = nil
 		})).Should(Succeed())
+
+		By("Ensuring finalizers are empty before delete")
+		Expect(serverMaintenance.Finalizers).To(BeEmpty())
 
 		By("Deleting the ServerMaintenance")
 		Expect(k8sClient.Delete(ctx, serverMaintenance)).To(Succeed())
 
 		By("Ensuring the ServerMaintenance is deleted immediately without cleanup side-effects")
 		Eventually(Get(serverMaintenance)).ShouldNot(Succeed())
-
-		By("Ensuring the Server was not modified during deletion")
-		Consistently(Object(server)).Should(
-			HaveField("Spec.ServerMaintenanceRef", BeNil()),
-		)
 	})
 })


### PR DESCRIPTION
# Proposed Changes

Fixes #949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ServerMaintenance deletion behavior when the referenced Server is missing, so cleanup is skipped gracefully and the maintenance record is fully removed without errors.
  * Updated deletion handling to exit early when the finalizer is absent, avoiding unnecessary processing and ensuring reliable final deletion.
* **Tests**
  * Added coverage for deletion scenarios where the referenced Server was deleted first and where the finalizer is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->