### PR TITLE
Fix Redfish event parsing and missing Prometheus metric registration

### DIFF
--- a/internal/serverevents/metrics.go
+++ b/internal/serverevents/metrics.go
@@ -101,19 +101,18 @@ func (c *RedfishEventCollector) UpdateFromEvent(hostname string, data EventData)
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
-	events := data.GetEvents() // Use new method to get events from either field
+	events := data.GetEvents()
 	for _, event := range events {
 		// Determine the component from the URI (e.g., .../Sensors/Fan1 -> Fan1)
 		component := "system"
-		if event.OriginOfCondition != "" {
-			parts := strings.Split(strings.TrimRight(event.OriginOfCondition, "/"), "/")
+		if event.OriginOfCondition.ODataID != "" {
+			parts := strings.Split(strings.TrimRight(event.OriginOfCondition.ODataID, "/"), "/")
 			component = parts[len(parts)-1]
 		}
-		event.OriginOfCondition = component
 		key := EventKey{
 			Source:    hostname,
-			Severity:  event.Severity,
-			EventID:   event.EventID,
+			Severity:  event.GetSeverity(),
+			EventID:   event.GetMessageID(),
 			Component: component,
 		}
 		c.alertCounts[key]++
@@ -124,6 +123,7 @@ func (c *RedfishEventCollector) UpdateFromEvent(hostname string, data EventData)
 // Describe and Collect implement the prometheus.Collector interface to expose metrics.
 func (c *RedfishEventCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.sensorDesc
+	ch <- c.alertDesc
 }
 
 // Collect gathers the latest metrics and sends them to Prometheus.

--- a/internal/serverevents/server.go
+++ b/internal/serverevents/server.go
@@ -73,7 +73,7 @@ func (o *OriginOfConditionRef) UnmarshalJSON(data []byte) error {
 	var ref struct {
 		ODataID string `json:"@odata.id"`
 	}
-	if err := json.Unmarshal(data, &ref); err == nil && ref.ODataID != "" {
+	if err := json.Unmarshal(data, &ref); err == nil {
 		o.ODataID = ref.ODataID
 		return nil
 	}

--- a/internal/serverevents/server.go
+++ b/internal/serverevents/server.go
@@ -63,12 +63,53 @@ func (e *EventData) GetEvents() []Event {
 	return e.Alerts
 }
 
+// OriginOfConditionRef handles both the official Redfish spec ({"@odata.id": "..."})
+// and Dell iDRAC which sends it as a plain string.
+type OriginOfConditionRef struct {
+	ODataID string
+}
+
+func (o *OriginOfConditionRef) UnmarshalJSON(data []byte) error {
+	var ref struct {
+		ODataID string `json:"@odata.id"`
+	}
+	if err := json.Unmarshal(data, &ref); err == nil && ref.ODataID != "" {
+		o.ODataID = ref.ODataID
+		return nil
+	}
+	// Fall back to plain string (Dell iDRAC)
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	o.ODataID = s
+	return nil
+}
+
 type Event struct {
-	EventID           string `json:"EventId"`
-	Message           string `json:"Message"`
-	Severity          string `json:"Severity"`
-	EventTimestamp    string `json:"EventTimestamp"`
-	OriginOfCondition string `json:"OriginOfCondition"`
+	EventID           string               `json:"EventId"`
+	MessageID         string               `json:"MessageId"`
+	Message           string               `json:"Message"`
+	Severity          string               `json:"Severity"`        // deprecated since Redfish v1.5, kept for compatibility
+	MessageSeverity   string               `json:"MessageSeverity"` // preferred since Redfish v1.5
+	EventTimestamp    string               `json:"EventTimestamp"`
+	OriginOfCondition OriginOfConditionRef `json:"OriginOfCondition"`
+}
+
+// GetSeverity returns MessageSeverity if set, falling back to the deprecated Severity field.
+func (e *Event) GetSeverity() string {
+	if e.MessageSeverity != "" {
+		return e.MessageSeverity
+	}
+	return e.Severity
+}
+
+// GetMessageID returns MessageId if set, falling back to EventId.
+func (e *Event) GetMessageID() string {
+	if e.MessageID != "" {
+		return e.MessageID
+	}
+	return e.EventID
 }
 
 func NewServer(log logr.Logger, addr string) *Server {


### PR DESCRIPTION
Fixes #
- Add MessageId and MessageSeverity fields to Event struct to support the current Redfish spec (v1.5+), with fallback to deprecated Severity and EventId for older firmware
- Replace OriginOfCondition string with OriginOfConditionRef that unmarshals both the official object form ({"@odata.id": "..."}) and Dell iDRAC's plain string form
- Add GetSeverity() and GetMessageID() helpers for clean fallback logic
- Fix UpdateFromEvent to use the new accessors so Prometheus labels carry the correct severity and message_id values
- Register alertDesc in Describe() so redfish_event_alert_total is actually exposed to Prometheus scrapers





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server event parsing to support both object and string forms for condition origin details, and to correctly interpret message severity and message IDs.
  * Refined alert counting so alert components and keys are derived from the correct event fields rather than mutating incoming data.
  * Updated alert metrics registration to include alert metric descriptors alongside existing sensor/reading descriptors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->