### PR TITLE
Transition ServerMaintenance to Pending for missing Server resource

### DIFF
--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -73,6 +73,13 @@ func (r *ServerMaintenanceReconciler) reconcile(ctx context.Context, maintenance
 	server := &metalv1alpha1.Server{}
 	if err := r.Get(ctx, client.ObjectKey{Name: maintenance.Spec.ServerRef.Name}, server); err != nil {
 		if apierrors.IsNotFound(err) {
+			log.V(1).Info("Referenced Server not found, transitioning to Pending state",
+				"ServerMaintenance", client.ObjectKeyFromObject(maintenance),
+				"Server", maintenance.Spec.ServerRef.Name,
+			)
+			if modified, err := r.patchMaintenanceState(ctx, maintenance, metalv1alpha1.ServerMaintenanceStatePending); err != nil || modified {
+				return ctrl.Result{}, err
+			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get Server: %w", err)

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -537,6 +537,32 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		Expect(k8sClient.Delete(ctx, serverClaim)).To(Succeed())
 	})
 
+	It("should transition ServerMaintenance to Pending state when its referenced Server no longer exists", func(ctx SpecContext) {
+		By("Creating a ServerMaintenance object")
+		serverMaintenance := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-server-maintenance-orphan",
+				Namespace: ns.Name,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				ServerRef: &corev1.LocalObjectReference{Name: server.Name},
+				Policy:    metalv1alpha1.ServerMaintenancePolicyEnforced,
+			},
+		}
+		Expect(k8sClient.Create(ctx, serverMaintenance)).To(Succeed())
+
+		By("Deleting the Server")
+		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
+		Eventually(Get(server)).ShouldNot(Succeed())
+
+		By("Expecting the ServerMaintenance to transition to Pending state")
+		Eventually(Object(serverMaintenance)).Should(HaveField("Status.State", Equal(metalv1alpha1.ServerMaintenanceStatePending)))
+
+		By("Cleaning up the ServerMaintenance")
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, serverMaintenance))).To(Succeed())
+		Eventually(Get(serverMaintenance)).ShouldNot(Succeed())
+	})
+
 	It("should complete deletion when the referenced Server is already gone", func(ctx SpecContext) {
 		By("Creating a ServerMaintenance object")
 		serverMaintenance := &metalv1alpha1.ServerMaintenance{


### PR DESCRIPTION
Fixes #367

When a BMC is deleted, Kubernetes cascades deletion to owned `Server` resources. `ServerMaintenance` objects referencing those servers were left orphaned due to two bugs in the `ServerMaintenanceReconciler`:

- `reconcile()` returned silently on `NotFound` server before adding the finalizer — so the resource was never garbage collected
- `delete()` propagated `NotFound` as an error, blocking finalizer removal permanently

Both paths now handle a missing `Server` gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation when a referenced Server is missing: ServerMaintenance now records the condition, transitions to **Pending**, and exits without further processing.

* **Tests**
  * Added coverage confirming that ServerMaintenance remains available and transitions to **Pending** when its referenced Server is deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->