### PR TITLE
Spec migration for BIOS/BMC Settings/Version resources

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/biossettingsspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/biossettingsspec.go
@@ -17,10 +17,6 @@ import (
 type BIOSSettingsSpecApplyConfiguration struct {
 	// BIOSSettingsTemplate defines the template for BIOS Settings to be applied on the servers.
 	BIOSSettingsTemplateApplyConfiguration `json:",inline"`
-	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-	// after the resource has been applied. Empty string (default) means the controller is fully active.
-	// Set by the parent CRD; must not be set manually.
-	DriftPolicy *apiv1alpha1.DriftPolicy `json:"driftPolicy,omitempty"`
 	// ServerMaintenanceRef is a reference to a ServerMaintenance object that BIOSSettings has requested for the referred server.
 	ServerMaintenanceRef *ObjectReferenceApplyConfiguration `json:"serverMaintenanceRef,omitempty"`
 	// ServerRef is a reference to a specific server to apply the BIOS settings on.
@@ -67,14 +63,6 @@ func (b *BIOSSettingsSpecApplyConfiguration) WithRetryPolicy(value *RetryPolicyA
 // If called multiple times, the ServerMaintenancePolicy field is set to the value of the last call.
 func (b *BIOSSettingsSpecApplyConfiguration) WithServerMaintenancePolicy(value apiv1alpha1.ServerMaintenancePolicy) *BIOSSettingsSpecApplyConfiguration {
 	b.BIOSSettingsTemplateApplyConfiguration.ServerMaintenancePolicy = &value
-	return b
-}
-
-// WithDriftPolicy sets the DriftPolicy field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the DriftPolicy field is set to the value of the last call.
-func (b *BIOSSettingsSpecApplyConfiguration) WithDriftPolicy(value apiv1alpha1.DriftPolicy) *BIOSSettingsSpecApplyConfiguration {
-	b.DriftPolicy = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/biossettingsspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/biossettingsspec.go
@@ -17,6 +17,10 @@ import (
 type BIOSSettingsSpecApplyConfiguration struct {
 	// BIOSSettingsTemplate defines the template for BIOS Settings to be applied on the servers.
 	BIOSSettingsTemplateApplyConfiguration `json:",inline"`
+	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+	// after the resource has been applied. Empty string (default) means the controller is fully active.
+	// Set by the parent CRD; must not be set manually.
+	DriftPolicy *apiv1alpha1.DriftPolicy `json:"driftPolicy,omitempty"`
 	// ServerMaintenanceRef is a reference to a ServerMaintenance object that BIOSSettings has requested for the referred server.
 	ServerMaintenanceRef *ObjectReferenceApplyConfiguration `json:"serverMaintenanceRef,omitempty"`
 	// ServerRef is a reference to a specific server to apply the BIOS settings on.
@@ -63,6 +67,14 @@ func (b *BIOSSettingsSpecApplyConfiguration) WithRetryPolicy(value *RetryPolicyA
 // If called multiple times, the ServerMaintenancePolicy field is set to the value of the last call.
 func (b *BIOSSettingsSpecApplyConfiguration) WithServerMaintenancePolicy(value apiv1alpha1.ServerMaintenancePolicy) *BIOSSettingsSpecApplyConfiguration {
 	b.BIOSSettingsTemplateApplyConfiguration.ServerMaintenancePolicy = &value
+	return b
+}
+
+// WithDriftPolicy sets the DriftPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DriftPolicy field is set to the value of the last call.
+func (b *BIOSSettingsSpecApplyConfiguration) WithDriftPolicy(value apiv1alpha1.DriftPolicy) *BIOSSettingsSpecApplyConfiguration {
+	b.DriftPolicy = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/biosversionspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/biosversionspec.go
@@ -17,6 +17,10 @@ import (
 type BIOSVersionSpecApplyConfiguration struct {
 	// BIOSVersionTemplate defines the template for Version to be applied on the servers.
 	BIOSVersionTemplateApplyConfiguration `json:",inline"`
+	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+	// after the upgrade completes. Empty string (default) means the controller is fully active.
+	// Set by the parent CRD; must not be set manually.
+	DriftPolicy *apiv1alpha1.DriftPolicy `json:"driftPolicy,omitempty"`
 	// ServerMaintenanceRef is a reference to a ServerMaintenance object that the controller has requested for the referred server.
 	ServerMaintenanceRef *ObjectReferenceApplyConfiguration `json:"serverMaintenanceRef,omitempty"`
 	// ServerRef is a reference to a specific server to apply the BIOS upgrade on.
@@ -66,6 +70,14 @@ func (b *BIOSVersionSpecApplyConfiguration) WithServerMaintenancePolicy(value ap
 // If called multiple times, the RetryPolicy field is set to the value of the last call.
 func (b *BIOSVersionSpecApplyConfiguration) WithRetryPolicy(value *RetryPolicyApplyConfiguration) *BIOSVersionSpecApplyConfiguration {
 	b.BIOSVersionTemplateApplyConfiguration.RetryPolicy = value
+	return b
+}
+
+// WithDriftPolicy sets the DriftPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DriftPolicy field is set to the value of the last call.
+func (b *BIOSVersionSpecApplyConfiguration) WithDriftPolicy(value apiv1alpha1.DriftPolicy) *BIOSVersionSpecApplyConfiguration {
+	b.DriftPolicy = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/biosversionspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/biosversionspec.go
@@ -17,10 +17,6 @@ import (
 type BIOSVersionSpecApplyConfiguration struct {
 	// BIOSVersionTemplate defines the template for Version to be applied on the servers.
 	BIOSVersionTemplateApplyConfiguration `json:",inline"`
-	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-	// after the upgrade completes. Empty string (default) means the controller is fully active.
-	// Set by the parent CRD; must not be set manually.
-	DriftPolicy *apiv1alpha1.DriftPolicy `json:"driftPolicy,omitempty"`
 	// ServerMaintenanceRef is a reference to a ServerMaintenance object that the controller has requested for the referred server.
 	ServerMaintenanceRef *ObjectReferenceApplyConfiguration `json:"serverMaintenanceRef,omitempty"`
 	// ServerRef is a reference to a specific server to apply the BIOS upgrade on.
@@ -70,14 +66,6 @@ func (b *BIOSVersionSpecApplyConfiguration) WithServerMaintenancePolicy(value ap
 // If called multiple times, the RetryPolicy field is set to the value of the last call.
 func (b *BIOSVersionSpecApplyConfiguration) WithRetryPolicy(value *RetryPolicyApplyConfiguration) *BIOSVersionSpecApplyConfiguration {
 	b.BIOSVersionTemplateApplyConfiguration.RetryPolicy = value
-	return b
-}
-
-// WithDriftPolicy sets the DriftPolicy field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the DriftPolicy field is set to the value of the last call.
-func (b *BIOSVersionSpecApplyConfiguration) WithDriftPolicy(value apiv1alpha1.DriftPolicy) *BIOSVersionSpecApplyConfiguration {
-	b.DriftPolicy = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcsettingsspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcsettingsspec.go
@@ -16,10 +16,6 @@ import (
 // BMCSettingsSpec defines the desired state of BMCSettings.
 type BMCSettingsSpecApplyConfiguration struct {
 	BMCSettingsTemplateApplyConfiguration `json:",inline"`
-	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-	// after the resource has been applied. Empty string (default) means the controller is fully active.
-	// Set by the parent CRD; must not be set manually.
-	DriftPolicy *apiv1alpha1.DriftPolicy `json:"driftPolicy,omitempty"`
 	// ServerMaintenanceRefs are references to ServerMaintenance objects which are created by the controller for each
 	// server that needs to be updated with the BMC settings.
 	ServerMaintenanceRefs []ServerMaintenanceRefItemApplyConfiguration `json:"serverMaintenanceRefs,omitempty"`
@@ -94,14 +90,6 @@ func (b *BMCSettingsSpecApplyConfiguration) WithRetryPolicy(value *RetryPolicyAp
 // If called multiple times, the ServerMaintenancePolicy field is set to the value of the last call.
 func (b *BMCSettingsSpecApplyConfiguration) WithServerMaintenancePolicy(value apiv1alpha1.ServerMaintenancePolicy) *BMCSettingsSpecApplyConfiguration {
 	b.BMCSettingsTemplateApplyConfiguration.ServerMaintenancePolicy = &value
-	return b
-}
-
-// WithDriftPolicy sets the DriftPolicy field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the DriftPolicy field is set to the value of the last call.
-func (b *BMCSettingsSpecApplyConfiguration) WithDriftPolicy(value apiv1alpha1.DriftPolicy) *BMCSettingsSpecApplyConfiguration {
-	b.DriftPolicy = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcsettingsspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcsettingsspec.go
@@ -16,6 +16,10 @@ import (
 // BMCSettingsSpec defines the desired state of BMCSettings.
 type BMCSettingsSpecApplyConfiguration struct {
 	BMCSettingsTemplateApplyConfiguration `json:",inline"`
+	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+	// after the resource has been applied. Empty string (default) means the controller is fully active.
+	// Set by the parent CRD; must not be set manually.
+	DriftPolicy *apiv1alpha1.DriftPolicy `json:"driftPolicy,omitempty"`
 	// ServerMaintenanceRefs are references to ServerMaintenance objects which are created by the controller for each
 	// server that needs to be updated with the BMC settings.
 	ServerMaintenanceRefs []ServerMaintenanceRefItemApplyConfiguration `json:"serverMaintenanceRefs,omitempty"`
@@ -51,6 +55,19 @@ func (b *BMCSettingsSpecApplyConfiguration) WithSettingsMap(entries map[string]s
 	return b
 }
 
+// WithSettingsFlow adds the given value to the SettingsFlow field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SettingsFlow field.
+func (b *BMCSettingsSpecApplyConfiguration) WithSettingsFlow(values ...*SettingsFlowItemApplyConfiguration) *BMCSettingsSpecApplyConfiguration {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithSettingsFlow")
+		}
+		b.BMCSettingsTemplateApplyConfiguration.SettingsFlow = append(b.BMCSettingsTemplateApplyConfiguration.SettingsFlow, *values[i])
+	}
+	return b
+}
+
 // WithVariables adds the given value to the Variables field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Variables field.
@@ -77,6 +94,14 @@ func (b *BMCSettingsSpecApplyConfiguration) WithRetryPolicy(value *RetryPolicyAp
 // If called multiple times, the ServerMaintenancePolicy field is set to the value of the last call.
 func (b *BMCSettingsSpecApplyConfiguration) WithServerMaintenancePolicy(value apiv1alpha1.ServerMaintenancePolicy) *BMCSettingsSpecApplyConfiguration {
 	b.BMCSettingsTemplateApplyConfiguration.ServerMaintenancePolicy = &value
+	return b
+}
+
+// WithDriftPolicy sets the DriftPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DriftPolicy field is set to the value of the last call.
+func (b *BMCSettingsSpecApplyConfiguration) WithDriftPolicy(value apiv1alpha1.DriftPolicy) *BMCSettingsSpecApplyConfiguration {
+	b.DriftPolicy = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcsettingstemplate.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcsettingstemplate.go
@@ -16,8 +16,13 @@ import (
 type BMCSettingsTemplateApplyConfiguration struct {
 	// Version specifies the BMC firmware version for which the settings should be applied.
 	Version *string `json:"version,omitempty"`
-	// SettingsMap contains BMC settings as a map.
+	// SettingsMap contains BMC settings as a flat key/value map.
+	// Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+	// This field will be removed in next release.
 	SettingsMap map[string]string `json:"settings,omitempty"`
+	// SettingsFlow contains BMC settings as a named, priority-ordered list of groups.
+	// Replaces the flat settings map. Preferred over settings;
+	SettingsFlow []SettingsFlowItemApplyConfiguration `json:"settingsFlow,omitempty"`
 	// Variables is a list of variables that can be used in the settings for templating.
 	Variables []VariableApplyConfiguration `json:"variables,omitempty"`
 	// RetryPolicy defines the retry behavior for automatic retries on transient failures.
@@ -50,6 +55,19 @@ func (b *BMCSettingsTemplateApplyConfiguration) WithSettingsMap(entries map[stri
 	}
 	for k, v := range entries {
 		b.SettingsMap[k] = v
+	}
+	return b
+}
+
+// WithSettingsFlow adds the given value to the SettingsFlow field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SettingsFlow field.
+func (b *BMCSettingsTemplateApplyConfiguration) WithSettingsFlow(values ...*SettingsFlowItemApplyConfiguration) *BMCSettingsTemplateApplyConfiguration {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithSettingsFlow")
+		}
+		b.SettingsFlow = append(b.SettingsFlow, *values[i])
 	}
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcsettingstemplate.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcsettingstemplate.go
@@ -17,7 +17,7 @@ type BMCSettingsTemplateApplyConfiguration struct {
 	// Version specifies the BMC firmware version for which the settings should be applied.
 	Version *string `json:"version,omitempty"`
 	// SettingsMap contains BMC settings as a flat key/value map.
-	// Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+	// Deprecated: use settingsFlow instead. This field is mutually exclusive with settingsFlow.
 	// This field will be removed in next release.
 	SettingsMap map[string]string `json:"settings,omitempty"`
 	// SettingsFlow contains BMC settings as a named, priority-ordered list of groups.

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcspec.go
@@ -29,12 +29,12 @@ type BMCSpecApplyConfiguration struct {
 	ConsoleProtocol *ConsoleProtocolApplyConfiguration `json:"consoleProtocol,omitempty"`
 	// BMCSettingRef is a reference to a BMCSettings object that specifies
 	// the BMC configuration for this BMC.
-	// Deprecated: use bmcSettingsRefsList instead. Will be removed in next release.
+	// Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
 	BMCSettingRef *v1.LocalObjectReference `json:"bmcSettingsRef,omitempty"`
 	// BMCSettingsRefs is a list of references to BMCSettings objects that specify
 	// the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support
 	// multiple simultaneous settings objects created.
-	BMCSettingsRefs []v1.LocalObjectReference `json:"bmcSettingsRefsList,omitempty"`
+	BMCSettingsRefs []v1.LocalObjectReference `json:"bmcSettingsRefs,omitempty"`
 	// Hostname is the hostname of the BMC.
 	Hostname *string `json:"hostname,omitempty"`
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcspec.go
@@ -29,7 +29,7 @@ type BMCSpecApplyConfiguration struct {
 	ConsoleProtocol *ConsoleProtocolApplyConfiguration `json:"consoleProtocol,omitempty"`
 	// BMCSettingRef is a reference to a BMCSettings object that specifies
 	// the BMC configuration for this BMC.
-	// Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
+	// Deprecated: use bmcSettingsRefsList instead. Will be removed in next release.
 	BMCSettingRef *v1.LocalObjectReference `json:"bmcSettingsRef,omitempty"`
 	// BMCSettingsRefs is a list of references to BMCSettings objects that specify
 	// the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcspec.go
@@ -29,7 +29,12 @@ type BMCSpecApplyConfiguration struct {
 	ConsoleProtocol *ConsoleProtocolApplyConfiguration `json:"consoleProtocol,omitempty"`
 	// BMCSettingRef is a reference to a BMCSettings object that specifies
 	// the BMC configuration for this BMC.
+	// Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
 	BMCSettingRef *v1.LocalObjectReference `json:"bmcSettingsRef,omitempty"`
+	// BMCSettingsRefs is a list of references to BMCSettings objects that specify
+	// the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support
+	// multiple simultaneous settings objects created.
+	BMCSettingsRefs []v1.LocalObjectReference `json:"bmcSettingsRefsList,omitempty"`
 	// Hostname is the hostname of the BMC.
 	Hostname *string `json:"hostname,omitempty"`
 }
@@ -93,6 +98,16 @@ func (b *BMCSpecApplyConfiguration) WithConsoleProtocol(value *ConsoleProtocolAp
 // If called multiple times, the BMCSettingRef field is set to the value of the last call.
 func (b *BMCSpecApplyConfiguration) WithBMCSettingRef(value v1.LocalObjectReference) *BMCSpecApplyConfiguration {
 	b.BMCSettingRef = &value
+	return b
+}
+
+// WithBMCSettingsRefs adds the given value to the BMCSettingsRefs field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the BMCSettingsRefs field.
+func (b *BMCSpecApplyConfiguration) WithBMCSettingsRefs(values ...v1.LocalObjectReference) *BMCSpecApplyConfiguration {
+	for i := range values {
+		b.BMCSettingsRefs = append(b.BMCSettingsRefs, values[i])
+	}
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcversionspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcversionspec.go
@@ -17,6 +17,10 @@ import (
 type BMCVersionSpecApplyConfiguration struct {
 	// BMCVersionTemplate defines the template for BMC version to be applied on the server's BMC.
 	BMCVersionTemplateApplyConfiguration `json:",inline"`
+	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+	// after the upgrade completes. Empty string (default) means the controller is fully active.
+	// Set by the parent CRD; must not be set manually.
+	DriftPolicy *apiv1alpha1.DriftPolicy `json:"driftPolicy,omitempty"`
 	// ServerMaintenanceRefs are references to ServerMaintenance objects that the controller has requested for the related servers.
 	ServerMaintenanceRefs []ObjectReferenceApplyConfiguration `json:"serverMaintenanceRefs,omitempty"`
 	// BMCRef is a reference to a specific BMC to apply BMC upgrade on.
@@ -66,6 +70,14 @@ func (b *BMCVersionSpecApplyConfiguration) WithRetryPolicy(value *RetryPolicyApp
 // If called multiple times, the ServerMaintenancePolicy field is set to the value of the last call.
 func (b *BMCVersionSpecApplyConfiguration) WithServerMaintenancePolicy(value apiv1alpha1.ServerMaintenancePolicy) *BMCVersionSpecApplyConfiguration {
 	b.BMCVersionTemplateApplyConfiguration.ServerMaintenancePolicy = &value
+	return b
+}
+
+// WithDriftPolicy sets the DriftPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DriftPolicy field is set to the value of the last call.
+func (b *BMCVersionSpecApplyConfiguration) WithDriftPolicy(value apiv1alpha1.DriftPolicy) *BMCVersionSpecApplyConfiguration {
+	b.DriftPolicy = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcversionspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcversionspec.go
@@ -17,10 +17,6 @@ import (
 type BMCVersionSpecApplyConfiguration struct {
 	// BMCVersionTemplate defines the template for BMC version to be applied on the server's BMC.
 	BMCVersionTemplateApplyConfiguration `json:",inline"`
-	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-	// after the upgrade completes. Empty string (default) means the controller is fully active.
-	// Set by the parent CRD; must not be set manually.
-	DriftPolicy *apiv1alpha1.DriftPolicy `json:"driftPolicy,omitempty"`
 	// ServerMaintenanceRefs are references to ServerMaintenance objects that the controller has requested for the related servers.
 	ServerMaintenanceRefs []ObjectReferenceApplyConfiguration `json:"serverMaintenanceRefs,omitempty"`
 	// BMCRef is a reference to a specific BMC to apply BMC upgrade on.
@@ -70,14 +66,6 @@ func (b *BMCVersionSpecApplyConfiguration) WithRetryPolicy(value *RetryPolicyApp
 // If called multiple times, the ServerMaintenancePolicy field is set to the value of the last call.
 func (b *BMCVersionSpecApplyConfiguration) WithServerMaintenancePolicy(value apiv1alpha1.ServerMaintenancePolicy) *BMCVersionSpecApplyConfiguration {
 	b.BMCVersionTemplateApplyConfiguration.ServerMaintenancePolicy = &value
-	return b
-}
-
-// WithDriftPolicy sets the DriftPolicy field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the DriftPolicy field is set to the value of the last call.
-func (b *BMCVersionSpecApplyConfiguration) WithDriftPolicy(value apiv1alpha1.DriftPolicy) *BMCVersionSpecApplyConfiguration {
-	b.DriftPolicy = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/serverspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/serverspec.go
@@ -47,12 +47,12 @@ type ServerSpecApplyConfiguration struct {
 	BootOrder []BootOrderApplyConfiguration `json:"bootOrder,omitempty"`
 	// BIOSSettingsRef is a reference to a biossettings object that specifies
 	// the BIOS configuration for this server.
-	// Deprecated: use biosSettingsRefs instead. Will be removed in next release.
+	// Deprecated: use biosSettingsRefsList instead. Will be removed in next release.
 	BIOSSettingsRef *v1.LocalObjectReference `json:"biosSettingsRef,omitempty"`
 	// BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
-	// the BIOS configuration for this server. Replaces the single biosSettingsRef to support
+	// the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support
 	// multiple simultaneous settings objects created.
-	BIOSSettingsRefs []v1.LocalObjectReference `json:"biosSettingsRefs,omitempty"`
+	BIOSSettingsRefs []v1.LocalObjectReference `json:"biosSettingsRefsList,omitempty"`
 	// Taints control which ServerClaims can be bound to this server.
 	Taints []TaintApplyConfiguration `json:"taints,omitempty"`
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/serverspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/serverspec.go
@@ -47,7 +47,12 @@ type ServerSpecApplyConfiguration struct {
 	BootOrder []BootOrderApplyConfiguration `json:"bootOrder,omitempty"`
 	// BIOSSettingsRef is a reference to a biossettings object that specifies
 	// the BIOS configuration for this server.
+	// Deprecated: use biosSettingsRefs instead. Will be removed in next release.
 	BIOSSettingsRef *v1.LocalObjectReference `json:"biosSettingsRef,omitempty"`
+	// BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
+	// the BIOS configuration for this server. Replaces the single biosSettingsRef to support
+	// multiple simultaneous settings objects created.
+	BIOSSettingsRefs []v1.LocalObjectReference `json:"biosSettingsRefs,omitempty"`
 	// Taints control which ServerClaims can be bound to this server.
 	Taints []TaintApplyConfiguration `json:"taints,omitempty"`
 }
@@ -164,6 +169,16 @@ func (b *ServerSpecApplyConfiguration) WithBootOrder(values ...*BootOrderApplyCo
 // If called multiple times, the BIOSSettingsRef field is set to the value of the last call.
 func (b *ServerSpecApplyConfiguration) WithBIOSSettingsRef(value v1.LocalObjectReference) *ServerSpecApplyConfiguration {
 	b.BIOSSettingsRef = &value
+	return b
+}
+
+// WithBIOSSettingsRefs adds the given value to the BIOSSettingsRefs field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the BIOSSettingsRefs field.
+func (b *ServerSpecApplyConfiguration) WithBIOSSettingsRefs(values ...v1.LocalObjectReference) *ServerSpecApplyConfiguration {
+	for i := range values {
+		b.BIOSSettingsRefs = append(b.BIOSSettingsRefs, values[i])
+	}
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/serverspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/serverspec.go
@@ -47,12 +47,12 @@ type ServerSpecApplyConfiguration struct {
 	BootOrder []BootOrderApplyConfiguration `json:"bootOrder,omitempty"`
 	// BIOSSettingsRef is a reference to a biossettings object that specifies
 	// the BIOS configuration for this server.
-	// Deprecated: use biosSettingsRefsList instead. Will be removed in next release.
+	// Deprecated: use biosSettingsRefs instead. Will be removed in next release.
 	BIOSSettingsRef *v1.LocalObjectReference `json:"biosSettingsRef,omitempty"`
 	// BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
 	// the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support
 	// multiple simultaneous settings objects created.
-	BIOSSettingsRefs []v1.LocalObjectReference `json:"biosSettingsRefsList,omitempty"`
+	BIOSSettingsRefs []v1.LocalObjectReference `json:"biosSettingsRefs,omitempty"`
 	// Taints control which ServerClaims can be bound to this server.
 	Taints []TaintApplyConfiguration `json:"taints,omitempty"`
 }

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -118,6 +118,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.BIOSSettingsSpec
   map:
     fields:
+    - name: driftPolicy
+      type:
+        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.DriftPolicy
     - name: retryPolicy
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.RetryPolicy
@@ -255,6 +258,9 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.BIOSVersionSpec
   map:
     fields:
+    - name: driftPolicy
+      type:
+        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.DriftPolicy
     - name: image
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.ImageSpec
@@ -449,6 +455,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: BMCRef
       type:
         namedType: io.k8s.api.core.v1.LocalObjectReference
+    - name: driftPolicy
+      type:
+        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.DriftPolicy
     - name: retryPolicy
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.RetryPolicy
@@ -466,6 +475,12 @@ var schemaYAML = typed.YAMLObject(`types:
         map:
           elementType:
             scalar: string
+    - name: settingsFlow
+      type:
+        list:
+          elementType:
+            namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.SettingsFlowItem
+          elementRelationship: atomic
     - name: variables
       type:
         list:
@@ -509,6 +524,12 @@ var schemaYAML = typed.YAMLObject(`types:
         map:
           elementType:
             scalar: string
+    - name: settingsFlow
+      type:
+        list:
+          elementType:
+            namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.SettingsFlowItem
+          elementRelationship: atomic
     - name: variables
       type:
         list:
@@ -530,6 +551,12 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: bmcSettingsRef
       type:
         namedType: io.k8s.api.core.v1.LocalObjectReference
+    - name: bmcSettingsRefsList
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LocalObjectReference
+          elementRelationship: atomic
     - name: bmcUUID
       type:
         scalar: string
@@ -719,6 +746,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: bmcRef
       type:
         namedType: io.k8s.api.core.v1.LocalObjectReference
+    - name: driftPolicy
+      type:
+        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.DriftPolicy
     - name: image
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.ImageSpec
@@ -812,6 +842,8 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: numeric
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.ConsoleProtocolName
+  scalar: string
+- name: com.github.ironcore-dev.metal-operator.api.v1alpha1.DriftPolicy
   scalar: string
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.Endpoint
   map:
@@ -1259,6 +1291,12 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: biosSettingsRef
       type:
         namedType: io.k8s.api.core.v1.LocalObjectReference
+    - name: biosSettingsRefs
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LocalObjectReference
+          elementRelationship: atomic
     - name: bmc
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.BMCAccess

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -1291,7 +1291,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: biosSettingsRef
       type:
         namedType: io.k8s.api.core.v1.LocalObjectReference
-    - name: biosSettingsRefs
+    - name: biosSettingsRefsList
       type:
         list:
           elementType:

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -118,9 +118,6 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.BIOSSettingsSpec
   map:
     fields:
-    - name: driftPolicy
-      type:
-        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.DriftPolicy
     - name: retryPolicy
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.RetryPolicy
@@ -258,9 +255,6 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.BIOSVersionSpec
   map:
     fields:
-    - name: driftPolicy
-      type:
-        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.DriftPolicy
     - name: image
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.ImageSpec
@@ -455,9 +449,6 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: BMCRef
       type:
         namedType: io.k8s.api.core.v1.LocalObjectReference
-    - name: driftPolicy
-      type:
-        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.DriftPolicy
     - name: retryPolicy
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.RetryPolicy
@@ -746,9 +737,6 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: bmcRef
       type:
         namedType: io.k8s.api.core.v1.LocalObjectReference
-    - name: driftPolicy
-      type:
-        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.DriftPolicy
     - name: image
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.ImageSpec
@@ -842,8 +830,6 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: numeric
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.ConsoleProtocolName
-  scalar: string
-- name: com.github.ironcore-dev.metal-operator.api.v1alpha1.DriftPolicy
   scalar: string
 - name: com.github.ironcore-dev.metal-operator.api.v1alpha1.Endpoint
   map:

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -551,7 +551,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: bmcSettingsRef
       type:
         namedType: io.k8s.api.core.v1.LocalObjectReference
-    - name: bmcSettingsRefsList
+    - name: bmcSettingsRefs
       type:
         list:
           elementType:
@@ -1291,7 +1291,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: biosSettingsRef
       type:
         namedType: io.k8s.api.core.v1.LocalObjectReference
-    - name: biosSettingsRefsList
+    - name: biosSettingsRefs
       type:
         list:
           elementType:

--- a/api/v1alpha1/biossettings_types.go
+++ b/api/v1alpha1/biossettings_types.go
@@ -52,12 +52,6 @@ type BIOSSettingsSpec struct {
 	// BIOSSettingsTemplate defines the template for BIOS Settings to be applied on the servers.
 	BIOSSettingsTemplate `json:",inline"`
 
-	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-	// after the resource has been applied. Empty string (default) means the controller is fully active.
-	// Set by the parent CRD; must not be set manually.
-	// +optional
-	DriftPolicy DriftPolicy `json:"driftPolicy,omitempty"`
-
 	// ServerMaintenanceRef is a reference to a ServerMaintenance object that BIOSSettings has requested for the referred server.
 	// +optional
 	ServerMaintenanceRef *ObjectReference `json:"serverMaintenanceRef,omitempty"`

--- a/api/v1alpha1/biossettings_types.go
+++ b/api/v1alpha1/biossettings_types.go
@@ -11,8 +11,8 @@ import (
 
 type BIOSSettingsTemplate struct {
 	// Version specifies the software version (e.g. BIOS, BMC) these settings apply to.
-	// +required
-	Version string `json:"version"`
+	// +optional
+	Version string `json:"version,omitempty"`
 
 	// SettingsFlow contains the BIOS settings sequence to apply in the given order.
 	// +optional
@@ -46,9 +46,17 @@ type SettingsFlowItem struct {
 }
 
 // BIOSSettingsSpec defines the desired state of BIOSSettings.
+// +kubebuilder:validation:XValidation:rule="size(self.version) > 0",message="version is required on BIOSSettings"
+// +kubebuilder:validation:XValidation:rule="has(self.serverRef)",message="serverRef is required"
 type BIOSSettingsSpec struct {
 	// BIOSSettingsTemplate defines the template for BIOS Settings to be applied on the servers.
 	BIOSSettingsTemplate `json:",inline"`
+
+	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+	// after the resource has been applied. Empty string (default) means the controller is fully active.
+	// Set by the parent CRD; must not be set manually.
+	// +optional
+	DriftPolicy DriftPolicy `json:"driftPolicy,omitempty"`
 
 	// ServerMaintenanceRef is a reference to a ServerMaintenance object that BIOSSettings has requested for the referred server.
 	// +optional
@@ -56,7 +64,7 @@ type BIOSSettingsSpec struct {
 
 	// ServerRef is a reference to a specific server to apply the BIOS settings on.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="serverRef is immutable"
-	ServerRef *corev1.LocalObjectReference `json:"serverRef,omitempty"`
+	ServerRef *corev1.LocalObjectReference `json:"serverRef"`
 }
 
 // BIOSSettingsState specifies the current state of the BIOS Settings update.

--- a/api/v1alpha1/biosversion_types.go
+++ b/api/v1alpha1/biosversion_types.go
@@ -69,7 +69,6 @@ type BIOSVersionSpec struct {
 
 	// ServerRef is a reference to a specific server to apply the BIOS upgrade on.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="serverRef is immutable"
-	// +optional
 	ServerRef *corev1.LocalObjectReference `json:"serverRef"`
 }
 

--- a/api/v1alpha1/biosversion_types.go
+++ b/api/v1alpha1/biosversion_types.go
@@ -57,12 +57,6 @@ type BIOSVersionSpec struct {
 	// BIOSVersionTemplate defines the template for Version to be applied on the servers.
 	BIOSVersionTemplate `json:",inline"`
 
-	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-	// after the upgrade completes. Empty string (default) means the controller is fully active.
-	// Set by the parent CRD; must not be set manually.
-	// +optional
-	DriftPolicy DriftPolicy `json:"driftPolicy,omitempty"`
-
 	// ServerMaintenanceRef is a reference to a ServerMaintenance object that the controller has requested for the referred server.
 	// +optional
 	ServerMaintenanceRef *ObjectReference `json:"serverMaintenanceRef,omitempty"`

--- a/api/v1alpha1/biosversion_types.go
+++ b/api/v1alpha1/biosversion_types.go
@@ -52,9 +52,16 @@ type BIOSVersionTemplate struct {
 }
 
 // BIOSVersionSpec defines the desired state of BIOSVersion.
+// +kubebuilder:validation:XValidation:rule="has(self.serverRef)",message="serverRef is required"
 type BIOSVersionSpec struct {
 	// BIOSVersionTemplate defines the template for Version to be applied on the servers.
 	BIOSVersionTemplate `json:",inline"`
+
+	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+	// after the upgrade completes. Empty string (default) means the controller is fully active.
+	// Set by the parent CRD; must not be set manually.
+	// +optional
+	DriftPolicy DriftPolicy `json:"driftPolicy,omitempty"`
 
 	// ServerMaintenanceRef is a reference to a ServerMaintenance object that the controller has requested for the referred server.
 	// +optional
@@ -63,7 +70,7 @@ type BIOSVersionSpec struct {
 	// ServerRef is a reference to a specific server to apply the BIOS upgrade on.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="serverRef is immutable"
 	// +optional
-	ServerRef *corev1.LocalObjectReference `json:"serverRef,omitempty"`
+	ServerRef *corev1.LocalObjectReference `json:"serverRef"`
 }
 
 type ImageSpec struct {

--- a/api/v1alpha1/bmc_types.go
+++ b/api/v1alpha1/bmc_types.go
@@ -56,7 +56,7 @@ type BMCSpec struct {
 
 	// BMCSettingRef is a reference to a BMCSettings object that specifies
 	// the BMC configuration for this BMC.
-	// Deprecated: use bmcSettingsRefsList instead. Will be removed in next release.
+	// Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
 	// +optional
 	BMCSettingRef *v1.LocalObjectReference `json:"bmcSettingsRef,omitempty"`
 
@@ -64,7 +64,7 @@ type BMCSpec struct {
 	// the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support
 	// multiple simultaneous settings objects created.
 	// +optional
-	BMCSettingsRefs []v1.LocalObjectReference `json:"bmcSettingsRefsList,omitempty"`
+	BMCSettingsRefs []v1.LocalObjectReference `json:"bmcSettingsRefs,omitempty"`
 
 	// Hostname is the hostname of the BMC.
 	// +optional

--- a/api/v1alpha1/bmc_types.go
+++ b/api/v1alpha1/bmc_types.go
@@ -56,8 +56,15 @@ type BMCSpec struct {
 
 	// BMCSettingRef is a reference to a BMCSettings object that specifies
 	// the BMC configuration for this BMC.
+	// Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
 	// +optional
 	BMCSettingRef *v1.LocalObjectReference `json:"bmcSettingsRef,omitempty"`
+
+	// BMCSettingsRefs is a list of references to BMCSettings objects that specify
+	// the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support
+	// multiple simultaneous settings objects created.
+	// +optional
+	BMCSettingsRefs []v1.LocalObjectReference `json:"bmcSettingsRefsList,omitempty"`
 
 	// Hostname is the hostname of the BMC.
 	// +optional

--- a/api/v1alpha1/bmc_types.go
+++ b/api/v1alpha1/bmc_types.go
@@ -56,7 +56,7 @@ type BMCSpec struct {
 
 	// BMCSettingRef is a reference to a BMCSettings object that specifies
 	// the BMC configuration for this BMC.
-	// Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
+	// Deprecated: use bmcSettingsRefsList instead. Will be removed in next release.
 	// +optional
 	BMCSettingRef *v1.LocalObjectReference `json:"bmcSettingsRef,omitempty"`
 

--- a/api/v1alpha1/bmcsettings_types.go
+++ b/api/v1alpha1/bmcsettings_types.go
@@ -18,7 +18,7 @@ type BMCSettingsTemplate struct {
 	Version string `json:"version,omitempty"`
 
 	// SettingsMap contains BMC settings as a flat key/value map.
-	// Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+	// Deprecated: use settingsFlow instead. This field is mutually exclusive with settingsFlow.
 	// This field will be removed in next release.
 	// +optional
 	SettingsMap map[string]string `json:"settings,omitempty"`

--- a/api/v1alpha1/bmcsettings_types.go
+++ b/api/v1alpha1/bmcsettings_types.go
@@ -11,14 +11,22 @@ import (
 
 // BMCSettingsTemplate defines the template for BMC settings to be applied.
 // +kubebuilder:validation:XValidation:rule="!has(self.variables) || self.variables.all(v, self.variables.filter(w, w.key == v.key).size() == 1)",message="variable keys must be unique"
+// +kubebuilder:validation:XValidation:rule="!(has(self.settings) && has(self.settingsFlow))",message="settings and settingsFlow are mutually exclusive; migrate to settingsFlow"
 type BMCSettingsTemplate struct {
 	// Version specifies the BMC firmware version for which the settings should be applied.
-	// +required
-	Version string `json:"version"`
+	// +optional
+	Version string `json:"version,omitempty"`
 
-	// SettingsMap contains BMC settings as a map.
+	// SettingsMap contains BMC settings as a flat key/value map.
+	// Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+	// This field will be removed in next release.
 	// +optional
 	SettingsMap map[string]string `json:"settings,omitempty"`
+
+	// SettingsFlow contains BMC settings as a named, priority-ordered list of groups.
+	// Replaces the flat settings map. Preferred over settings;
+	// +optional
+	SettingsFlow []SettingsFlowItem `json:"settingsFlow,omitempty"`
 
 	// Variables is a list of variables that can be used in the settings for templating.
 	// +kubebuilder:validation:MaxItems=64
@@ -125,8 +133,16 @@ type NamespacedKeySelector struct {
 }
 
 // BMCSettingsSpec defines the desired state of BMCSettings.
+// +kubebuilder:validation:XValidation:rule="size(self.version) > 0",message="version is required on BMCSettings"
+// +kubebuilder:validation:XValidation:rule="has(self.BMCRef)",message="BMCRef is required"
 type BMCSettingsSpec struct {
 	BMCSettingsTemplate `json:",inline"`
+
+	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+	// after the resource has been applied. Empty string (default) means the controller is fully active.
+	// Set by the parent CRD; must not be set manually.
+	// +optional
+	DriftPolicy DriftPolicy `json:"driftPolicy,omitempty"`
 
 	// ServerMaintenanceRefs are references to ServerMaintenance objects which are created by the controller for each
 	// server that needs to be updated with the BMC settings.
@@ -136,7 +152,7 @@ type BMCSettingsSpec struct {
 	// BMCRef is a reference to a specific BMC to apply settings to.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="BMCRef is immutable"
 	// +required
-	BMCRef *corev1.LocalObjectReference `json:"BMCRef,omitempty"`
+	BMCRef *corev1.LocalObjectReference `json:"BMCRef"`
 }
 
 // ServerMaintenanceRefItem is a reference to a ServerMaintenance object.

--- a/api/v1alpha1/bmcsettings_types.go
+++ b/api/v1alpha1/bmcsettings_types.go
@@ -138,12 +138,6 @@ type NamespacedKeySelector struct {
 type BMCSettingsSpec struct {
 	BMCSettingsTemplate `json:",inline"`
 
-	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-	// after the resource has been applied. Empty string (default) means the controller is fully active.
-	// Set by the parent CRD; must not be set manually.
-	// +optional
-	DriftPolicy DriftPolicy `json:"driftPolicy,omitempty"`
-
 	// ServerMaintenanceRefs are references to ServerMaintenance objects which are created by the controller for each
 	// server that needs to be updated with the BMC settings.
 	// +optional

--- a/api/v1alpha1/bmcversion_types.go
+++ b/api/v1alpha1/bmcversion_types.go
@@ -50,12 +50,6 @@ type BMCVersionSpec struct {
 	// BMCVersionTemplate defines the template for BMC version to be applied on the server's BMC.
 	BMCVersionTemplate `json:",inline"`
 
-	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-	// after the upgrade completes. Empty string (default) means the controller is fully active.
-	// Set by the parent CRD; must not be set manually.
-	// +optional
-	DriftPolicy DriftPolicy `json:"driftPolicy,omitempty"`
-
 	// ServerMaintenanceRefs are references to ServerMaintenance objects that the controller has requested for the related servers.
 	// +optional
 	ServerMaintenanceRefs []ObjectReference `json:"serverMaintenanceRefs,omitempty"`

--- a/api/v1alpha1/bmcversion_types.go
+++ b/api/v1alpha1/bmcversion_types.go
@@ -45,9 +45,16 @@ type BMCVersionTemplate struct {
 }
 
 // BMCVersionSpec defines the desired state of BMCVersion.
+// +kubebuilder:validation:XValidation:rule="has(self.bmcRef)",message="bmcRef is required"
 type BMCVersionSpec struct {
 	// BMCVersionTemplate defines the template for BMC version to be applied on the server's BMC.
 	BMCVersionTemplate `json:",inline"`
+
+	// DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+	// after the upgrade completes. Empty string (default) means the controller is fully active.
+	// Set by the parent CRD; must not be set manually.
+	// +optional
+	DriftPolicy DriftPolicy `json:"driftPolicy,omitempty"`
 
 	// ServerMaintenanceRefs are references to ServerMaintenance objects that the controller has requested for the related servers.
 	// +optional
@@ -55,7 +62,7 @@ type BMCVersionSpec struct {
 
 	// BMCRef is a reference to a specific BMC to apply BMC upgrade on.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="bmcRef is immutable"
-	BMCRef *corev1.LocalObjectReference `json:"bmcRef,omitempty"`
+	BMCRef *corev1.LocalObjectReference `json:"bmcRef"`
 }
 
 // BMCVersionStatus defines the observed state of BMCVersion.

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -259,17 +259,6 @@ func EqualIPPrefixes(a, b IPPrefix) bool {
 	return a == b
 }
 
-// DriftPolicy specifies what action to take when hardware deviates from the desired state.
-// +kubebuilder:validation:Enum=Observe;Suspend
-type DriftPolicy string
-
-const (
-	// DriftPolicyObserve detects drift and surfaces a DriftDetected condition but does not apply any hardware changes.
-	DriftPolicyObserve DriftPolicy = "Observe"
-	// DriftPolicySuspend completely freezes reconciliation: no drift detection, no status updates, no hardware actions.
-	DriftPolicySuspend DriftPolicy = "Suspend"
-)
-
 // TaintEffect defines the effect of a taint on a ServerClaim.
 // +kubebuilder:validation:Enum=NoBind;Evict
 type TaintEffect string

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -259,6 +259,17 @@ func EqualIPPrefixes(a, b IPPrefix) bool {
 	return a == b
 }
 
+// DriftPolicy specifies what action to take when hardware deviates from the desired state.
+// +kubebuilder:validation:Enum=Observe;Suspend
+type DriftPolicy string
+
+const (
+	// DriftPolicyObserve detects drift and surfaces a DriftDetected condition but does not apply any hardware changes.
+	DriftPolicyObserve DriftPolicy = "Observe"
+	// DriftPolicySuspend completely freezes reconciliation: no drift detection, no status updates, no hardware actions.
+	DriftPolicySuspend DriftPolicy = "Suspend"
+)
+
 // TaintEffect defines the effect of a taint on a ServerClaim.
 // +kubebuilder:validation:Enum=NoBind;Evict
 type TaintEffect string

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -148,15 +148,15 @@ type ServerSpec struct {
 
 	// BIOSSettingsRef is a reference to a biossettings object that specifies
 	// the BIOS configuration for this server.
-	// Deprecated: use biosSettingsRefs instead. Will be removed in next release.
+	// Deprecated: use biosSettingsRefsList instead. Will be removed in next release.
 	// +optional
 	BIOSSettingsRef *v1.LocalObjectReference `json:"biosSettingsRef,omitempty"`
 
 	// BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
-	// the BIOS configuration for this server. Replaces the single biosSettingsRef to support
+	// the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support
 	// multiple simultaneous settings objects created.
 	// +optional
-	BIOSSettingsRefs []v1.LocalObjectReference `json:"biosSettingsRefs,omitempty"`
+	BIOSSettingsRefs []v1.LocalObjectReference `json:"biosSettingsRefsList,omitempty"`
 
 	// Taints control which ServerClaims can be bound to this server.
 	// +optional

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -148,7 +148,7 @@ type ServerSpec struct {
 
 	// BIOSSettingsRef is a reference to a biossettings object that specifies
 	// the BIOS configuration for this server.
-	// Deprecated: use biosSettingsRefsList instead. Will be removed in next release.
+	// Deprecated: use biosSettingsRefs instead. Will be removed in next release.
 	// +optional
 	BIOSSettingsRef *v1.LocalObjectReference `json:"biosSettingsRef,omitempty"`
 
@@ -156,7 +156,7 @@ type ServerSpec struct {
 	// the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support
 	// multiple simultaneous settings objects created.
 	// +optional
-	BIOSSettingsRefs []v1.LocalObjectReference `json:"biosSettingsRefsList,omitempty"`
+	BIOSSettingsRefs []v1.LocalObjectReference `json:"biosSettingsRefs,omitempty"`
 
 	// Taints control which ServerClaims can be bound to this server.
 	// +optional

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -148,8 +148,15 @@ type ServerSpec struct {
 
 	// BIOSSettingsRef is a reference to a biossettings object that specifies
 	// the BIOS configuration for this server.
+	// Deprecated: use biosSettingsRefs instead. Will be removed in next release.
 	// +optional
 	BIOSSettingsRef *v1.LocalObjectReference `json:"biosSettingsRef,omitempty"`
+
+	// BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
+	// the BIOS configuration for this server. Replaces the single biosSettingsRef to support
+	// multiple simultaneous settings objects created.
+	// +optional
+	BIOSSettingsRefs []v1.LocalObjectReference `json:"biosSettingsRefs,omitempty"`
 
 	// Taints control which ServerClaims can be bound to this server.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -872,6 +872,13 @@ func (in *BMCSettingsTemplate) DeepCopyInto(out *BMCSettingsTemplate) {
 			(*out)[key] = val
 		}
 	}
+	if in.SettingsFlow != nil {
+		in, out := &in.SettingsFlow, &out.SettingsFlow
+		*out = make([]SettingsFlowItem, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Variables != nil {
 		in, out := &in.Variables, &out.Variables
 		*out = make([]Variable, len(*in))
@@ -920,6 +927,11 @@ func (in *BMCSpec) DeepCopyInto(out *BMCSpec) {
 		in, out := &in.BMCSettingRef, &out.BMCSettingRef
 		*out = new(v1.LocalObjectReference)
 		**out = **in
+	}
+	if in.BMCSettingsRefs != nil {
+		in, out := &in.BMCSettingsRefs, &out.BMCSettingsRefs
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
 	}
 	if in.Hostname != nil {
 		in, out := &in.Hostname, &out.Hostname
@@ -2203,6 +2215,11 @@ func (in *ServerSpec) DeepCopyInto(out *ServerSpec) {
 		in, out := &in.BIOSSettingsRef, &out.BIOSSettingsRef
 		*out = new(v1.LocalObjectReference)
 		**out = **in
+	}
+	if in.BIOSSettingsRefs != nil {
+		in, out := &in.BIOSSettingsRefs, &out.BIOSSettingsRefs
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
 	}
 	if in.Taints != nil {
 		in, out := &in.Taints, &out.Taints

--- a/config/crd/bases/metal.ironcore.dev_biossettings.yaml
+++ b/config/crd/bases/metal.ironcore.dev_biossettings.yaml
@@ -60,6 +60,15 @@ spec:
           spec:
             description: BIOSSettingsSpec defines the desired state of BIOSSettings.
             properties:
+              driftPolicy:
+                description: |-
+                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+                  after the resource has been applied. Empty string (default) means the controller is fully active.
+                  Set by the parent CRD; must not be set manually.
+                enum:
+                - Observe
+                - Suspend
+                type: string
               retryPolicy:
                 description: RetryPolicy defines the retry behavior for automatic
                   retries on transient failures.
@@ -144,8 +153,13 @@ spec:
                   these settings apply to.
                 type: string
             required:
-            - version
+            - serverRef
             type: object
+            x-kubernetes-validations:
+            - message: version is required on BIOSSettings
+              rule: size(self.version) > 0
+            - message: serverRef is required
+              rule: has(self.serverRef)
           status:
             description: BIOSSettingsStatus defines the observed state of BIOSSettings.
             properties:

--- a/config/crd/bases/metal.ironcore.dev_biossettings.yaml
+++ b/config/crd/bases/metal.ironcore.dev_biossettings.yaml
@@ -60,15 +60,6 @@ spec:
           spec:
             description: BIOSSettingsSpec defines the desired state of BIOSSettings.
             properties:
-              driftPolicy:
-                description: |-
-                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-                  after the resource has been applied. Empty string (default) means the controller is fully active.
-                  Set by the parent CRD; must not be set manually.
-                enum:
-                - Observe
-                - Suspend
-                type: string
               retryPolicy:
                 description: RetryPolicy defines the retry behavior for automatic
                   retries on transient failures.

--- a/config/crd/bases/metal.ironcore.dev_biossettingssets.yaml
+++ b/config/crd/bases/metal.ironcore.dev_biossettingssets.yaml
@@ -121,8 +121,6 @@ spec:
                     description: Version specifies the software version (e.g. BIOS,
                       BMC) these settings apply to.
                     type: string
-                required:
-                - version
                 type: object
               serverSelector:
                 description: ServerSelector specifies a label selector to identify

--- a/config/crd/bases/metal.ironcore.dev_biosversions.yaml
+++ b/config/crd/bases/metal.ironcore.dev_biosversions.yaml
@@ -165,6 +165,7 @@ spec:
                 type: string
             required:
             - image
+            - serverRef
             - version
             type: object
             x-kubernetes-validations:

--- a/config/crd/bases/metal.ironcore.dev_biosversions.yaml
+++ b/config/crd/bases/metal.ironcore.dev_biosversions.yaml
@@ -69,15 +69,6 @@ spec:
           spec:
             description: BIOSVersionSpec defines the desired state of BIOSVersion.
             properties:
-              driftPolicy:
-                description: |-
-                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-                  after the upgrade completes. Empty string (default) means the controller is fully active.
-                  Set by the parent CRD; must not be set manually.
-                enum:
-                - Observe
-                - Suspend
-                type: string
               image:
                 description: Image specifies the image to use to upgrade to the given
                   BIOS version.

--- a/config/crd/bases/metal.ironcore.dev_biosversions.yaml
+++ b/config/crd/bases/metal.ironcore.dev_biosversions.yaml
@@ -69,6 +69,15 @@ spec:
           spec:
             description: BIOSVersionSpec defines the desired state of BIOSVersion.
             properties:
+              driftPolicy:
+                description: |-
+                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+                  after the upgrade completes. Empty string (default) means the controller is fully active.
+                  Set by the parent CRD; must not be set manually.
+                enum:
+                - Observe
+                - Suspend
+                type: string
               image:
                 description: Image specifies the image to use to upgrade to the given
                   BIOS version.
@@ -158,6 +167,9 @@ spec:
             - image
             - version
             type: object
+            x-kubernetes-validations:
+            - message: serverRef is required
+              rule: has(self.serverRef)
           status:
             description: BIOSVersionStatus defines the observed state of BIOSVersion.
             properties:

--- a/config/crd/bases/metal.ironcore.dev_bmcs.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcs.yaml
@@ -104,7 +104,7 @@ spec:
                 description: |-
                   BMCSettingRef is a reference to a BMCSettings object that specifies
                   the BMC configuration for this BMC.
-                  Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
+                  Deprecated: use bmcSettingsRefsList instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""

--- a/config/crd/bases/metal.ironcore.dev_bmcs.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcs.yaml
@@ -104,6 +104,7 @@ spec:
                 description: |-
                   BMCSettingRef is a reference to a BMCSettings object that specifies
                   the BMC configuration for this BMC.
+                  Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""
@@ -116,6 +117,28 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              bmcSettingsRefsList:
+                description: |-
+                  BMCSettingsRefs is a list of references to BMCSettings objects that specify
+                  the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support
+                  multiple simultaneous settings objects created.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               bmcUUID:
                 description: BMCUUID is the unique identifier for the BMC as defined
                   in Redfish API.

--- a/config/crd/bases/metal.ironcore.dev_bmcs.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcs.yaml
@@ -104,7 +104,7 @@ spec:
                 description: |-
                   BMCSettingRef is a reference to a BMCSettings object that specifies
                   the BMC configuration for this BMC.
-                  Deprecated: use bmcSettingsRefsList instead. Will be removed in next release.
+                  Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""
@@ -117,7 +117,7 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              bmcSettingsRefsList:
+              bmcSettingsRefs:
                 description: |-
                   BMCSettingsRefs is a list of references to BMCSettings objects that specify
                   the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support

--- a/config/crd/bases/metal.ironcore.dev_bmcsettings.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcsettings.yaml
@@ -67,15 +67,6 @@ spec:
                 x-kubernetes-validations:
                 - message: BMCRef is immutable
                   rule: self == oldSelf
-              driftPolicy:
-                description: |-
-                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-                  after the resource has been applied. Empty string (default) means the controller is fully active.
-                  Set by the parent CRD; must not be set manually.
-                enum:
-                - Observe
-                - Suspend
-                type: string
               retryPolicy:
                 description: RetryPolicy defines the retry behavior for automatic
                   retries on transient failures.

--- a/config/crd/bases/metal.ironcore.dev_bmcsettings.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcsettings.yaml
@@ -125,7 +125,7 @@ spec:
                   type: string
                 description: |-
                   SettingsMap contains BMC settings as a flat key/value map.
-                  Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+                  Deprecated: use settingsFlow instead. This field is mutually exclusive with settingsFlow.
                   This field will be removed in next release.
                 type: object
               settingsFlow:

--- a/config/crd/bases/metal.ironcore.dev_bmcsettings.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcsettings.yaml
@@ -67,6 +67,15 @@ spec:
                 x-kubernetes-validations:
                 - message: BMCRef is immutable
                   rule: self == oldSelf
+              driftPolicy:
+                description: |-
+                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+                  after the resource has been applied. Empty string (default) means the controller is fully active.
+                  Set by the parent CRD; must not be set manually.
+                enum:
+                - Observe
+                - Suspend
+                type: string
               retryPolicy:
                 description: RetryPolicy defines the retry behavior for automatic
                   retries on transient failures.
@@ -114,8 +123,41 @@ spec:
               settings:
                 additionalProperties:
                   type: string
-                description: SettingsMap contains BMC settings as a map.
+                description: |-
+                  SettingsMap contains BMC settings as a flat key/value map.
+                  Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+                  This field will be removed in next release.
                 type: object
+              settingsFlow:
+                description: |-
+                  SettingsFlow contains BMC settings as a named, priority-ordered list of groups.
+                  Replaces the flat settings map. Preferred over settings;
+                items:
+                  properties:
+                    name:
+                      description: Name is the name of the flow item.
+                      maxLength: 1000
+                      minLength: 1
+                      type: string
+                    priority:
+                      description: Priority defines the order of applying the settings.
+                        Lower numbers have higher priority (i.e. lower numbers are
+                        applied first).
+                      format: int32
+                      maximum: 2147483645
+                      minimum: 1
+                      type: integer
+                    settings:
+                      additionalProperties:
+                        type: string
+                      description: Settings contains software (e.g. BIOS, BMC) settings
+                        as a map.
+                      type: object
+                  required:
+                  - name
+                  - priority
+                  type: object
+                type: array
               variables:
                 description: Variables is a list of variables that can be used in
                   the settings for templating.
@@ -248,12 +290,18 @@ spec:
                 type: string
             required:
             - BMCRef
-            - version
             type: object
             x-kubernetes-validations:
+            - message: version is required on BMCSettings
+              rule: size(self.version) > 0
+            - message: BMCRef is required
+              rule: has(self.BMCRef)
             - message: variable keys must be unique
               rule: '!has(self.variables) || self.variables.all(v, self.variables.filter(w,
                 w.key == v.key).size() == 1)'
+            - message: settings and settingsFlow are mutually exclusive; migrate to
+                settingsFlow
+              rule: '!(has(self.settings) && has(self.settingsFlow))'
           status:
             description: BMCSettingsStatus defines the observed state of BMCSettings.
             properties:

--- a/config/crd/bases/metal.ironcore.dev_bmcsettingssets.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcsettingssets.yaml
@@ -136,8 +136,41 @@ spec:
                   settings:
                     additionalProperties:
                       type: string
-                    description: SettingsMap contains BMC settings as a map.
+                    description: |-
+                      SettingsMap contains BMC settings as a flat key/value map.
+                      Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+                      This field will be removed in next release.
                     type: object
+                  settingsFlow:
+                    description: |-
+                      SettingsFlow contains BMC settings as a named, priority-ordered list of groups.
+                      Replaces the flat settings map. Preferred over settings;
+                    items:
+                      properties:
+                        name:
+                          description: Name is the name of the flow item.
+                          maxLength: 1000
+                          minLength: 1
+                          type: string
+                        priority:
+                          description: Priority defines the order of applying the
+                            settings. Lower numbers have higher priority (i.e. lower
+                            numbers are applied first).
+                          format: int32
+                          maximum: 2147483645
+                          minimum: 1
+                          type: integer
+                        settings:
+                          additionalProperties:
+                            type: string
+                          description: Settings contains software (e.g. BIOS, BMC)
+                            settings as a map.
+                          type: object
+                      required:
+                      - name
+                      - priority
+                      type: object
+                    type: array
                   variables:
                     description: Variables is a list of variables that can be used
                       in the settings for templating.
@@ -272,13 +305,14 @@ spec:
                     description: Version specifies the BMC firmware version for which
                       the settings should be applied.
                     type: string
-                required:
-                - version
                 type: object
                 x-kubernetes-validations:
                 - message: variable keys must be unique
                   rule: '!has(self.variables) || self.variables.all(v, self.variables.filter(w,
                     w.key == v.key).size() == 1)'
+                - message: settings and settingsFlow are mutually exclusive; migrate
+                    to settingsFlow
+                  rule: '!(has(self.settings) && has(self.settingsFlow))'
             required:
             - bmcSelector
             - bmcSettingsTemplate

--- a/config/crd/bases/metal.ironcore.dev_bmcsettingssets.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcsettingssets.yaml
@@ -138,7 +138,7 @@ spec:
                       type: string
                     description: |-
                       SettingsMap contains BMC settings as a flat key/value map.
-                      Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+                      Deprecated: use settingsFlow instead. This field is mutually exclusive with settingsFlow.
                       This field will be removed in next release.
                     type: object
                   settingsFlow:

--- a/config/crd/bases/metal.ironcore.dev_bmcversions.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcversions.yaml
@@ -84,15 +84,6 @@ spec:
                 x-kubernetes-validations:
                 - message: bmcRef is immutable
                   rule: self == oldSelf
-              driftPolicy:
-                description: |-
-                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-                  after the upgrade completes. Empty string (default) means the controller is fully active.
-                  Set by the parent CRD; must not be set manually.
-                enum:
-                - Observe
-                - Suspend
-                type: string
               image:
                 description: Image specifies the image to use to upgrade to the given
                   BMC version.

--- a/config/crd/bases/metal.ironcore.dev_bmcversions.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcversions.yaml
@@ -84,6 +84,15 @@ spec:
                 x-kubernetes-validations:
                 - message: bmcRef is immutable
                   rule: self == oldSelf
+              driftPolicy:
+                description: |-
+                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+                  after the upgrade completes. Empty string (default) means the controller is fully active.
+                  Set by the parent CRD; must not be set manually.
+                enum:
+                - Observe
+                - Suspend
+                type: string
               image:
                 description: Image specifies the image to use to upgrade to the given
                   BMC version.
@@ -156,9 +165,13 @@ spec:
                 description: Version specifies the BMC version to upgrade to.
                 type: string
             required:
+            - bmcRef
             - image
             - version
             type: object
+            x-kubernetes-validations:
+            - message: bmcRef is required
+              rule: has(self.bmcRef)
           status:
             description: BMCVersionStatus defines the observed state of BMCVersion.
             properties:

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -79,7 +79,7 @@ spec:
                 description: |-
                   BIOSSettingsRef is a reference to a biossettings object that specifies
                   the BIOS configuration for this server.
-                  Deprecated: use biosSettingsRefsList instead. Will be removed in next release.
+                  Deprecated: use biosSettingsRefs instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""
@@ -92,7 +92,7 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              biosSettingsRefsList:
+              biosSettingsRefs:
                 description: |-
                   BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
                   the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -79,7 +79,7 @@ spec:
                 description: |-
                   BIOSSettingsRef is a reference to a biossettings object that specifies
                   the BIOS configuration for this server.
-                  Deprecated: use biosSettingsRefs instead. Will be removed in next release.
+                  Deprecated: use biosSettingsRefsList instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""
@@ -92,10 +92,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              biosSettingsRefs:
+              biosSettingsRefsList:
                 description: |-
                   BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
-                  the BIOS configuration for this server. Replaces the single biosSettingsRef to support
+                  the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support
                   multiple simultaneous settings objects created.
                 items:
                   description: |-

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -79,6 +79,7 @@ spec:
                 description: |-
                   BIOSSettingsRef is a reference to a biossettings object that specifies
                   the BIOS configuration for this server.
+                  Deprecated: use biosSettingsRefs instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""
@@ -91,6 +92,28 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              biosSettingsRefs:
+                description: |-
+                  BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
+                  the BIOS configuration for this server. Replaces the single biosSettingsRef to support
+                  multiple simultaneous settings objects created.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               bmc:
                 description: BMC contains the access details for the BMC.
                 properties:

--- a/dist/chart/templates/crd/metal.ironcore.dev_biossettings.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_biossettings.yaml
@@ -66,6 +66,15 @@ spec:
           spec:
             description: BIOSSettingsSpec defines the desired state of BIOSSettings.
             properties:
+              driftPolicy:
+                description: |-
+                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+                  after the resource has been applied. Empty string (default) means the controller is fully active.
+                  Set by the parent CRD; must not be set manually.
+                enum:
+                - Observe
+                - Suspend
+                type: string
               retryPolicy:
                 description: RetryPolicy defines the retry behavior for automatic
                   retries on transient failures.
@@ -150,8 +159,13 @@ spec:
                   these settings apply to.
                 type: string
             required:
-            - version
+            - serverRef
             type: object
+            x-kubernetes-validations:
+            - message: version is required on BIOSSettings
+              rule: size(self.version) > 0
+            - message: serverRef is required
+              rule: has(self.serverRef)
           status:
             description: BIOSSettingsStatus defines the observed state of BIOSSettings.
             properties:

--- a/dist/chart/templates/crd/metal.ironcore.dev_biossettings.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_biossettings.yaml
@@ -66,15 +66,6 @@ spec:
           spec:
             description: BIOSSettingsSpec defines the desired state of BIOSSettings.
             properties:
-              driftPolicy:
-                description: |-
-                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-                  after the resource has been applied. Empty string (default) means the controller is fully active.
-                  Set by the parent CRD; must not be set manually.
-                enum:
-                - Observe
-                - Suspend
-                type: string
               retryPolicy:
                 description: RetryPolicy defines the retry behavior for automatic
                   retries on transient failures.

--- a/dist/chart/templates/crd/metal.ironcore.dev_biossettingssets.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_biossettingssets.yaml
@@ -127,8 +127,6 @@ spec:
                     description: Version specifies the software version (e.g. BIOS,
                       BMC) these settings apply to.
                     type: string
-                required:
-                - version
                 type: object
               serverSelector:
                 description: ServerSelector specifies a label selector to identify

--- a/dist/chart/templates/crd/metal.ironcore.dev_biosversions.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_biosversions.yaml
@@ -171,6 +171,7 @@ spec:
                 type: string
             required:
             - image
+            - serverRef
             - version
             type: object
             x-kubernetes-validations:

--- a/dist/chart/templates/crd/metal.ironcore.dev_biosversions.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_biosversions.yaml
@@ -75,15 +75,6 @@ spec:
           spec:
             description: BIOSVersionSpec defines the desired state of BIOSVersion.
             properties:
-              driftPolicy:
-                description: |-
-                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-                  after the upgrade completes. Empty string (default) means the controller is fully active.
-                  Set by the parent CRD; must not be set manually.
-                enum:
-                - Observe
-                - Suspend
-                type: string
               image:
                 description: Image specifies the image to use to upgrade to the given
                   BIOS version.

--- a/dist/chart/templates/crd/metal.ironcore.dev_biosversions.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_biosversions.yaml
@@ -75,6 +75,15 @@ spec:
           spec:
             description: BIOSVersionSpec defines the desired state of BIOSVersion.
             properties:
+              driftPolicy:
+                description: |-
+                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+                  after the upgrade completes. Empty string (default) means the controller is fully active.
+                  Set by the parent CRD; must not be set manually.
+                enum:
+                - Observe
+                - Suspend
+                type: string
               image:
                 description: Image specifies the image to use to upgrade to the given
                   BIOS version.
@@ -164,6 +173,9 @@ spec:
             - image
             - version
             type: object
+            x-kubernetes-validations:
+            - message: serverRef is required
+              rule: has(self.serverRef)
           status:
             description: BIOSVersionStatus defines the observed state of BIOSVersion.
             properties:

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcs.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcs.yaml
@@ -110,6 +110,7 @@ spec:
                 description: |-
                   BMCSettingRef is a reference to a BMCSettings object that specifies
                   the BMC configuration for this BMC.
+                  Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""
@@ -122,6 +123,28 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              bmcSettingsRefsList:
+                description: |-
+                  BMCSettingsRefs is a list of references to BMCSettings objects that specify
+                  the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support
+                  multiple simultaneous settings objects created.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               bmcUUID:
                 description: BMCUUID is the unique identifier for the BMC as defined
                   in Redfish API.

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcs.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcs.yaml
@@ -110,7 +110,7 @@ spec:
                 description: |-
                   BMCSettingRef is a reference to a BMCSettings object that specifies
                   the BMC configuration for this BMC.
-                  Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
+                  Deprecated: use bmcSettingsRefsList instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcs.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcs.yaml
@@ -110,7 +110,7 @@ spec:
                 description: |-
                   BMCSettingRef is a reference to a BMCSettings object that specifies
                   the BMC configuration for this BMC.
-                  Deprecated: use bmcSettingsRefsList instead. Will be removed in next release.
+                  Deprecated: use bmcSettingsRefs instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""
@@ -123,7 +123,7 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              bmcSettingsRefsList:
+              bmcSettingsRefs:
                 description: |-
                   BMCSettingsRefs is a list of references to BMCSettings objects that specify
                   the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcsettings.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcsettings.yaml
@@ -131,7 +131,7 @@ spec:
                   type: string
                 description: |-
                   SettingsMap contains BMC settings as a flat key/value map.
-                  Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+                  Deprecated: use settingsFlow instead. This field is mutually exclusive with settingsFlow.
                   This field will be removed in next release.
                 type: object
               settingsFlow:

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcsettings.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcsettings.yaml
@@ -73,6 +73,15 @@ spec:
                 x-kubernetes-validations:
                 - message: BMCRef is immutable
                   rule: self == oldSelf
+              driftPolicy:
+                description: |-
+                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+                  after the resource has been applied. Empty string (default) means the controller is fully active.
+                  Set by the parent CRD; must not be set manually.
+                enum:
+                - Observe
+                - Suspend
+                type: string
               retryPolicy:
                 description: RetryPolicy defines the retry behavior for automatic
                   retries on transient failures.
@@ -120,8 +129,41 @@ spec:
               settings:
                 additionalProperties:
                   type: string
-                description: SettingsMap contains BMC settings as a map.
+                description: |-
+                  SettingsMap contains BMC settings as a flat key/value map.
+                  Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+                  This field will be removed in next release.
                 type: object
+              settingsFlow:
+                description: |-
+                  SettingsFlow contains BMC settings as a named, priority-ordered list of groups.
+                  Replaces the flat settings map. Preferred over settings;
+                items:
+                  properties:
+                    name:
+                      description: Name is the name of the flow item.
+                      maxLength: 1000
+                      minLength: 1
+                      type: string
+                    priority:
+                      description: Priority defines the order of applying the settings.
+                        Lower numbers have higher priority (i.e. lower numbers are
+                        applied first).
+                      format: int32
+                      maximum: 2147483645
+                      minimum: 1
+                      type: integer
+                    settings:
+                      additionalProperties:
+                        type: string
+                      description: Settings contains software (e.g. BIOS, BMC) settings
+                        as a map.
+                      type: object
+                  required:
+                  - name
+                  - priority
+                  type: object
+                type: array
               variables:
                 description: Variables is a list of variables that can be used in
                   the settings for templating.
@@ -254,12 +296,18 @@ spec:
                 type: string
             required:
             - BMCRef
-            - version
             type: object
             x-kubernetes-validations:
+            - message: version is required on BMCSettings
+              rule: size(self.version) > 0
+            - message: BMCRef is required
+              rule: has(self.BMCRef)
             - message: variable keys must be unique
               rule: '!has(self.variables) || self.variables.all(v, self.variables.filter(w,
                 w.key == v.key).size() == 1)'
+            - message: settings and settingsFlow are mutually exclusive; migrate to
+                settingsFlow
+              rule: '!(has(self.settings) && has(self.settingsFlow))'
           status:
             description: BMCSettingsStatus defines the observed state of BMCSettings.
             properties:

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcsettings.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcsettings.yaml
@@ -73,15 +73,6 @@ spec:
                 x-kubernetes-validations:
                 - message: BMCRef is immutable
                   rule: self == oldSelf
-              driftPolicy:
-                description: |-
-                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-                  after the resource has been applied. Empty string (default) means the controller is fully active.
-                  Set by the parent CRD; must not be set manually.
-                enum:
-                - Observe
-                - Suspend
-                type: string
               retryPolicy:
                 description: RetryPolicy defines the retry behavior for automatic
                   retries on transient failures.

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcsettingssets.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcsettingssets.yaml
@@ -144,7 +144,7 @@ spec:
                       type: string
                     description: |-
                       SettingsMap contains BMC settings as a flat key/value map.
-                      Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+                      Deprecated: use settingsFlow instead. This field is mutually exclusive with settingsFlow.
                       This field will be removed in next release.
                     type: object
                   settingsFlow:

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcsettingssets.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcsettingssets.yaml
@@ -142,8 +142,41 @@ spec:
                   settings:
                     additionalProperties:
                       type: string
-                    description: SettingsMap contains BMC settings as a map.
+                    description: |-
+                      SettingsMap contains BMC settings as a flat key/value map.
+                      Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.
+                      This field will be removed in next release.
                     type: object
+                  settingsFlow:
+                    description: |-
+                      SettingsFlow contains BMC settings as a named, priority-ordered list of groups.
+                      Replaces the flat settings map. Preferred over settings;
+                    items:
+                      properties:
+                        name:
+                          description: Name is the name of the flow item.
+                          maxLength: 1000
+                          minLength: 1
+                          type: string
+                        priority:
+                          description: Priority defines the order of applying the
+                            settings. Lower numbers have higher priority (i.e. lower
+                            numbers are applied first).
+                          format: int32
+                          maximum: 2147483645
+                          minimum: 1
+                          type: integer
+                        settings:
+                          additionalProperties:
+                            type: string
+                          description: Settings contains software (e.g. BIOS, BMC)
+                            settings as a map.
+                          type: object
+                      required:
+                      - name
+                      - priority
+                      type: object
+                    type: array
                   variables:
                     description: Variables is a list of variables that can be used
                       in the settings for templating.
@@ -278,13 +311,14 @@ spec:
                     description: Version specifies the BMC firmware version for which
                       the settings should be applied.
                     type: string
-                required:
-                - version
                 type: object
                 x-kubernetes-validations:
                 - message: variable keys must be unique
                   rule: '!has(self.variables) || self.variables.all(v, self.variables.filter(w,
                     w.key == v.key).size() == 1)'
+                - message: settings and settingsFlow are mutually exclusive; migrate
+                    to settingsFlow
+                  rule: '!(has(self.settings) && has(self.settingsFlow))'
             required:
             - bmcSelector
             - bmcSettingsTemplate

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcversions.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcversions.yaml
@@ -90,15 +90,6 @@ spec:
                 x-kubernetes-validations:
                 - message: bmcRef is immutable
                   rule: self == oldSelf
-              driftPolicy:
-                description: |-
-                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
-                  after the upgrade completes. Empty string (default) means the controller is fully active.
-                  Set by the parent CRD; must not be set manually.
-                enum:
-                - Observe
-                - Suspend
-                type: string
               image:
                 description: Image specifies the image to use to upgrade to the given
                   BMC version.

--- a/dist/chart/templates/crd/metal.ironcore.dev_bmcversions.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_bmcversions.yaml
@@ -90,6 +90,15 @@ spec:
                 x-kubernetes-validations:
                 - message: bmcRef is immutable
                   rule: self == oldSelf
+              driftPolicy:
+                description: |-
+                  DriftPolicy controls how the controller reacts when hardware deviates from the desired state
+                  after the upgrade completes. Empty string (default) means the controller is fully active.
+                  Set by the parent CRD; must not be set manually.
+                enum:
+                - Observe
+                - Suspend
+                type: string
               image:
                 description: Image specifies the image to use to upgrade to the given
                   BMC version.
@@ -162,9 +171,13 @@ spec:
                 description: Version specifies the BMC version to upgrade to.
                 type: string
             required:
+            - bmcRef
             - image
             - version
             type: object
+            x-kubernetes-validations:
+            - message: bmcRef is required
+              rule: has(self.bmcRef)
           status:
             description: BMCVersionStatus defines the observed state of BMCVersion.
             properties:

--- a/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
@@ -85,7 +85,7 @@ spec:
                 description: |-
                   BIOSSettingsRef is a reference to a biossettings object that specifies
                   the BIOS configuration for this server.
-                  Deprecated: use biosSettingsRefsList instead. Will be removed in next release.
+                  Deprecated: use biosSettingsRefs instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""
@@ -98,7 +98,7 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              biosSettingsRefsList:
+              biosSettingsRefs:
                 description: |-
                   BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
                   the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support

--- a/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
@@ -85,6 +85,7 @@ spec:
                 description: |-
                   BIOSSettingsRef is a reference to a biossettings object that specifies
                   the BIOS configuration for this server.
+                  Deprecated: use biosSettingsRefs instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""
@@ -97,6 +98,28 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              biosSettingsRefs:
+                description: |-
+                  BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
+                  the BIOS configuration for this server. Replaces the single biosSettingsRef to support
+                  multiple simultaneous settings objects created.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               bmc:
                 description: BMC contains the access details for the BMC.
                 properties:

--- a/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_servers.yaml
@@ -85,7 +85,7 @@ spec:
                 description: |-
                   BIOSSettingsRef is a reference to a biossettings object that specifies
                   the BIOS configuration for this server.
-                  Deprecated: use biosSettingsRefs instead. Will be removed in next release.
+                  Deprecated: use biosSettingsRefsList instead. Will be removed in next release.
                 properties:
                   name:
                     default: ""
@@ -98,10 +98,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              biosSettingsRefs:
+              biosSettingsRefsList:
                 description: |-
                   BIOSSettingsRefs is a list of references to BIOSSettings objects that specify
-                  the BIOS configuration for this server. Replaces the single biosSettingsRef to support
+                  the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support
                   multiple simultaneous settings objects created.
                 items:
                   description: |-

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1817,8 +1817,8 @@ _Appears in:_
 | `bootConfigurationRef` _[ObjectReference](#objectreference)_ | BootConfigurationRef is a reference to a BootConfiguration object that specifies<br />the boot configuration for this server. |  |  |
 | `maintenanceBootConfigurationRef` _[ObjectReference](#objectreference)_ | MaintenanceBootConfigurationRef is a reference to a BootConfiguration object that specifies<br />the boot configuration for this server during maintenance. |  |  |
 | `bootOrder` _[BootOrder](#bootorder) array_ | BootOrder specifies the boot order of the server. |  |  |
-| `biosSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BIOSSettingsRef is a reference to a biossettings object that specifies<br />the BIOS configuration for this server.<br />Deprecated: use biosSettingsRefs instead. Will be removed in next release. |  |  |
-| `biosSettingsRefs` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core) array_ | BIOSSettingsRefs is a list of references to BIOSSettings objects that specify<br />the BIOS configuration for this server. Replaces the single biosSettingsRef to support<br />multiple simultaneous settings objects created. |  |  |
+| `biosSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BIOSSettingsRef is a reference to a biossettings object that specifies<br />the BIOS configuration for this server.<br />Deprecated: use biosSettingsRefsList instead. Will be removed in next release. |  |  |
+| `biosSettingsRefsList` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core) array_ | BIOSSettingsRefs is a list of references to BIOSSettings objects that specify<br />the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support<br />multiple simultaneous settings objects created. |  |  |
 | `taints` _[Taint](#taint) array_ | Taints control which ServerClaims can be bound to this server. |  |  |
 
 

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -645,8 +645,8 @@ _Appears in:_
 | `bmcSecretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCSecretRef is a reference to the BMCSecret object that contains the credentials<br />required to access the BMC. |  |  |
 | `protocol` _[Protocol](#protocol)_ | Protocol specifies the protocol to be used for communicating with the BMC. |  |  |
 | `consoleProtocol` _[ConsoleProtocol](#consoleprotocol)_ | ConsoleProtocol specifies the protocol to be used for console access to the BMC. |  |  |
-| `bmcSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCSettingRef is a reference to a BMCSettings object that specifies<br />the BMC configuration for this BMC.<br />Deprecated: use bmcSettingsRefsList instead. Will be removed in next release. |  |  |
-| `bmcSettingsRefsList` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core) array_ | BMCSettingsRefs is a list of references to BMCSettings objects that specify<br />the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support<br />multiple simultaneous settings objects created. |  |  |
+| `bmcSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCSettingRef is a reference to a BMCSettings object that specifies<br />the BMC configuration for this BMC.<br />Deprecated: use bmcSettingsRefs instead. Will be removed in next release. |  |  |
+| `bmcSettingsRefs` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core) array_ | BMCSettingsRefs is a list of references to BMCSettings objects that specify<br />the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support<br />multiple simultaneous settings objects created. |  |  |
 | `hostname` _string_ | Hostname is the hostname of the BMC. |  |  |
 
 
@@ -1817,8 +1817,8 @@ _Appears in:_
 | `bootConfigurationRef` _[ObjectReference](#objectreference)_ | BootConfigurationRef is a reference to a BootConfiguration object that specifies<br />the boot configuration for this server. |  |  |
 | `maintenanceBootConfigurationRef` _[ObjectReference](#objectreference)_ | MaintenanceBootConfigurationRef is a reference to a BootConfiguration object that specifies<br />the boot configuration for this server during maintenance. |  |  |
 | `bootOrder` _[BootOrder](#bootorder) array_ | BootOrder specifies the boot order of the server. |  |  |
-| `biosSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BIOSSettingsRef is a reference to a biossettings object that specifies<br />the BIOS configuration for this server.<br />Deprecated: use biosSettingsRefsList instead. Will be removed in next release. |  |  |
-| `biosSettingsRefsList` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core) array_ | BIOSSettingsRefs is a list of references to BIOSSettings objects that specify<br />the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support<br />multiple simultaneous settings objects created. |  |  |
+| `biosSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BIOSSettingsRef is a reference to a biossettings object that specifies<br />the BIOS configuration for this server.<br />Deprecated: use biosSettingsRefs instead. Will be removed in next release. |  |  |
+| `biosSettingsRefs` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core) array_ | BIOSSettingsRefs is a list of references to BIOSSettings objects that specify<br />the BIOS configuration for t1his server. Replaces the single biosSettingsRef to support<br />multiple simultaneous settings objects created. |  |  |
 | `taints` _[Taint](#taint) array_ | Taints control which ServerClaims can be bound to this server. |  |  |
 
 

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -163,6 +163,7 @@ _Appears in:_
 | `settingsFlow` _[SettingsFlowItem](#settingsflowitem) array_ | SettingsFlow contains the BIOS settings sequence to apply in the given order. |  |  |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
 | `serverMaintenancePolicy` _[ServerMaintenancePolicy](#servermaintenancepolicy)_ | ServerMaintenancePolicy is a maintenance policy to be enforced on the server. |  |  |
+| `driftPolicy` _[DriftPolicy](#driftpolicy)_ | DriftPolicy controls how the controller reacts when hardware deviates from the desired state<br />after the resource has been applied. Empty string (default) means the controller is fully active.<br />Set by the parent CRD; must not be set manually. |  | Enum: [Observe Suspend] <br /> |
 | `serverMaintenanceRef` _[ObjectReference](#objectreference)_ | ServerMaintenanceRef is a reference to a ServerMaintenance object that BIOSSettings has requested for the referred server. |  |  |
 | `serverRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | ServerRef is a reference to a specific server to apply the BIOS settings on. |  |  |
 
@@ -321,6 +322,7 @@ _Appears in:_
 | `image` _[ImageSpec](#imagespec)_ | Image specifies the image to use to upgrade to the given BIOS version. |  |  |
 | `serverMaintenancePolicy` _[ServerMaintenancePolicy](#servermaintenancepolicy)_ | ServerMaintenancePolicy is a maintenance policy to be enforced on the server. |  |  |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
+| `driftPolicy` _[DriftPolicy](#driftpolicy)_ | DriftPolicy controls how the controller reacts when hardware deviates from the desired state<br />after the upgrade completes. Empty string (default) means the controller is fully active.<br />Set by the parent CRD; must not be set manually. |  | Enum: [Observe Suspend] <br /> |
 | `serverMaintenanceRef` _[ObjectReference](#objectreference)_ | ServerMaintenanceRef is a reference to a ServerMaintenance object that the controller has requested for the referred server. |  |  |
 | `serverRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | ServerRef is a reference to a specific server to apply the BIOS upgrade on. |  |  |
 
@@ -554,10 +556,12 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `version` _string_ | Version specifies the BMC firmware version for which the settings should be applied. |  |  |
-| `settings` _object (keys:string, values:string)_ | SettingsMap contains BMC settings as a map. |  |  |
+| `settings` _object (keys:string, values:string)_ | SettingsMap contains BMC settings as a flat key/value map.<br />Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.<br />This field will be removed in next release. |  |  |
+| `settingsFlow` _[SettingsFlowItem](#settingsflowitem) array_ | SettingsFlow contains BMC settings as a named, priority-ordered list of groups.<br />Replaces the flat settings map. Preferred over settings; |  |  |
 | `variables` _[Variable](#variable) array_ | Variables is a list of variables that can be used in the settings for templating. |  | MaxItems: 64 <br /> |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
 | `serverMaintenancePolicy` _[ServerMaintenancePolicy](#servermaintenancepolicy)_ | ServerMaintenancePolicy is a maintenance policy to be applied on the server. |  |  |
+| `driftPolicy` _[DriftPolicy](#driftpolicy)_ | DriftPolicy controls how the controller reacts when hardware deviates from the desired state<br />after the resource has been applied. Empty string (default) means the controller is fully active.<br />Set by the parent CRD; must not be set manually. |  | Enum: [Observe Suspend] <br /> |
 | `serverMaintenanceRefs` _[ServerMaintenanceRefItem](#servermaintenancerefitem) array_ | ServerMaintenanceRefs are references to ServerMaintenance objects which are created by the controller for each<br />server that needs to be updated with the BMC settings. |  |  |
 | `BMCRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCRef is a reference to a specific BMC to apply settings to. |  |  |
 
@@ -615,7 +619,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `version` _string_ | Version specifies the BMC firmware version for which the settings should be applied. |  |  |
-| `settings` _object (keys:string, values:string)_ | SettingsMap contains BMC settings as a map. |  |  |
+| `settings` _object (keys:string, values:string)_ | SettingsMap contains BMC settings as a flat key/value map.<br />Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.<br />This field will be removed in next release. |  |  |
+| `settingsFlow` _[SettingsFlowItem](#settingsflowitem) array_ | SettingsFlow contains BMC settings as a named, priority-ordered list of groups.<br />Replaces the flat settings map. Preferred over settings; |  |  |
 | `variables` _[Variable](#variable) array_ | Variables is a list of variables that can be used in the settings for templating. |  | MaxItems: 64 <br /> |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
 | `serverMaintenancePolicy` _[ServerMaintenancePolicy](#servermaintenancepolicy)_ | ServerMaintenancePolicy is a maintenance policy to be applied on the server. |  |  |
@@ -640,7 +645,8 @@ _Appears in:_
 | `bmcSecretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCSecretRef is a reference to the BMCSecret object that contains the credentials<br />required to access the BMC. |  |  |
 | `protocol` _[Protocol](#protocol)_ | Protocol specifies the protocol to be used for communicating with the BMC. |  |  |
 | `consoleProtocol` _[ConsoleProtocol](#consoleprotocol)_ | ConsoleProtocol specifies the protocol to be used for console access to the BMC. |  |  |
-| `bmcSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCSettingRef is a reference to a BMCSettings object that specifies<br />the BMC configuration for this BMC. |  |  |
+| `bmcSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCSettingRef is a reference to a BMCSettings object that specifies<br />the BMC configuration for this BMC.<br />Deprecated: use bmcSettingsRefs instead. Will be removed in next release. |  |  |
+| `bmcSettingsRefsList` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core) array_ | BMCSettingsRefs is a list of references to BMCSettings objects that specify<br />the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support<br />multiple simultaneous settings objects created. |  |  |
 | `hostname` _string_ | Hostname is the hostname of the BMC. |  |  |
 
 
@@ -843,6 +849,7 @@ _Appears in:_
 | `image` _[ImageSpec](#imagespec)_ | Image specifies the image to use to upgrade to the given BMC version. |  |  |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
 | `serverMaintenancePolicy` _[ServerMaintenancePolicy](#servermaintenancepolicy)_ | ServerMaintenancePolicy is a maintenance policy to be enforced on the server managed by referred BMC. |  |  |
+| `driftPolicy` _[DriftPolicy](#driftpolicy)_ | DriftPolicy controls how the controller reacts when hardware deviates from the desired state<br />after the upgrade completes. Empty string (default) means the controller is fully active.<br />Set by the parent CRD; must not be set manually. |  | Enum: [Observe Suspend] <br /> |
 | `serverMaintenanceRefs` _[ObjectReference](#objectreference) array_ | ServerMaintenanceRefs are references to ServerMaintenance objects that the controller has requested for the related servers. |  |  |
 | `bmcRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCRef is a reference to a specific BMC to apply BMC upgrade on. |  |  |
 
@@ -976,6 +983,27 @@ _Appears in:_
 | `IPMI` | ConsoleProtocolNameIPMI represents the IPMI console protocol.<br /> |
 | `SSH` | ConsoleProtocolNameSSH represents the SSH console protocol.<br /> |
 | `SSHLenovo` | ConsoleProtocolNameSSHLenovo represents the SSH console protocol specific to Lenovo hardware.<br /> |
+
+
+#### DriftPolicy
+
+_Underlying type:_ _string_
+
+DriftPolicy specifies what action to take when hardware deviates from the desired state.
+
+_Validation:_
+- Enum: [Observe Suspend]
+
+_Appears in:_
+- [BIOSSettingsSpec](#biossettingsspec)
+- [BIOSVersionSpec](#biosversionspec)
+- [BMCSettingsSpec](#bmcsettingsspec)
+- [BMCVersionSpec](#bmcversionspec)
+
+| Field | Description |
+| --- | --- |
+| `Observe` | DriftPolicyObserve detects drift and surfaces a DriftDetected condition but does not apply any hardware changes.<br /> |
+| `Suspend` | DriftPolicySuspend completely freezes reconciliation: no drift detection, no status updates, no hardware actions.<br /> |
 
 
 #### Endpoint
@@ -1789,7 +1817,8 @@ _Appears in:_
 | `bootConfigurationRef` _[ObjectReference](#objectreference)_ | BootConfigurationRef is a reference to a BootConfiguration object that specifies<br />the boot configuration for this server. |  |  |
 | `maintenanceBootConfigurationRef` _[ObjectReference](#objectreference)_ | MaintenanceBootConfigurationRef is a reference to a BootConfiguration object that specifies<br />the boot configuration for this server during maintenance. |  |  |
 | `bootOrder` _[BootOrder](#bootorder) array_ | BootOrder specifies the boot order of the server. |  |  |
-| `biosSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BIOSSettingsRef is a reference to a biossettings object that specifies<br />the BIOS configuration for this server. |  |  |
+| `biosSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BIOSSettingsRef is a reference to a biossettings object that specifies<br />the BIOS configuration for this server.<br />Deprecated: use biosSettingsRefs instead. Will be removed in next release. |  |  |
+| `biosSettingsRefs` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core) array_ | BIOSSettingsRefs is a list of references to BIOSSettings objects that specify<br />the BIOS configuration for this server. Replaces the single biosSettingsRef to support<br />multiple simultaneous settings objects created. |  |  |
 | `taints` _[Taint](#taint) array_ | Taints control which ServerClaims can be bound to this server. |  |  |
 
 
@@ -1854,6 +1883,8 @@ _Appears in:_
 _Appears in:_
 - [BIOSSettingsSpec](#biossettingsspec)
 - [BIOSSettingsTemplate](#biossettingstemplate)
+- [BMCSettingsSpec](#bmcsettingsspec)
+- [BMCSettingsTemplate](#bmcsettingstemplate)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -556,7 +556,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `version` _string_ | Version specifies the BMC firmware version for which the settings should be applied. |  |  |
-| `settings` _object (keys:string, values:string)_ | SettingsMap contains BMC settings as a flat key/value map.<br />Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.<br />This field will be removed in next release. |  |  |
+| `settings` _object (keys:string, values:string)_ | SettingsMap contains BMC settings as a flat key/value map.<br />Deprecated: use settingsFlow instead. This field is mutually exclusive with settingsFlow.<br />This field will be removed in next release. |  |  |
 | `settingsFlow` _[SettingsFlowItem](#settingsflowitem) array_ | SettingsFlow contains BMC settings as a named, priority-ordered list of groups.<br />Replaces the flat settings map. Preferred over settings; |  |  |
 | `variables` _[Variable](#variable) array_ | Variables is a list of variables that can be used in the settings for templating. |  | MaxItems: 64 <br /> |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
@@ -619,7 +619,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `version` _string_ | Version specifies the BMC firmware version for which the settings should be applied. |  |  |
-| `settings` _object (keys:string, values:string)_ | SettingsMap contains BMC settings as a flat key/value map.<br />Deprecated: use settingsFlow instead. If both fields are set, settingsFlow takes precedence.<br />This field will be removed in next release. |  |  |
+| `settings` _object (keys:string, values:string)_ | SettingsMap contains BMC settings as a flat key/value map.<br />Deprecated: use settingsFlow instead. This field is mutually exclusive with settingsFlow.<br />This field will be removed in next release. |  |  |
 | `settingsFlow` _[SettingsFlowItem](#settingsflowitem) array_ | SettingsFlow contains BMC settings as a named, priority-ordered list of groups.<br />Replaces the flat settings map. Preferred over settings; |  |  |
 | `variables` _[Variable](#variable) array_ | Variables is a list of variables that can be used in the settings for templating. |  | MaxItems: 64 <br /> |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
@@ -645,7 +645,7 @@ _Appears in:_
 | `bmcSecretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCSecretRef is a reference to the BMCSecret object that contains the credentials<br />required to access the BMC. |  |  |
 | `protocol` _[Protocol](#protocol)_ | Protocol specifies the protocol to be used for communicating with the BMC. |  |  |
 | `consoleProtocol` _[ConsoleProtocol](#consoleprotocol)_ | ConsoleProtocol specifies the protocol to be used for console access to the BMC. |  |  |
-| `bmcSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCSettingRef is a reference to a BMCSettings object that specifies<br />the BMC configuration for this BMC.<br />Deprecated: use bmcSettingsRefs instead. Will be removed in next release. |  |  |
+| `bmcSettingsRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCSettingRef is a reference to a BMCSettings object that specifies<br />the BMC configuration for this BMC.<br />Deprecated: use bmcSettingsRefsList instead. Will be removed in next release. |  |  |
 | `bmcSettingsRefsList` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core) array_ | BMCSettingsRefs is a list of references to BMCSettings objects that specify<br />the BMC configuration for this BMC. Replaces the single bmcSettingsRef to support<br />multiple simultaneous settings objects created. |  |  |
 | `hostname` _string_ | Hostname is the hostname of the BMC. |  |  |
 

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -163,7 +163,6 @@ _Appears in:_
 | `settingsFlow` _[SettingsFlowItem](#settingsflowitem) array_ | SettingsFlow contains the BIOS settings sequence to apply in the given order. |  |  |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
 | `serverMaintenancePolicy` _[ServerMaintenancePolicy](#servermaintenancepolicy)_ | ServerMaintenancePolicy is a maintenance policy to be enforced on the server. |  |  |
-| `driftPolicy` _[DriftPolicy](#driftpolicy)_ | DriftPolicy controls how the controller reacts when hardware deviates from the desired state<br />after the resource has been applied. Empty string (default) means the controller is fully active.<br />Set by the parent CRD; must not be set manually. |  | Enum: [Observe Suspend] <br /> |
 | `serverMaintenanceRef` _[ObjectReference](#objectreference)_ | ServerMaintenanceRef is a reference to a ServerMaintenance object that BIOSSettings has requested for the referred server. |  |  |
 | `serverRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | ServerRef is a reference to a specific server to apply the BIOS settings on. |  |  |
 
@@ -322,7 +321,6 @@ _Appears in:_
 | `image` _[ImageSpec](#imagespec)_ | Image specifies the image to use to upgrade to the given BIOS version. |  |  |
 | `serverMaintenancePolicy` _[ServerMaintenancePolicy](#servermaintenancepolicy)_ | ServerMaintenancePolicy is a maintenance policy to be enforced on the server. |  |  |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
-| `driftPolicy` _[DriftPolicy](#driftpolicy)_ | DriftPolicy controls how the controller reacts when hardware deviates from the desired state<br />after the upgrade completes. Empty string (default) means the controller is fully active.<br />Set by the parent CRD; must not be set manually. |  | Enum: [Observe Suspend] <br /> |
 | `serverMaintenanceRef` _[ObjectReference](#objectreference)_ | ServerMaintenanceRef is a reference to a ServerMaintenance object that the controller has requested for the referred server. |  |  |
 | `serverRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | ServerRef is a reference to a specific server to apply the BIOS upgrade on. |  |  |
 
@@ -561,7 +559,6 @@ _Appears in:_
 | `variables` _[Variable](#variable) array_ | Variables is a list of variables that can be used in the settings for templating. |  | MaxItems: 64 <br /> |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
 | `serverMaintenancePolicy` _[ServerMaintenancePolicy](#servermaintenancepolicy)_ | ServerMaintenancePolicy is a maintenance policy to be applied on the server. |  |  |
-| `driftPolicy` _[DriftPolicy](#driftpolicy)_ | DriftPolicy controls how the controller reacts when hardware deviates from the desired state<br />after the resource has been applied. Empty string (default) means the controller is fully active.<br />Set by the parent CRD; must not be set manually. |  | Enum: [Observe Suspend] <br /> |
 | `serverMaintenanceRefs` _[ServerMaintenanceRefItem](#servermaintenancerefitem) array_ | ServerMaintenanceRefs are references to ServerMaintenance objects which are created by the controller for each<br />server that needs to be updated with the BMC settings. |  |  |
 | `BMCRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCRef is a reference to a specific BMC to apply settings to. |  |  |
 
@@ -849,7 +846,6 @@ _Appears in:_
 | `image` _[ImageSpec](#imagespec)_ | Image specifies the image to use to upgrade to the given BMC version. |  |  |
 | `retryPolicy` _[RetryPolicy](#retrypolicy)_ | RetryPolicy defines the retry behavior for automatic retries on transient failures. |  |  |
 | `serverMaintenancePolicy` _[ServerMaintenancePolicy](#servermaintenancepolicy)_ | ServerMaintenancePolicy is a maintenance policy to be enforced on the server managed by referred BMC. |  |  |
-| `driftPolicy` _[DriftPolicy](#driftpolicy)_ | DriftPolicy controls how the controller reacts when hardware deviates from the desired state<br />after the upgrade completes. Empty string (default) means the controller is fully active.<br />Set by the parent CRD; must not be set manually. |  | Enum: [Observe Suspend] <br /> |
 | `serverMaintenanceRefs` _[ObjectReference](#objectreference) array_ | ServerMaintenanceRefs are references to ServerMaintenance objects that the controller has requested for the related servers. |  |  |
 | `bmcRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core)_ | BMCRef is a reference to a specific BMC to apply BMC upgrade on. |  |  |
 
@@ -983,27 +979,6 @@ _Appears in:_
 | `IPMI` | ConsoleProtocolNameIPMI represents the IPMI console protocol.<br /> |
 | `SSH` | ConsoleProtocolNameSSH represents the SSH console protocol.<br /> |
 | `SSHLenovo` | ConsoleProtocolNameSSHLenovo represents the SSH console protocol specific to Lenovo hardware.<br /> |
-
-
-#### DriftPolicy
-
-_Underlying type:_ _string_
-
-DriftPolicy specifies what action to take when hardware deviates from the desired state.
-
-_Validation:_
-- Enum: [Observe Suspend]
-
-_Appears in:_
-- [BIOSSettingsSpec](#biossettingsspec)
-- [BIOSVersionSpec](#biosversionspec)
-- [BMCSettingsSpec](#bmcsettingsspec)
-- [BMCVersionSpec](#bmcversionspec)
-
-| Field | Description |
-| --- | --- |
-| `Observe` | DriftPolicyObserve detects drift and surfaces a DriftDetected condition but does not apply any hardware changes.<br /> |
-| `Suspend` | DriftPolicySuspend completely freezes reconciliation: no drift detection, no status updates, no hardware actions.<br /> |
 
 
 #### Endpoint

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -207,6 +207,9 @@ func (r *BIOSSettingsReconciler) cleanupReferences(ctx context.Context, settings
 	if containsRef(server.Spec.BIOSSettingsRefs, settings.Name) {
 		return r.removeBIOSSettingsRefFromServer(ctx, server, settings.Name)
 	}
+	if server.Spec.BIOSSettingsRef != nil && server.Spec.BIOSSettingsRef.Name == settings.Name {
+		return r.removeBIOSSettingsRefFromServer(ctx, server, settings.Name)
+	}
 	return nil
 }
 
@@ -234,14 +237,14 @@ func (r *BIOSSettingsReconciler) reconcile(ctx context.Context, settings *metalv
 		return ctrl.Result{}, err
 	}
 
+	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, settings, BIOSSettingsFinalizer); err != nil || modified {
+		return ctrl.Result{}, err
+	}
+
 	if !containsRef(server.Spec.BIOSSettingsRefs, settings.Name) {
 		if err := r.patchBIOSSettingsRefForServer(ctx, server, settings); err != nil {
 			return ctrl.Result{}, err
 		}
-	}
-
-	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, settings, BIOSSettingsFinalizer); err != nil || modified {
-		return ctrl.Result{}, err
 	}
 
 	bmcClient, err := bmcutils.GetBMCClientForServer(ctx, r.Client, server, r.DefaultProtocol, r.SkipCertValidation, r.BMCOptions)

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -1265,14 +1265,6 @@ func (r *BIOSSettingsReconciler) requestMaintenanceForServer(ctx context.Context
 	return true, nil
 }
 
-func (r *BIOSSettingsReconciler) getBIOSSettingsByName(ctx context.Context, name string) (*metalv1alpha1.BIOSSettings, error) {
-	biosSettings := &metalv1alpha1.BIOSSettings{}
-	if err := r.Get(ctx, client.ObjectKey{Name: name}, biosSettings); err != nil {
-		return nil, fmt.Errorf("failed to get referred BIOSSetting: %w", err)
-	}
-	return biosSettings, nil
-}
-
 func (r *BIOSSettingsReconciler) patchBIOSSettingsRefForServer(ctx context.Context, server *metalv1alpha1.Server, settings *metalv1alpha1.BIOSSettings) error {
 	if server == nil {
 		return nil

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -204,16 +204,10 @@ func (r *BIOSSettingsReconciler) cleanupReferences(ctx context.Context, settings
 		return err
 	}
 
-	if server.Spec.BIOSSettingsRef == nil {
-		log.V(1).Info("Server does not have a BIOSSettingsRef")
-		return nil
+	if containsRef(server.Spec.BIOSSettingsRefs, settings.Name) {
+		return r.removeBIOSSettingsRefFromServer(ctx, server, settings.Name)
 	}
-
-	if server.Spec.BIOSSettingsRef.Name != settings.Name {
-		return nil
-	}
-
-	return r.patchBIOSSettingsRefForServer(ctx, server, nil)
+	return nil
 }
 
 func (r *BIOSSettingsReconciler) reconcile(ctx context.Context, settings *metalv1alpha1.BIOSSettings) (ctrl.Result, error) {
@@ -240,31 +234,9 @@ func (r *BIOSSettingsReconciler) reconcile(ctx context.Context, settings *metalv
 		return ctrl.Result{}, err
 	}
 
-	if server.Spec.BIOSSettingsRef == nil {
+	if !containsRef(server.Spec.BIOSSettingsRefs, settings.Name) {
 		if err := r.patchBIOSSettingsRefForServer(ctx, server, settings); err != nil {
 			return ctrl.Result{}, err
-		}
-	} else if server.Spec.BIOSSettingsRef.Name != settings.Name {
-		referredBIOSSetting, err := r.getBIOSSettingsByName(ctx, server.Spec.BIOSSettingsRef.Name)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				log.V(1).Info("Referred server contains reference to non-existing BIOSSettings object, updating reference to the current BIOSSettings")
-				if err := r.patchBIOSSettingsRefForServer(ctx, server, settings); err != nil {
-					return ctrl.Result{}, err
-				}
-				// need to requeue to make sure that reconcile re-happens here. updating server object does not trigger reconcile here.
-				return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
-			}
-			log.V(1).Info("Server contains a reference to a different BIOSSettings object", "BIOSSettings", server.Spec.BIOSSettingsRef.Name)
-			return ctrl.Result{}, err
-		}
-		// Check if the current BIOSSettings version is newer and update reference if it is newer
-		// todo : handle version checks correctly
-		if referredBIOSSetting.Spec.Version < settings.Spec.Version {
-			log.V(1).Info("Updating BIOSSettings reference to the latest BIOS version")
-			if err := r.patchBIOSSettingsRefForServer(ctx, server, settings); err != nil {
-				return ctrl.Result{}, err
-			}
 		}
 	}
 
@@ -1306,17 +1278,50 @@ func (r *BIOSSettingsReconciler) patchBIOSSettingsRefForServer(ctx context.Conte
 		return nil
 	}
 
-	current := server.Spec.BIOSSettingsRef
-	if settings != nil && current != nil && current.Name == settings.Name {
+	// Migrate deprecated spec.biosSettingsRef into spec.biosSettingsRefs.
+	// The old single-ref field is cleared once moved so it is ready for removal in the next release.
+	needsMigration := server.Spec.BIOSSettingsRef != nil &&
+		!containsRef(server.Spec.BIOSSettingsRefs, server.Spec.BIOSSettingsRef.Name)
+
+	if !needsMigration && containsRef(server.Spec.BIOSSettingsRefs, settings.Name) {
 		return nil
 	}
 
 	serverBase := server.DeepCopy()
-	if settings == nil {
+
+	if needsMigration {
+		server.Spec.BIOSSettingsRefs = append(server.Spec.BIOSSettingsRefs, *server.Spec.BIOSSettingsRef)
 		server.Spec.BIOSSettingsRef = nil
-	} else {
-		server.Spec.BIOSSettingsRef = &corev1.LocalObjectReference{Name: settings.Name}
 	}
+
+	if !containsRef(server.Spec.BIOSSettingsRefs, settings.Name) {
+		server.Spec.BIOSSettingsRefs = append(server.Spec.BIOSSettingsRefs, corev1.LocalObjectReference{Name: settings.Name})
+	}
+
+	return r.Patch(ctx, server, client.MergeFrom(serverBase))
+}
+
+func (r *BIOSSettingsReconciler) removeBIOSSettingsRefFromServer(ctx context.Context, server *metalv1alpha1.Server, name string) error {
+	if server == nil {
+		return nil
+	}
+
+	// Migrate deprecated spec.biosSettingsRef into spec.biosSettingsRefs.
+	needsMigration := server.Spec.BIOSSettingsRef != nil &&
+		!containsRef(server.Spec.BIOSSettingsRefs, server.Spec.BIOSSettingsRef.Name)
+
+	if !needsMigration && !containsRef(server.Spec.BIOSSettingsRefs, name) {
+		return nil
+	}
+
+	serverBase := server.DeepCopy()
+
+	if needsMigration {
+		server.Spec.BIOSSettingsRefs = append(server.Spec.BIOSSettingsRefs, *server.Spec.BIOSSettingsRef)
+		server.Spec.BIOSSettingsRef = nil
+	}
+
+	server.Spec.BIOSSettingsRefs = removeRef(server.Spec.BIOSSettingsRefs, name)
 
 	return r.Patch(ctx, server, client.MergeFrom(serverBase))
 }
@@ -1508,21 +1513,19 @@ func (r *BIOSSettingsReconciler) enqueueBiosSettingsByBMC(ctx context.Context, o
 
 	var reqs []ctrl.Request
 	for _, server := range serverList.Items {
-		if server.Spec.BIOSSettingsRef == nil {
-			continue
-		}
+		for _, ref := range server.Spec.BIOSSettingsRefs {
+			settings := &metalv1alpha1.BIOSSettings{}
+			if err := r.Get(ctx, types.NamespacedName{Name: ref.Name}, settings); err != nil {
+				log.Error(err, "Failed to get BIOSSettings, skipping", "name", ref.Name)
+				continue
+			}
 
-		settings := &metalv1alpha1.BIOSSettings{}
-		if err := r.Get(ctx, types.NamespacedName{Name: server.Spec.BIOSSettingsRef.Name}, settings); err != nil {
-			log.Error(err, "Failed to get BIOSSettings, skipping", "name", server.Spec.BIOSSettingsRef.Name)
-			continue
-		}
-
-		// Only enqueue if BMC reset was issued but not yet completed
-		if settings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress {
-			resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionResetIssued)
-			if err == nil && resetCond.Status != metav1.ConditionTrue && resetCond.Reason == ReasonResetIssued {
-				reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: settings.Name}})
+			// Only enqueue if BMC reset was issued but not yet completed
+			if settings.Status.State == metalv1alpha1.BIOSSettingsStateInProgress {
+				resetCond, err := GetCondition(r.Conditions, settings.Status.Conditions, ConditionResetIssued)
+				if err == nil && resetCond.Status != metav1.ConditionTrue && resetCond.Reason == ReasonResetIssued {
+					reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: settings.Name}})
+				}
 			}
 		}
 	}

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -116,7 +116,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the Server has the correct server bios setting ref")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", biosSettingsV1.Name),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettingsV1.Name})),
 		)
 
 		By("Ensuring that the BIOS setting has reached next state: Applied")
@@ -162,7 +162,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the Server has the correct server bios setting ref")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", biosSettingsV2.Name),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettingsV2.Name})),
 		)
 
 		Eventually(Object(biosSettingsV2)).Should(SatisfyAll(
@@ -175,12 +175,12 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the Server has the correct server bios setting ref")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", biosSettingsV2.Name),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettingsV2.Name})),
 		)
 		By("Deleting the BIOSSettings V2 (new)")
 		Expect(k8sClient.Delete(ctx, biosSettingsV2)).To(Succeed())
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef", BeNil()),
+			HaveField("Spec.BIOSSettingsRefs", BeEmpty()),
 		)
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
@@ -215,7 +215,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the Server has the bios setting ref")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", biosSettings.Name),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings.Name})),
 		)
 
 		Eventually(Object(biosSettings)).Should(SatisfyAll(
@@ -243,7 +243,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the bios ref is empty")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef", BeNil()),
+			HaveField("Spec.BIOSSettingsRefs", BeEmpty()),
 		)
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
@@ -278,7 +278,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the Server has the bios setting ref")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", biosSettings.Name),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings.Name})),
 		)
 
 		Eventually(Object(biosSettings)).Should(
@@ -302,7 +302,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the bios ref is empty")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef", BeNil()),
+			HaveField("Spec.BIOSSettingsRefs", BeEmpty()),
 		)
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
@@ -445,7 +445,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the Server BIOSSettings ref is empty")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef", BeNil()),
+			HaveField("Spec.BIOSSettingsRefs", BeEmpty()),
 		)
 
 		// cleanup
@@ -632,7 +632,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the Server has the bios setting ref")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef", &v1.LocalObjectReference{Name: biosSettings.Name}),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings.Name})),
 		)
 
 		By("Ensuring that the Maintenance resource has been created")
@@ -675,7 +675,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the bios ref is empty")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef", BeNil()),
+			HaveField("Spec.BIOSSettingsRefs", BeEmpty()),
 		)
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
@@ -744,8 +744,8 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the BMC has the correct BMC settings ref")
 		Eventually(Object(server)).Should(SatisfyAll(
-			HaveField("Spec.BIOSSettingsRef", Not(BeNil())),
-			HaveField("Spec.BIOSSettingsRef.Name", biosSettings.Name),
+			HaveField("Spec.BIOSSettingsRefs", Not(BeEmpty())),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings.Name})),
 		))
 
 		By("Ensuring that the biosSettings resource state is correct State inVersionUpgrade")
@@ -794,10 +794,10 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Ensuring that the Server biosSettings ref is empty on BMC")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef", BeNil()),
+			HaveField("Spec.BIOSSettingsRefs", BeEmpty()),
 		)
 		Consistently(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef", BeNil()),
+			HaveField("Spec.BIOSSettingsRefs", BeEmpty()),
 		)
 
 		// cleanup
@@ -913,8 +913,8 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Wait for the BIOSSettings to be ref on the Server")
 		Eventually(Object(server)).Should(SatisfyAll(
-			HaveField("Spec.BIOSSettingsRef", Not(BeNil())),
-			HaveField("Spec.BIOSSettingsRef.Name", biosSettings.Name),
+			HaveField("Spec.BIOSSettingsRefs", Not(BeEmpty())),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings.Name})),
 		))
 		// delete the old settings
 		Expect(k8sClient.Delete(ctx, biosSettings)).To(Succeed())
@@ -976,8 +976,8 @@ var _ = Describe("BIOSSettings Controller", func() {
 
 		By("Wait for the BIOSSettings2 to be ref on the Server")
 		Eventually(Object(server)).Should(SatisfyAll(
-			HaveField("Spec.BIOSSettingsRef", Not(BeNil())),
-			HaveField("Spec.BIOSSettingsRef.Name", biosSettings2.Name),
+			HaveField("Spec.BIOSSettingsRefs", Not(BeEmpty())),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings2.Name})),
 		))
 
 		Eventually(Object(biosSettings2)).Should(SatisfyAny(
@@ -995,6 +995,53 @@ var _ = Describe("BIOSSettings Controller", func() {
 		Eventually(Object(server)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
 		)
+	})
+
+	It("should migrate deprecated Server.spec.biosSettingsRef to Server.spec.biosSettingsRefs on first reconcile", func(ctx SpecContext) {
+		By("Creating a BIOSSettings to trigger the ref write path")
+		biosSettings := &metalv1alpha1.BIOSSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-bios-migrate-ref-",
+			},
+			Spec: metalv1alpha1.BIOSSettingsSpec{
+				ServerRef: &v1.LocalObjectReference{Name: server.Name},
+				BIOSSettingsTemplate: metalv1alpha1.BIOSSettingsTemplate{
+					Version:                 "1.0.0",
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, biosSettings)).To(Succeed())
+
+		By("Waiting for the ref to appear in BIOSSettingsRefs")
+		Eventually(Object(server)).Should(
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings.Name})),
+		)
+
+		By("Patching the deprecated Server.spec.biosSettingsRef field to simulate a pre-migration Server object")
+		Eventually(Update(server, func() {
+			server.Spec.BIOSSettingsRef = &v1.LocalObjectReference{Name: biosSettings.Name}
+			server.Spec.BIOSSettingsRefs = nil
+		})).Should(Succeed())
+
+		// Touch the BIOSSettings object with a no-op annotation to re-trigger reconciliation
+		// so the migration path in patchBIOSSettingsRefForServer is exercised.
+		By("Forcing a BIOSSettings reconcile via a no-op annotation to re-trigger migration")
+		Eventually(Update(biosSettings, func() {
+			if biosSettings.Annotations == nil {
+				biosSettings.Annotations = map[string]string{}
+			}
+			biosSettings.Annotations["metal.ironcore.dev/migration-trigger"] = "true"
+		})).Should(Succeed())
+
+		By("Ensuring the controller migrates biosSettingsRef into biosSettingsRefs and clears biosSettingsRef")
+		Eventually(Object(server)).Should(SatisfyAll(
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings.Name})),
+			HaveField("Spec.BIOSSettingsRef", BeNil()),
+		))
+
+		Expect(k8sClient.Delete(ctx, biosSettings)).To(Succeed())
+		Eventually(Get(biosSettings)).Should(Satisfy(apierrors.IsNotFound))
 	})
 })
 
@@ -1193,7 +1240,7 @@ var _ = Describe("BIOSSettings Controller with BMCRef BMC", func() {
 
 		By("Ensuring that the Server BIOSSettings ref is empty")
 		Eventually(Object(server)).Should(
-			HaveField("Spec.BIOSSettingsRef", BeNil()),
+			HaveField("Spec.BIOSSettingsRefs", BeEmpty()),
 		)
 
 		// cleanup

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -1031,7 +1031,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 			if biosSettings.Annotations == nil {
 				biosSettings.Annotations = map[string]string{}
 			}
-			biosSettings.Annotations["metal.ironcore.dev/migration-trigger"] = "true"
+			biosSettings.Annotations["metal.ironcore.dev/migration-trigger"] = trueValue
 		})).Should(Succeed())
 
 		By("Ensuring the controller migrates biosSettingsRef into biosSettingsRefs and clears biosSettingsRef")

--- a/internal/controller/biossettingsset_controller.go
+++ b/internal/controller/biossettingsset_controller.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -225,24 +224,29 @@ func (r *BIOSSettingsSetReconciler) createMissingBIOSSettings(ctx context.Contex
 		serverWithSettings[settings.Spec.ServerRef.Name] = struct{}{}
 	}
 
+	// Fetch all BIOSSettings cluster-wide to detect same-version duplicates owned by other sets.
+	allBIOSSettings := &metalv1alpha1.BIOSSettingsList{}
+	if err := r.List(ctx, allBIOSSettings); err != nil {
+		return fmt.Errorf("failed to list all BIOSSettings: %w", err)
+	}
+	type serverVersion struct{ server, version string }
+	existingByServerVersion := make(map[serverVersion]struct{}, len(allBIOSSettings.Items))
+	for _, s := range allBIOSSettings.Items {
+		if s.Spec.ServerRef != nil {
+			existingByServerVersion[serverVersion{s.Spec.ServerRef.Name, s.Spec.Version}] = struct{}{}
+		}
+	}
+	desiredVersion := set.Spec.BIOSSettingsTemplate.Version
+
 	var errs []error
 	for _, server := range servers.Items {
 		if _, ok := serverWithSettings[server.Name]; !ok {
-			if server.Spec.BIOSSettingsRef != nil {
-				if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.BIOSSettingsRef.Name}, &metalv1alpha1.BIOSSettings{}); err != nil {
-					if apierrors.IsNotFound(err) {
-						log.Error(err, "Failed to get BIOSSettings referenced by Server", "Server", server.Name, "BIOSSettings", server.Spec.BIOSSettingsRef.Name)
-						// we will go ahead and create a new BIOSSettings for this server. the ref will be updated when the new BIOSSettings is created
-					} else {
-						log.Error(err, "Error when trying to get BIOSSettings referenced by Server", "Server", server.Name, "BIOSSettings", server.Spec.BIOSSettingsRef.Name)
-						// we will try this again in next reconciliation loop
-						continue
-					}
-				} else {
-					// the referenced BIOSSettings exists or unable to determining, so we skip creating a new one
-					log.V(1).Info("Server already has a BIOSSettings ref", "Server", server.Name, "BIOSSettings", server.Spec.BIOSSettingsRef.Name)
-					continue
-				}
+			// Skip if another BIOSSettings already exists for this server at the same version —
+			// it was created by a different set and creating a duplicate would be a conflict.
+			if _, exists := existingByServerVersion[serverVersion{server.Name, desiredVersion}]; exists {
+				log.V(1).Info("BIOSSettings for this server and version already exists, skipping",
+					"server", server.Name, "version", desiredVersion)
+				continue
 			}
 			newBiosSettingsName := fmt.Sprintf("%s-%s", set.Name, server.Name)
 			var newBiosSetting *metalv1alpha1.BIOSSettings
@@ -388,12 +392,12 @@ func (r *BIOSSettingsSetReconciler) enqueueByServer(ctx context.Context, obj cli
 		}
 	}
 
-	// Additionally, check if the Server has a BIOSSettingsRef and enqueue its owner BIOSSettingsSet
-	if server.Spec.BIOSSettingsRef != nil {
+	// Additionally, check if the Server has BIOSSettingsRefs and enqueue their owner BIOSSettingsSets
+	for _, ref := range server.Spec.BIOSSettingsRefs {
 		settings := &metalv1alpha1.BIOSSettings{}
-		if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.BIOSSettingsRef.Name}, settings); err != nil {
-			log.Error(err, "Failed to get BIOSSettings referenced by Server", "Server", server.Name, "BIOSSettings", server.Spec.BIOSSettingsRef.Name)
-			return nil
+		if err := r.Get(ctx, client.ObjectKey{Name: ref.Name}, settings); err != nil {
+			log.Error(err, "Failed to get BIOSSettings referenced by Server", "Server", server.Name, "BIOSSettings", ref.Name)
+			continue
 		}
 		owner := metav1.GetControllerOf(settings)
 		if owner != nil && owner.Kind == "BIOSSettingsSet" {
@@ -419,7 +423,7 @@ func (r *BIOSSettingsSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					oldServer := e.ObjectOld.(*metalv1alpha1.Server)
 					newServer := e.ObjectNew.(*metalv1alpha1.Server)
-					return labelChangeOrAnyFieldChangeInObject(e, []any{oldServer.Spec.BIOSSettingsRef}, []any{newServer.Spec.BIOSSettingsRef})
+					return labelChangeOrAnyFieldChangeInObject(e, []any{oldServer.Spec.BIOSSettingsRefs}, []any{newServer.Spec.BIOSSettingsRefs})
 				},
 			})).
 		Complete(r)

--- a/internal/controller/biossettingsset_controller_test.go
+++ b/internal/controller/biossettingsset_controller_test.go
@@ -329,7 +329,7 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 
 		By("creating the server02")
 		server02.ResourceVersion = ""
-		server02.Spec.BIOSSettingsRef = nil
+		server02.Spec.BIOSSettingsRefs = nil
 		Expect(k8sClient.Create(ctx, server02)).Should(Succeed())
 
 		By("Checking if the BIOSSettings have been created")
@@ -491,16 +491,16 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 
 		By("Checking if the server BIOSSetting Ref has not be overritten by the 2nd BIOSSettingsSet")
 		Eventually(Object(server02)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", Equal(biosSettings02.Name)),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings02.Name})),
 		)
 		Consistently(Object(server02)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", Equal(biosSettings02.Name)),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings02.Name})),
 		)
 		Eventually(Object(server03)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", Equal(biosSettings03.Name)),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings03.Name})),
 		)
 		Consistently(Object(server03)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", Equal(biosSettings03.Name)),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings03.Name})),
 		)
 
 		By("Checking the status of the 2nd BIOSSettingsSet")
@@ -529,10 +529,10 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 
 		By("Checking if the server BIOSSetting Ref is empty")
 		Eventually(Object(server02)).Should(
-			HaveField("Spec.BIOSSettingsRef", BeNil()),
+			HaveField("Spec.BIOSSettingsRefs", BeEmpty()),
 		)
 		Eventually(Object(server03)).Should(
-			HaveField("Spec.BIOSSettingsRef", BeNil()),
+			HaveField("Spec.BIOSSettingsRefs", BeEmpty()),
 		)
 
 		By("Checking the status at the 2nd BIOSSettingsSet")
@@ -574,16 +574,16 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 
 		By("Checking if the server BIOSSetting Ref has been set by the 2nd BIOSSettingsSet")
 		Eventually(Object(server02)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", Equal(biosSettings02_02.Name)),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings02_02.Name})),
 		)
 		Consistently(Object(server02)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", Equal(biosSettings02_02.Name)),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings02_02.Name})),
 		)
 		Eventually(Object(server03)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", Equal(biosSettings03_02.Name)),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings03_02.Name})),
 		)
 		Consistently(Object(server03)).Should(
-			HaveField("Spec.BIOSSettingsRef.Name", Equal(biosSettings03_02.Name)),
+			HaveField("Spec.BIOSSettingsRefs", ContainElement(v1.LocalObjectReference{Name: biosSettings03_02.Name})),
 		)
 
 		By("Checking if the status has been updated")

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -92,19 +92,21 @@ func (r *BMCReconciler) delete(ctx context.Context, bmcObj *metalv1alpha1.BMC) (
 	// todo: delete this post migration once BMCSettingRef is removed from BMC spec
 	if bmcObj.Spec.BMCSettingRef != nil {
 		bmcSettings := &metalv1alpha1.BMCSettings{}
-		if err := r.Get(ctx, client.ObjectKey{Name: bmcObj.Spec.BMCSettingRef.Name}, bmcSettings); client.IgnoreNotFound(err) != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to get BMCSettings for BMC: %w", err)
-		}
-		if err := r.Delete(ctx, bmcSettings); err != nil {
+		if err := r.Get(ctx, client.ObjectKey{Name: bmcObj.Spec.BMCSettingRef.Name}, bmcSettings); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to get BMCSettings for BMC: %w", err)
+			}
+		} else if err := r.Delete(ctx, bmcSettings); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to delete referred BMCSettings. %w", err)
 		}
 	}
 	for _, ref := range bmcObj.Spec.BMCSettingsRefs {
 		bmcSettings := &metalv1alpha1.BMCSettings{}
-		if err := r.Get(ctx, client.ObjectKey{Name: ref.Name}, bmcSettings); client.IgnoreNotFound(err) != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to get BMCSettings for BMC: %w", err)
-		}
-		if err := r.Delete(ctx, bmcSettings); err != nil {
+		if err := r.Get(ctx, client.ObjectKey{Name: ref.Name}, bmcSettings); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to get BMCSettings for BMC: %w", err)
+			}
+		} else if err := r.Delete(ctx, bmcSettings); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to delete referred BMCSettings: %w", err)
 		}
 	}

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -89,6 +89,7 @@ func (r *BMCReconciler) reconcileExists(ctx context.Context, bmcObj *metalv1alph
 func (r *BMCReconciler) delete(ctx context.Context, bmcObj *metalv1alpha1.BMC) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Deleting BMC")
+	// todo: delete this post migration once BMCSettingRef is removed from BMC spec
 	if bmcObj.Spec.BMCSettingRef != nil {
 		bmcSettings := &metalv1alpha1.BMCSettings{}
 		if err := r.Get(ctx, client.ObjectKey{Name: bmcObj.Spec.BMCSettingRef.Name}, bmcSettings); client.IgnoreNotFound(err) != nil {
@@ -96,6 +97,15 @@ func (r *BMCReconciler) delete(ctx context.Context, bmcObj *metalv1alpha1.BMC) (
 		}
 		if err := r.Delete(ctx, bmcSettings); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to delete referred BMCSettings. %w", err)
+		}
+	}
+	for _, ref := range bmcObj.Spec.BMCSettingsRefs {
+		bmcSettings := &metalv1alpha1.BMCSettings{}
+		if err := r.Get(ctx, client.ObjectKey{Name: ref.Name}, bmcSettings); client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get BMCSettings for BMC: %w", err)
+		}
+		if err := r.Delete(ctx, bmcSettings); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete referred BMCSettings: %w", err)
 		}
 	}
 

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -1120,15 +1120,6 @@ func (r *BMCSettingsReconciler) getReferredServerMaintenances(ctx context.Contex
 	return serverMaintenances, nil
 }
 
-func (r *BMCSettingsReconciler) getReferredBMCSettings(ctx context.Context, referredBMCSettingsRef *corev1.LocalObjectReference) (*metalv1alpha1.BMCSettings, error) {
-	key := client.ObjectKey{Name: referredBMCSettingsRef.Name, Namespace: metav1.NamespaceNone}
-	settings := &metalv1alpha1.BMCSettings{}
-	if err := r.Get(ctx, key, settings); err != nil {
-		return nil, err
-	}
-	return settings, nil
-}
-
 func (r *BMCSettingsReconciler) getServerMaintenanceRefForServer(ServerMaintenanceRefs []metalv1alpha1.ServerMaintenanceRefItem, name, namespace string) *metalv1alpha1.ObjectReference {
 	for _, serverMaintenanceRef := range ServerMaintenanceRefs {
 		if serverMaintenanceRef.ServerMaintenanceRef.Name == name && serverMaintenanceRef.ServerMaintenanceRef.Namespace == namespace {

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -198,6 +198,9 @@ func (r *BMCSettingsReconciler) cleanupReferences(ctx context.Context, settings 
 	if containsRef(bmcObj.Spec.BMCSettingsRefs, settings.Name) {
 		return r.removeBMCSettingsRefFromBMC(ctx, bmcObj, settings.Name)
 	}
+	if bmcObj.Spec.BMCSettingRef != nil && bmcObj.Spec.BMCSettingRef.Name == settings.Name {
+		return r.removeBMCSettingsRefFromBMC(ctx, bmcObj, settings.Name)
+	}
 	return nil
 }
 
@@ -211,6 +214,10 @@ func (r *BMCSettingsReconciler) reconcile(ctx context.Context, settings *metalv1
 	if settings.Spec.BMCRef == nil {
 		log.V(1).Info("Object does not refer to BMC object")
 		return ctrl.Result{}, nil
+	}
+
+	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, settings, BMCSettingFinalizer); err != nil || modified {
+		return ctrl.Result{}, err
 	}
 
 	// Migrate deprecated spec.settings (flat map) to spec.settingsFlow.
@@ -240,10 +247,6 @@ func (r *BMCSettingsReconciler) reconcile(ctx context.Context, settings *metalv1
 		if err := r.patchBMCSettingsRefOnBMC(ctx, bmcObj, &corev1.LocalObjectReference{Name: settings.Name}); err != nil {
 			return ctrl.Result{}, err
 		}
-	}
-
-	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, settings, BMCSettingFinalizer); err != nil || modified {
-		return ctrl.Result{}, err
 	}
 
 	return r.ensureBMCSettingsMaintenanceStateTransition(ctx, settings, bmcObj)
@@ -1130,7 +1133,7 @@ func (r *BMCSettingsReconciler) getServerMaintenanceRefForServer(ServerMaintenan
 }
 
 func (r *BMCSettingsReconciler) patchBMCSettingsRefOnBMC(ctx context.Context, bmcObj *metalv1alpha1.BMC, BMCSettingsReference *corev1.LocalObjectReference) error {
-	// Migrate deprecated spec.bmcSettingsRef into spec.bmcSettingsRefsList.
+	// Migrate deprecated spec.bmcSettingsRef into spec.bmcSettingsRefs.
 	// The old single-ref field is cleared once moved so it is ready for removal in the next release.
 	needsMigration := bmcObj.Spec.BMCSettingRef != nil &&
 		!containsRef(bmcObj.Spec.BMCSettingsRefs, bmcObj.Spec.BMCSettingRef.Name)
@@ -1157,7 +1160,7 @@ func (r *BMCSettingsReconciler) patchBMCSettingsRefOnBMC(ctx context.Context, bm
 }
 
 func (r *BMCSettingsReconciler) removeBMCSettingsRefFromBMC(ctx context.Context, bmcObj *metalv1alpha1.BMC, name string) error {
-	// Migrate deprecated spec.bmcSettingsRef into spec.bmcSettingsRefsList.
+	// Migrate deprecated spec.bmcSettingsRef into spec.bmcSettingsRefs.
 	needsMigration := bmcObj.Spec.BMCSettingRef != nil &&
 		!containsRef(bmcObj.Spec.BMCSettingsRefs, bmcObj.Spec.BMCSettingRef.Name)
 

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -195,8 +195,8 @@ func (r *BMCSettingsReconciler) cleanupReferences(ctx context.Context, settings 
 		return err
 	}
 
-	if bmcObj.Spec.BMCSettingRef != nil && bmcObj.Spec.BMCSettingRef.Name == settings.Name {
-		return r.patchBMCSettingsRefOnBMC(ctx, bmcObj, nil)
+	if containsRef(bmcObj.Spec.BMCSettingsRefs, settings.Name) {
+		return r.removeBMCSettingsRefFromBMC(ctx, bmcObj, settings.Name)
 	}
 	return nil
 }
@@ -213,41 +213,33 @@ func (r *BMCSettingsReconciler) reconcile(ctx context.Context, settings *metalv1
 		return ctrl.Result{}, nil
 	}
 
+	// Migrate deprecated spec.settings (flat map) to spec.settingsFlow.
+	// The patch triggers a new reconcile on the updated generation; return here so the
+	// remainder of the loop always operates on the canonical field.
+	if len(settings.Spec.SettingsMap) > 0 && len(settings.Spec.SettingsFlow) == 0 {
+		log.V(1).Info("Migrating deprecated spec.settings to spec.settingsFlow")
+		base := settings.DeepCopy()
+		settings.Spec.SettingsFlow = []metalv1alpha1.SettingsFlowItem{{
+			Name:     "migrated",
+			Priority: 1,
+			Settings: settings.Spec.SettingsMap,
+		}}
+		settings.Spec.SettingsMap = nil
+		if err := r.Patch(ctx, settings, client.MergeFrom(base)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to migrate spec.settings to spec.settingsFlow: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
 	bmcObj, err := r.getBMC(ctx, settings)
 	if err != nil {
 		log.V(1).Info("Failed to fetch referred BMC object")
 		return ctrl.Result{}, err
 	}
-	if bmcObj.Spec.BMCSettingRef == nil {
+	if !containsRef(bmcObj.Spec.BMCSettingsRefs, settings.Name) {
 		if err := r.patchBMCSettingsRefOnBMC(ctx, bmcObj, &corev1.LocalObjectReference{Name: settings.Name}); err != nil {
 			return ctrl.Result{}, err
 		}
-	} else if bmcObj.Spec.BMCSettingRef.Name != settings.Name {
-		referredBMCSettings, err := r.getReferredBMCSettings(ctx, bmcObj.Spec.BMCSettingRef)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				log.V(1).Info("Referred BMC contains reference to non-existing BMCSettings, updating reference")
-				if err := r.patchBMCSettingsRefOnBMC(ctx, bmcObj, &corev1.LocalObjectReference{Name: settings.Name}); err != nil {
-					return ctrl.Result{}, err
-				}
-				// Requeue since updating the BMC object does not trigger reconciliation here
-				return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
-			}
-			log.V(1).Info("Referred BMC contains reference to different BMCSettings, unable to fetch the referenced BMCSettings")
-			return ctrl.Result{}, err
-		}
-		// TODO: Handle version checks correctly
-		if referredBMCSettings.Spec.Version < settings.Spec.Version {
-			log.V(1).Info("Updating BMCSettings reference to the latest BMC version")
-			if err := r.patchBMCSettingsRefOnBMC(ctx, bmcObj, &corev1.LocalObjectReference{Name: settings.Name}); err != nil {
-				return ctrl.Result{}, err
-			}
-			// Requeue to reconcile with the updated BMC reference
-			return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
-		}
-		// This BMCSettings does not own the BMC — stop reconciliation
-		log.V(1).Info("BMC is owned by a newer or equal version BMCSettings, skipping reconciliation")
-		return ctrl.Result{}, nil
 	}
 
 	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, settings, BMCSettingFinalizer); err != nil || modified {
@@ -805,7 +797,7 @@ func (r *BMCSettingsReconciler) getBMCSettingsDifference(ctx context.Context, se
 	if err != nil {
 		return diff, fmt.Errorf("failed to resolve BMCSettings variables: %w", err)
 	}
-	effectiveSettingsMap := ApplyVariables(settings.Spec.SettingsMap, resolvedVars)
+	effectiveSettingsMap := ApplyVariables(flattenSettingsFlow(settings.Spec.SettingsFlow), resolvedVars)
 
 	currentSettings, err := bmcClient.GetBMCAttributeValues(ctx, bmcObj.Spec.BMCUUID, effectiveSettingsMap)
 	if err != nil {
@@ -1147,14 +1139,50 @@ func (r *BMCSettingsReconciler) getServerMaintenanceRefForServer(ServerMaintenan
 }
 
 func (r *BMCSettingsReconciler) patchBMCSettingsRefOnBMC(ctx context.Context, bmcObj *metalv1alpha1.BMC, BMCSettingsReference *corev1.LocalObjectReference) error {
-	if (bmcObj.Spec.BMCSettingRef == nil && BMCSettingsReference == nil) ||
-		(bmcObj.Spec.BMCSettingRef != nil && BMCSettingsReference != nil &&
-			bmcObj.Spec.BMCSettingRef.Name == BMCSettingsReference.Name) {
+	// Migrate deprecated spec.bmcSettingsRef into spec.bmcSettingsRefsList.
+	// The old single-ref field is cleared once moved so it is ready for removal in the next release.
+	needsMigration := bmcObj.Spec.BMCSettingRef != nil &&
+		!containsRef(bmcObj.Spec.BMCSettingsRefs, bmcObj.Spec.BMCSettingRef.Name)
+
+	if !needsMigration && containsRef(bmcObj.Spec.BMCSettingsRefs, BMCSettingsReference.Name) {
 		return nil
 	}
 
 	bmcObjBase := bmcObj.DeepCopy()
-	bmcObj.Spec.BMCSettingRef = BMCSettingsReference
+
+	if needsMigration {
+		bmcObj.Spec.BMCSettingsRefs = append(bmcObj.Spec.BMCSettingsRefs, *bmcObj.Spec.BMCSettingRef)
+		bmcObj.Spec.BMCSettingRef = nil
+	}
+
+	if !containsRef(bmcObj.Spec.BMCSettingsRefs, BMCSettingsReference.Name) {
+		bmcObj.Spec.BMCSettingsRefs = append(bmcObj.Spec.BMCSettingsRefs, *BMCSettingsReference)
+	}
+
+	if err := r.Patch(ctx, bmcObj, client.MergeFrom(bmcObjBase)); err != nil {
+		return fmt.Errorf("failed to patch BMC settings ref: %w", err)
+	}
+	return nil
+}
+
+func (r *BMCSettingsReconciler) removeBMCSettingsRefFromBMC(ctx context.Context, bmcObj *metalv1alpha1.BMC, name string) error {
+	// Migrate deprecated spec.bmcSettingsRef into spec.bmcSettingsRefsList.
+	needsMigration := bmcObj.Spec.BMCSettingRef != nil &&
+		!containsRef(bmcObj.Spec.BMCSettingsRefs, bmcObj.Spec.BMCSettingRef.Name)
+
+	if !needsMigration && !containsRef(bmcObj.Spec.BMCSettingsRefs, name) {
+		return nil
+	}
+
+	bmcObjBase := bmcObj.DeepCopy()
+
+	if needsMigration {
+		bmcObj.Spec.BMCSettingsRefs = append(bmcObj.Spec.BMCSettingsRefs, *bmcObj.Spec.BMCSettingRef)
+		bmcObj.Spec.BMCSettingRef = nil
+	}
+
+	bmcObj.Spec.BMCSettingsRefs = removeRef(bmcObj.Spec.BMCSettingsRefs, name)
+
 	if err := r.Patch(ctx, bmcObj, client.MergeFrom(bmcObjBase)); err != nil {
 		return fmt.Errorf("failed to patch BMC settings ref: %w", err)
 	}

--- a/internal/controller/bmcsettings_controller_test.go
+++ b/internal/controller/bmcsettings_controller_test.go
@@ -106,7 +106,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 				}},
 		}
@@ -114,7 +114,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMC has the BMCSettings ref")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", &v1.LocalObjectReference{Name: settings.Name}),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 
 		Eventually(Object(settings)).Should(SatisfyAny(
@@ -137,7 +137,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 				}},
 		}
@@ -145,7 +145,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMC has the BMCSettings ref")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", &v1.LocalObjectReference{Name: settings.Name}),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 
 		Eventually(Object(settings)).Should(SatisfyAll(
@@ -157,7 +157,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMCSettings ref is empty on BMC")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", BeNil()),
+			HaveField("Spec.BMCSettingsRefs", BeEmpty()),
 		))
 	})
 
@@ -180,7 +180,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 				}},
 		}
@@ -188,7 +188,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMC has the BMCSettings ref")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", &v1.LocalObjectReference{Name: settings.Name}),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 
 		By("Ensuring that the BMCSettings has reached next state")
@@ -213,7 +213,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMCSettings ref is empty on BMC")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", BeNil()),
+			HaveField("Spec.BMCSettingsRefs", BeEmpty()),
 		))
 
 		// cleanup
@@ -266,7 +266,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyOwnerApproval,
 				}},
 		}
@@ -300,7 +300,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMC has the BMCSettings ref")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", &v1.LocalObjectReference{Name: settings.Name}),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 
 		Eventually(Object(settings)).Should(SatisfyAny(
@@ -334,7 +334,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMCSettings ref is empty on BMC")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", BeNil()),
+			HaveField("Spec.BMCSettingsRefs", BeEmpty()),
 		))
 
 		// cleanup
@@ -364,7 +364,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "2.45.455b66-rev4",
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 				}},
 		}
@@ -372,8 +372,8 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMC has the correct BMC settings ref")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", Not(BeNil())),
-			HaveField("Spec.BMCSettingRef.Name", settings.Name),
+			HaveField("Spec.BMCSettingsRefs", Not(BeEmpty())),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 
 		By("Ensuring that the BMCSettings resource state is Pending while waiting for version upgrade")
@@ -433,7 +433,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the Server BMCSettings ref is empty on BMC")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", BeNil()),
+			HaveField("Spec.BMCSettingsRefs", BeEmpty()),
 		))
 
 		Eventually(Object(server)).Should(
@@ -461,7 +461,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 				}},
 		}
@@ -517,7 +517,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 				}},
 		}
@@ -525,8 +525,8 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Wait for the BMCSettings to be ref on the BMC")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", Not(BeNil())),
-			HaveField("Spec.BMCSettingRef.Name", settings.Name),
+			HaveField("Spec.BMCSettingsRefs", Not(BeEmpty())),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 		Expect(k8sClient.Delete(ctx, settings)).To(Succeed())
 		By("Forcing deletion of the object by removing finalizers")
@@ -575,7 +575,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 				}},
 		}
@@ -583,8 +583,8 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Wait for the BMCSettings2 to be ref on the BMC")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", Not(BeNil())),
-			HaveField("Spec.BMCSettingRef.Name", bmcSettings2.Name),
+			HaveField("Spec.BMCSettingsRefs", Not(BeEmpty())),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: bmcSettings2.Name})),
 		))
 
 		Eventually(Object(bmcSettings2)).Should(SatisfyAny(
@@ -633,7 +633,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 					RetryPolicy:             &metalv1alpha1.RetryPolicy{MaxAttempts: new(int32(failedAutoRetryCount))},
 				}},
@@ -698,8 +698,8 @@ var _ = Describe("BMCSettings Controller", func() {
 			Spec: metalv1alpha1.BMCSettingsSpec{
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
-					Version:     "1.45.455b66-rev4",
-					SettingsMap: map[string]string{"abc": "$(SETTING_VAL)"},
+					Version:      "1.45.455b66-rev4",
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: map[string]string{"abc": "$(SETTING_VAL)"}}},
 					Variables: []metalv1alpha1.Variable{
 						{
 							Key: "SETTING_VAL",
@@ -720,7 +720,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMC has the BMCSettings ref")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", &v1.LocalObjectReference{Name: settings.Name}),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 
 		By("Ensuring that the BMCSettings reaches Applied state after variable resolution")
@@ -755,8 +755,8 @@ var _ = Describe("BMCSettings Controller", func() {
 			Spec: metalv1alpha1.BMCSettingsSpec{
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
-					Version:     "1.45.455b66-rev4",
-					SettingsMap: map[string]string{"abc": "$(SETTING_VAL)"},
+					Version:      "1.45.455b66-rev4",
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: map[string]string{"abc": "$(SETTING_VAL)"}}},
 					Variables: []metalv1alpha1.Variable{
 						{
 							Key: "SETTING_VAL",
@@ -777,7 +777,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMC has the BMCSettings ref")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", &v1.LocalObjectReference{Name: settings.Name}),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 
 		By("Ensuring that the BMCSettings reaches Applied state after variable resolution")
@@ -799,8 +799,8 @@ var _ = Describe("BMCSettings Controller", func() {
 			Spec: metalv1alpha1.BMCSettingsSpec{
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
-					Version:     "1.45.455b66-rev4",
-					SettingsMap: map[string]string{"abc": "$(BMC_NAME)"},
+					Version:      "1.45.455b66-rev4",
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: map[string]string{"abc": "$(BMC_NAME)"}}},
 					Variables: []metalv1alpha1.Variable{
 						{
 							Key: "BMC_NAME",
@@ -819,7 +819,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMC has the BMCSettings ref")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", &v1.LocalObjectReference{Name: settings.Name}),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 
 		By("Ensuring that the BMCSettings reaches Applied state with the field value substituted")
@@ -857,7 +857,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version: "1.45.455b66-rev4",
 					// Both placeholders resolved from different sources into one value.
-					SettingsMap: map[string]string{"abc": "$(BmcName).$(SearchDomain)"},
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: map[string]string{"abc": "$(BmcName).$(SearchDomain)"}}},
 					Variables: []metalv1alpha1.Variable{
 						{
 							Key: "BmcName",
@@ -886,7 +886,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMC has the BMCSettings ref")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", &v1.LocalObjectReference{Name: settings.Name}),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 
 		By("Ensuring that the BMCSettings reaches Applied state with both variables substituted")
@@ -931,8 +931,8 @@ var _ = Describe("BMCSettings Controller", func() {
 			Spec: metalv1alpha1.BMCSettingsSpec{
 				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
-					Version:     "1.45.455b66-rev4",
-					SettingsMap: map[string]string{"abc": "$(LicenseKey)"},
+					Version:      "1.45.455b66-rev4",
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: map[string]string{"abc": "$(LicenseKey)"}}},
 					Variables: []metalv1alpha1.Variable{
 						{
 							// Step 1: resolve BmcName from the object's own field.
@@ -963,7 +963,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring that the BMC has the BMCSettings ref")
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("Spec.BMCSettingRef", &v1.LocalObjectReference{Name: settings.Name}),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
 		))
 
 		By("Ensuring that the BMCSettings reaches Applied state — chained variable resolved correctly")
@@ -973,6 +973,97 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		By("Ensuring the chained variable (LicenseKey looked up via BmcName) was written to the BMC")
 		Expect(mockServers[0].GetBMCSettingAttr("BMC")).To(HaveKeyWithValue("abc", "license-key-for-"+bmc.Name))
+
+		Expect(k8sClient.Delete(ctx, settings)).To(Succeed())
+	})
+
+	It("should migrate deprecated spec.settings (flat SettingsMap) to spec.settingsFlow on first reconcile", func(ctx SpecContext) {
+		By("Creating a BMCSettings using the deprecated SettingsMap field directly via a patch")
+		settings := &metalv1alpha1.BMCSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-bmc-migrate-settings-",
+			},
+			Spec: metalv1alpha1.BMCSettingsSpec{
+				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
+				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
+					Version: "1.45.455b66-rev4",
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{
+						Name:     "settings",
+						Priority: 1,
+						Settings: map[string]string{"abc": "migrate-test"},
+					}},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, settings)).To(Succeed())
+
+		By("Patching spec.settings with the deprecated flat map to simulate a pre-migration resource")
+		Eventually(Update(settings, func() {
+			settings.Spec.SettingsMap = map[string]string{"abc": "migrate-test"}
+			settings.Spec.SettingsFlow = nil
+		})).Should(Succeed())
+
+		By("Ensuring the controller migrates SettingsMap to SettingsFlow and clears SettingsMap")
+		Eventually(Object(settings)).Should(SatisfyAll(
+			HaveField("Spec.SettingsFlow", ContainElement(HaveField("Settings", HaveKeyWithValue("abc", "migrate-test")))),
+			HaveField("Spec.SettingsMap", BeEmpty()),
+		))
+
+		By("Ensuring the settings are applied after migration")
+		Eventually(Object(settings)).Should(
+			HaveField("Status.State", metalv1alpha1.BMCSettingsStateApplied),
+		)
+
+		Expect(k8sClient.Delete(ctx, settings)).To(Succeed())
+	})
+
+	It("should migrate deprecated BMC.spec.bmcSettingsRef to BMC.spec.bmcSettingsRefs on first reconcile", func(ctx SpecContext) {
+		By("Creating a BMCSettings to trigger the ref write path")
+		settings := &metalv1alpha1.BMCSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-bmc-migrate-ref-",
+			},
+			Spec: metalv1alpha1.BMCSettingsSpec{
+				BMCRef: &v1.LocalObjectReference{Name: bmc.Name},
+				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
+					Version: "1.45.455b66-rev4",
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{
+						Name: "settings", Priority: 1,
+						Settings: map[string]string{},
+					}},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, settings)).To(Succeed())
+
+		By("Waiting for the ref to appear in BMCSettingsRefs")
+		Eventually(Object(bmc)).Should(
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
+		)
+
+		By("Patching the deprecated BMC.spec.bmcSettingsRef field to simulate a pre-migration BMC object")
+		Eventually(Update(bmc, func() {
+			bmc.Spec.BMCSettingRef = &v1.LocalObjectReference{Name: settings.Name}
+			bmc.Spec.BMCSettingsRefs = nil
+		})).Should(Succeed())
+
+		// Touch the BMCSettings object with a no-op annotation to re-trigger reconciliation
+		// so the migration path in patchBMCSettingsRefOnBMC is exercised.
+		By("Forcing a BMCSettings reconcile via a no-op annotation to re-trigger migration")
+		Eventually(Update(settings, func() {
+			if settings.Annotations == nil {
+				settings.Annotations = map[string]string{}
+			}
+			settings.Annotations["metal.ironcore.dev/migration-trigger"] = "true"
+		})).Should(Succeed())
+
+		By("Ensuring the controller migrates bmcSettingsRef into bmcSettingsRefs and clears bmcSettingsRef")
+		Eventually(Object(bmc)).Should(SatisfyAll(
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: settings.Name})),
+			HaveField("Spec.BMCSettingRef", BeNil()),
+		))
 
 		Expect(k8sClient.Delete(ctx, settings)).To(Succeed())
 	})

--- a/internal/controller/bmcsettingsset_controller.go
+++ b/internal/controller/bmcsettingsset_controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -256,29 +255,39 @@ func (r *BMCSettingsSetReconciler) createMissingBMCSettings(
 	bmcSettingsSet *metalv1alpha1.BMCSettingsSet,
 ) error {
 	log := ctrl.LoggerFrom(ctx)
+
+	// bmcWithSettings: BMC name → exists in this set's owned list.
 	bmcWithSettings := make(map[string]struct{})
 	for _, bmcSettings := range bmcSettingsList.Items {
 		bmcWithSettings[bmcSettings.Spec.BMCRef.Name] = struct{}{}
 	}
 
+	// Fetch all BMCSettings cluster-wide to detect same-version duplicates owned by other sets.
+	// We build a set of (bmcName, version) pairs that already exist so we can skip creating
+	// duplicates without making per-BMC API calls inside the loop.
+	allBMCSettings := &metalv1alpha1.BMCSettingsList{}
+	if err := r.List(ctx, allBMCSettings); err != nil {
+		return fmt.Errorf("failed to list all BMCSettings: %w", err)
+	}
+	type bmcVersion struct{ bmc, version string }
+	existingByBMCVersion := make(map[bmcVersion]struct{}, len(allBMCSettings.Items))
+	for _, s := range allBMCSettings.Items {
+		if s.Spec.BMCRef != nil {
+			existingByBMCVersion[bmcVersion{s.Spec.BMCRef.Name, s.Spec.Version}] = struct{}{}
+		}
+	}
+
+	desiredVersion := bmcSettingsSet.Spec.BMCSettingsTemplate.Version
+
 	var errs []error
 	for _, bmc := range bmcList.Items {
 		if _, ok := bmcWithSettings[bmc.Name]; !ok {
-			if bmc.Spec.BMCSettingRef != nil {
-				if err := r.Get(ctx, client.ObjectKey{Name: bmc.Spec.BMCSettingRef.Name}, &metalv1alpha1.BMCSettings{}); err != nil {
-					if apierrors.IsNotFound(err) {
-						log.V(1).Info("BMCSettings referenced by BMC not found, will create a new one", "BMC", bmc.Name, "BMCSettings", bmc.Spec.BMCSettingRef.Name)
-						// proceed to create a new BMCSettings; the ref will be updated when it is created
-					} else {
-						log.Error(err, "Failed to get BMCSettings referenced by BMC", "BMC", bmc.Name, "BMCSettings", bmc.Spec.BMCSettingRef.Name)
-						// we will try this again in next reconciliation loop
-						continue
-					}
-				} else {
-					// the referenced BMCSettings exists, so we skip creating a new one
-					log.V(1).Info("BMC already has a BMCSettings ref", "BMC", bmc.Name, "BMCSettings", bmc.Spec.BMCSettingRef.Name)
-					continue
-				}
+			// Skip if another BMCSettings already exists for this BMC at the same version —
+			// it was created by a different set and creating a duplicate would be a conflict.
+			if _, exists := existingByBMCVersion[bmcVersion{bmc.Name, desiredVersion}]; exists {
+				log.V(1).Info("BMCSettings for this BMC and version already exists, skipping",
+					"BMC", bmc.Name, "version", desiredVersion)
+				continue
 			}
 
 			// generate k8s conform name for bmcsettings
@@ -455,7 +464,7 @@ func (r *BMCSettingsSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					oldBMC := e.ObjectOld.(*metalv1alpha1.BMC)
 					newBMC := e.ObjectNew.(*metalv1alpha1.BMC)
-					return labelChangeOrAnyFieldChangeInObject(e, []any{oldBMC.Spec.BMCSettingRef}, []any{newBMC.Spec.BMCSettingRef})
+					return labelChangeOrAnyFieldChangeInObject(e, []any{oldBMC.Spec.BMCSettingsRefs}, []any{newBMC.Spec.BMCSettingsRefs})
 				},
 			})).
 		Named("bmcsettingsset").

--- a/internal/controller/bmcsettingsset_controller_test.go
+++ b/internal/controller/bmcsettingsset_controller_test.go
@@ -163,7 +163,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 				},
 				BMCSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -187,7 +187,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 		Eventually(Object(bmcSettings01)).Should(SatisfyAll(
 			HaveField("Spec.BMCRef.Name", Equal(bmc01.Name)),
 			HaveField("Spec.Version", Equal(bmcSettingsSet.Spec.BMCSettingsTemplate.Version)),
-			HaveField("Spec.SettingsMap", HaveKeyWithValue("abc", changedBMCSetting)),
+			HaveField("Spec.SettingsFlow", ContainElement(HaveField("Settings", HaveKeyWithValue("abc", changedBMCSetting)))),
 			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
 				APIVersion:         "metal.ironcore.dev/v1alpha1",
 				Kind:               "BMCSettingsSet",
@@ -240,7 +240,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 				},
 				BMCSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -264,7 +264,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 		Eventually(Object(bmcSettings01)).Should(SatisfyAll(
 			HaveField("Spec.BMCRef.Name", Equal(bmc01.Name)),
 			HaveField("Spec.Version", Equal(bmcSettingsSet.Spec.BMCSettingsTemplate.Version)),
-			HaveField("Spec.SettingsMap", HaveKeyWithValue("abc", changedBMCSetting)),
+			HaveField("Spec.SettingsFlow", ContainElement(HaveField("Settings", HaveKeyWithValue("abc", changedBMCSetting)))),
 			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
 				APIVersion:         "metal.ironcore.dev/v1alpha1",
 				Kind:               "BMCSettingsSet",
@@ -327,7 +327,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 				},
 				BMCSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -372,7 +372,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 		Eventually(Object(bmcSettings02)).Should(SatisfyAll(
 			HaveField("Spec.BMCRef.Name", Equal(bmc02.Name)),
 			HaveField("Spec.Version", Equal(bmcSettingsSet.Spec.BMCSettingsTemplate.Version)),
-			HaveField("Spec.SettingsMap", HaveKeyWithValue("abc", changedBMCSetting)),
+			HaveField("Spec.SettingsFlow", ContainElement(HaveField("Settings", HaveKeyWithValue("abc", changedBMCSetting)))),
 			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
 				APIVersion:         "metal.ironcore.dev/v1alpha1",
 				Kind:               "BMCSettingsSet",
@@ -426,7 +426,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 				},
 				BMCSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -449,7 +449,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 		Eventually(Object(bmcSettings01)).Should(SatisfyAll(
 			HaveField("Spec.BMCRef.Name", Equal(bmc01.Name)),
 			HaveField("Spec.Version", Equal(bmcSettingsSet.Spec.BMCSettingsTemplate.Version)),
-			HaveField("Spec.SettingsMap", HaveKeyWithValue("abc", changedBMCSetting)),
+			HaveField("Spec.SettingsFlow", ContainElement(HaveField("Settings", HaveKeyWithValue("abc", changedBMCSetting)))),
 			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
 				APIVersion:         "metal.ironcore.dev/v1alpha1",
 				Kind:               "BMCSettingsSet",
@@ -479,12 +479,12 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 
 		By("Updating the BMCSettingsSet template")
 		Eventually(Update(bmcSettingsSet, func() {
-			bmcSettingsSet.Spec.BMCSettingsTemplate.SettingsMap = bmcSettingNew
+			bmcSettingsSet.Spec.BMCSettingsTemplate.SettingsFlow = []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSettingNew}}
 		})).Should(Succeed())
 
 		By("Checking if the bmcSettings was updated")
 		Eventually(Object(bmcSettings01)).Should(HaveField("Spec.Version", Equal("1.45.455b66-rev4")))
-		Eventually(Object(bmcSettings01)).Should(HaveField("Spec.SettingsMap", HaveKeyWithValue("abc", "new-bmc-setting")))
+		Eventually(Object(bmcSettings01)).Should(HaveField("Spec.SettingsFlow", ContainElement(HaveField("Settings", HaveKeyWithValue("abc", "new-bmc-setting")))))
 		// Ensure the bmcSettings are in a deletable state
 		Eventually(Object(bmcSettings01)).Should(HaveField("Status.State", Equal(metalv1alpha1.BMCSettingsStateApplied)))
 
@@ -528,7 +528,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 				},
 				BMCSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -565,7 +565,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 				},
 				BMCSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -588,10 +588,10 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 
 		By("Checking if the BMC BMCSetting Ref has not be overritten by the 2nd BMCSettingsSet")
 		Eventually(Object(bmc01)).Should(
-			HaveField("Spec.BMCSettingRef.Name", Equal(bmcSettings01.Name)),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: bmcSettings01.Name})),
 		)
 		Consistently(Object(bmc01)).Should(
-			HaveField("Spec.BMCSettingRef.Name", Equal(bmcSettings01.Name)),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: bmcSettings01.Name})),
 		)
 
 		By("Checking the status of the 2nd BMCSettingsSet")
@@ -618,7 +618,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 
 		By("Checking if the BMCSettingRef of the BMC is empty")
 		Eventually(Object(bmc01)).Should(
-			HaveField("Spec.BMCSettingRef", BeNil()),
+			HaveField("Spec.BMCSettingsRefs", BeEmpty()),
 		)
 
 		By("Checking the status of the 2nd BMCSettingsSet")
@@ -652,10 +652,10 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 
 		By("Checking if the BMCSetting Ref in the BMC objets has been set by the 2nd BMCSettingsSet")
 		Eventually(Object(bmc01)).Should(
-			HaveField("Spec.BMCSettingRef.Name", Equal(bmcSettings01_02.Name)),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: bmcSettings01_02.Name})),
 		)
 		Consistently(Object(bmc01)).Should(
-			HaveField("Spec.BMCSettingRef.Name", Equal(bmcSettings01_02.Name)),
+			HaveField("Spec.BMCSettingsRefs", ContainElement(v1.LocalObjectReference{Name: bmcSettings01_02.Name})),
 		)
 
 		By("Checking if the status has been updated")
@@ -687,7 +687,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "1.45.455b66-rev4",
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
-					SettingsMap:             bmcSetting,
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: bmcSetting}},
 					RetryPolicy:             &metalv1alpha1.RetryPolicy{MaxAttempts: new(int32(failedAutoRetryCount))},
 				},
 				BMCSelector: metav1.LabelSelector{
@@ -740,11 +740,10 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 			}
 		})).Should(Succeed())
 
-		By("Ensuring that the BMCSetting01 has been retried ")
-		Eventually(Object(bmcSettings01)).Should(SatisfyAll(
-			HaveField("Status.State", Not(Equal(metalv1alpha1.BMCSettingsStateFailed))),
-			HaveField("Status.FailedAttempts", Equal(int32(0))),
-		))
+		By("Ensuring that the BMCSetting01 retry was initiated")
+		Eventually(Object(bmcSettings01)).Should(
+			HaveField("Status.FailedAttempts", BeNumerically("<", int32(failedAutoRetryCount))),
+		)
 
 		By("Ensuring that the BMCSetting01 has failed again")
 		Eventually(Object(bmcSettings01)).Should(SatisfyAll(
@@ -773,8 +772,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 		By("Updating the BMCSettingsSet with NO retry annotation")
 		Eventually(Update(bmcSettingsSet, func() {
 			delete(bmcSettingsSet.GetAnnotations(), metalv1alpha1.OperationAnnotation)
-			delete(bmcSettingsSet.Spec.BMCSettingsTemplate.SettingsMap, "UnknownSettings")
-			bmcSettingsSet.Spec.BMCSettingsTemplate.SettingsMap["abc"] = changedBMCSetting
+			bmcSettingsSet.Spec.BMCSettingsTemplate.SettingsFlow = []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: map[string]string{"abc": changedBMCSetting}}}
 		})).Should(Succeed())
 
 		By("Checking if the status has been updated to completed (retried automatically)")

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -605,3 +605,44 @@ func settingKeys(attrs schemas.SettingsAttributes) []string {
 	}
 	return keys
 }
+
+// containsRef reports whether refs contains an entry with the given name.
+func containsRef(refs []corev1.LocalObjectReference, name string) bool {
+	for _, r := range refs {
+		if r.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// removeRef returns a copy of refs with any entry matching name removed.
+func removeRef(refs []corev1.LocalObjectReference, name string) []corev1.LocalObjectReference {
+	out := refs[:0:0]
+	for _, r := range refs {
+		if r.Name != name {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// flattenSettingsFlow merges all SettingsFlowItems into a single map for BMCSettings flow as temp solution.
+// this follows the current workflows in the BMCSettings controller,
+// but will need to be reworked when we want to support firing each SettingsFlowItem separately in list order.
+// Items are processed in ascending priority order (lower number = higher priority,
+// applied first), so higher-priority items win on key conflicts.
+// TODO: fire each SettingsFlowItem separately in list order rather than merging
+// them into one flat map — required for correct ordering semantics.
+func flattenSettingsFlow(flow []metalv1alpha1.SettingsFlowItem) map[string]string {
+	sorted := make([]metalv1alpha1.SettingsFlowItem, len(flow))
+	copy(sorted, flow)
+	slices.SortFunc(sorted, func(a, b metalv1alpha1.SettingsFlowItem) int {
+		return int(a.Priority) - int(b.Priority)
+	})
+	merged := make(map[string]string)
+	for _, item := range sorted {
+		maps.Copy(merged, item.Settings)
+	}
+	return merged
+}

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -630,15 +630,15 @@ func removeRef(refs []corev1.LocalObjectReference, name string) []corev1.LocalOb
 // flattenSettingsFlow merges all SettingsFlowItems into a single map for BMCSettings flow as temp solution.
 // this follows the current workflows in the BMCSettings controller,
 // but will need to be reworked when we want to support firing each SettingsFlowItem separately in list order.
-// Items are processed in ascending priority order (lower number = higher priority,
-// applied first), so higher-priority items win on key conflicts.
+// Items are processed in descending priority order so that higher-priority items (lower number) are
+// applied last and win on key conflicts.
 // TODO: fire each SettingsFlowItem separately in list order rather than merging
 // them into one flat map — required for correct ordering semantics.
 func flattenSettingsFlow(flow []metalv1alpha1.SettingsFlowItem) map[string]string {
 	sorted := make([]metalv1alpha1.SettingsFlowItem, len(flow))
 	copy(sorted, flow)
 	slices.SortFunc(sorted, func(a, b metalv1alpha1.SettingsFlowItem) int {
-		return int(a.Priority) - int(b.Priority)
+		return int(b.Priority) - int(a.Priority) // descending: lower priority number applied last, wins
 	})
 	merged := make(map[string]string)
 	for _, item := range sorted {

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -184,10 +184,10 @@ func (r *ServerReconciler) delete(ctx context.Context, server *metalv1alpha1.Ser
 		log.V(1).Info("Deleted server boot configuration")
 	}
 
-	if server.Spec.BIOSSettingsRef != nil {
+	for _, ref := range server.Spec.BIOSSettingsRefs {
 		if err := r.Delete(ctx, &metalv1alpha1.BIOSSettings{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: server.Spec.BIOSSettingsRef.Name,
+				Name: ref.Name,
 			}}); err != nil && !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, fmt.Errorf("failed to delete BIOS settings: %w", err)
 		}

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -185,13 +185,14 @@ func (r *ServerReconciler) delete(ctx context.Context, server *metalv1alpha1.Ser
 	}
 
 	for _, ref := range server.Spec.BIOSSettingsRefs {
-		if err := r.Delete(ctx, &metalv1alpha1.BIOSSettings{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ref.Name,
-			}}); err != nil && !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("failed to delete BIOS settings: %w", err)
+		biosSettings := &metalv1alpha1.BIOSSettings{}
+		if err := r.Get(ctx, client.ObjectKey{Name: ref.Name}, biosSettings); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to get BIOSSettings for BIOS: %w", err)
+			}
+		} else if err := r.Delete(ctx, biosSettings); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete referred BIOSSettings. %w", err)
 		}
-		log.V(1).Info("BIOS settings was deleted")
 	}
 
 	log.V(1).Info("Ensuring that the finalizer is removed")

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -358,12 +358,20 @@ var _ = Describe("Server Controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 
-		biosSettings := &metalv1alpha1.BIOSSettings{ObjectMeta: metav1.ObjectMeta{
-			Name: "bios-settings",
-		}}
+		biosSettings := &metalv1alpha1.BIOSSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bios-settings",
+			},
+			Spec: metalv1alpha1.BIOSSettingsSpec{
+				ServerRef: &v1.LocalObjectReference{Name: server.Name},
+				BIOSSettingsTemplate: metalv1alpha1.BIOSSettingsTemplate{
+					Version: "P79 v1.45 (12/06/2017)",
+				},
+			},
+		}
 		Expect(k8sClient.Create(ctx, biosSettings)).To(Succeed())
 		Eventually(Update(server, func() {
-			server.Spec.BIOSSettingsRef = &v1.LocalObjectReference{Name: biosSettings.Name}
+			server.Spec.BIOSSettingsRefs = []v1.LocalObjectReference{{Name: biosSettings.Name}}
 		})).Should(Succeed())
 
 		// cleanup

--- a/internal/webhook/v1alpha1/biossettings_webhook.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook.go
@@ -41,20 +41,20 @@ type BIOSSettingsCustomValidator struct {
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type BIOSSettings.
 func (v *BIOSSettingsCustomValidator) ValidateCreate(ctx context.Context, obj *metalv1alpha1.BIOSSettings) (admission.Warnings, error) {
 	settingsLog.Info("Validation for BIOSSettings upon creation", "name", obj.GetName())
-
-	settingsList := &metalv1alpha1.BIOSSettingsList{}
-	if err := v.List(ctx, settingsList); err != nil {
+	if errs := validateDriftPolicy(obj, obj.Spec.DriftPolicy); len(errs) > 0 {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind}, obj.GetName(), errs)
+	}
+	list := &metalv1alpha1.BIOSSettingsList{}
+	if err := v.List(ctx, list); err != nil {
 		return nil, fmt.Errorf("failed to list BIOSSettings: %w", err)
 	}
-
-	return checkForDuplicateBIOSSettingsRefToServer(settingsList, obj)
+	return nil, checkDuplicateBIOSSettings(list, obj)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type BIOSSettings.
 func (v *BIOSSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *metalv1alpha1.BIOSSettings) (admission.Warnings, error) {
 	settingsLog.Info("Validation for BIOSSettings upon update", "name", newObj.GetName())
 
-	// we do not allow Updates to BIOSSettings post server Maintenance creation
 	if oldObj.Status.State == metalv1alpha1.BIOSSettingsStateInProgress &&
 		!ShouldAllowForceUpdateInProgress(newObj) && oldObj.Spec.ServerMaintenanceRef != nil {
 		err := fmt.Errorf("BIOSSettings (%s) is in progress, unable to update %s", oldObj.Name, newObj.Name)
@@ -63,12 +63,15 @@ func (v *BIOSSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj
 			newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), err.Error())})
 	}
 
-	settingsList := &metalv1alpha1.BIOSSettingsList{}
-	if err := v.List(ctx, settingsList); err != nil {
-		return nil, fmt.Errorf("failed to list BIOSSettings: %w", err)
+	if errs := validateDriftPolicy(newObj, newObj.Spec.DriftPolicy); len(errs) > 0 {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind}, newObj.GetName(), errs)
 	}
 
-	return checkForDuplicateBIOSSettingsRefToServer(settingsList, newObj)
+	list := &metalv1alpha1.BIOSSettingsList{}
+	if err := v.List(ctx, list); err != nil {
+		return nil, fmt.Errorf("failed to list BIOSSettings: %w", err)
+	}
+	return nil, checkDuplicateBIOSSettings(list, newObj)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type BIOSSettings.
@@ -79,24 +82,5 @@ func (v *BIOSSettingsCustomValidator) ValidateDelete(_ context.Context, obj *met
 		return nil, apierrors.NewBadRequest("The bios settings in progress, unable to delete")
 	}
 
-	return nil, nil
-}
-
-func checkForDuplicateBIOSSettingsRefToServer(settingsList *metalv1alpha1.BIOSSettingsList, settings *metalv1alpha1.BIOSSettings) (admission.Warnings, error) {
-	for _, bs := range settingsList.Items {
-		if settings.Name == bs.Name {
-			continue
-		}
-		if settings.Spec.ServerRef.Name == bs.Spec.ServerRef.Name {
-			err := fmt.Errorf("server (%s) referred in %s is duplicate of server (%s) referred in %s",
-				settings.Spec.ServerRef.Name,
-				settings.Name,
-				bs.Spec.ServerRef.Name,
-				bs.Name)
-			return nil, apierrors.NewInvalid(
-				schema.GroupKind{Group: settings.GroupVersionKind().Group, Kind: settings.Kind},
-				settings.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("serverRef"), err)})
-		}
-	}
 	return nil, nil
 }

--- a/internal/webhook/v1alpha1/biossettings_webhook.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook.go
@@ -42,9 +42,6 @@ type BIOSSettingsCustomValidator struct {
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type BIOSSettings.
 func (v *BIOSSettingsCustomValidator) ValidateCreate(ctx context.Context, obj *metalv1alpha1.BIOSSettings) (admission.Warnings, error) {
 	settingsLog.Info("Validation for BIOSSettings upon creation", "name", obj.GetName())
-	if errs := validateDriftPolicy(obj, obj.Spec.DriftPolicy); len(errs) > 0 {
-		return nil, apierrors.NewInvalid(schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind}, obj.GetName(), errs)
-	}
 	list := &metalv1alpha1.BIOSSettingsList{}
 	if err := v.List(ctx, list); err != nil {
 		return nil, fmt.Errorf("failed to list BIOSSettings: %w", err)
@@ -62,10 +59,6 @@ func (v *BIOSSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj
 		return nil, apierrors.NewInvalid(
 			schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind},
 			newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), err.Error())})
-	}
-
-	if errs := validateDriftPolicy(newObj, newObj.Spec.DriftPolicy); len(errs) > 0 {
-		return nil, apierrors.NewInvalid(schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind}, newObj.GetName(), errs)
 	}
 
 	list := &metalv1alpha1.BIOSSettingsList{}

--- a/internal/webhook/v1alpha1/biossettings_webhook_test.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook_test.go
@@ -94,7 +94,7 @@ var _ = Describe("BIOSSettings Webhook", func() {
 		Expect(k8sClient.Create(ctx, biosSettingsV2)).To(Succeed())
 	})
 
-	It("should deny update if spec.serverRef is duplicate", func() {
+	It("should deny update if spec.serverRef and version is duplicate", func() {
 		By("Creating a BIOSSettings with different ServerRef")
 		biosSettingsV2 := &metalv1alpha1.BIOSSettings{
 			ObjectMeta: metav1.ObjectMeta{
@@ -103,7 +103,7 @@ var _ = Describe("BIOSSettings Webhook", func() {
 			Spec: metalv1alpha1.BIOSSettingsSpec{
 				ServerRef: &v1.LocalObjectReference{Name: "bar"},
 				BIOSSettingsTemplate: metalv1alpha1.BIOSSettingsTemplate{
-					Version: anotherMockUpServerBiosVersion,
+					Version: defaultMockUpServerBiosVersion,
 					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{
 						Settings: map[string]string{},
 						Priority: 1,

--- a/internal/webhook/v1alpha1/biosversion_webhook.go
+++ b/internal/webhook/v1alpha1/biosversion_webhook.go
@@ -43,9 +43,6 @@ type BIOSVersionCustomValidator struct {
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type BIOSVersion.
 func (v *BIOSVersionCustomValidator) ValidateCreate(ctx context.Context, obj *metalv1alpha1.BIOSVersion) (admission.Warnings, error) {
 	versionLog.Info("Validation for BIOSVersion upon creation", "name", obj.GetName())
-	if errs := validateDriftPolicy(obj, obj.Spec.DriftPolicy); len(errs) > 0 {
-		return nil, apierrors.NewInvalid(schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind}, obj.GetName(), errs)
-	}
 	list := &metalv1alpha1.BIOSVersionList{}
 	if err := v.List(ctx, list); err != nil {
 		return nil, fmt.Errorf("failed to list BIOSVersions: %w", err)
@@ -69,10 +66,6 @@ func (v *BIOSVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 				schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind},
 				newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), msg.Error())})
 		}
-	}
-
-	if errs := validateDriftPolicy(newObj, newObj.Spec.DriftPolicy); len(errs) > 0 {
-		return nil, apierrors.NewInvalid(schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind}, newObj.GetName(), errs)
 	}
 
 	list := &metalv1alpha1.BIOSVersionList{}

--- a/internal/webhook/v1alpha1/biosversion_webhook.go
+++ b/internal/webhook/v1alpha1/biosversion_webhook.go
@@ -42,12 +42,14 @@ type BIOSVersionCustomValidator struct {
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type BIOSVersion.
 func (v *BIOSVersionCustomValidator) ValidateCreate(ctx context.Context, obj *metalv1alpha1.BIOSVersion) (admission.Warnings, error) {
 	versionLog.Info("Validation for BIOSVersion upon creation", "name", obj.GetName())
-
-	versions := &metalv1alpha1.BIOSVersionList{}
-	if err := v.List(ctx, versions); err != nil {
-		return nil, fmt.Errorf("failed to list BIOSVersion: %w", err)
+	if errs := validateDriftPolicy(obj, obj.Spec.DriftPolicy); len(errs) > 0 {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind}, obj.GetName(), errs)
 	}
-	return checkForDuplicateBIOSVersionRefToServer(versions, obj)
+	list := &metalv1alpha1.BIOSVersionList{}
+	if err := v.List(ctx, list); err != nil {
+		return nil, fmt.Errorf("failed to list BIOSVersions: %w", err)
+	}
+	return nil, checkDuplicateBIOSVersions(list, obj)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type BIOSVersion.
@@ -64,12 +66,15 @@ func (v *BIOSVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 			newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), err.Error())})
 	}
 
-	versions := &metalv1alpha1.BIOSVersionList{}
-	if err := v.List(ctx, versions); err != nil {
-		return nil, fmt.Errorf("failed to list BIOSVersion: %w", err)
+	if errs := validateDriftPolicy(newObj, newObj.Spec.DriftPolicy); len(errs) > 0 {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind}, newObj.GetName(), errs)
 	}
 
-	return checkForDuplicateBIOSVersionRefToServer(versions, newObj)
+	list := &metalv1alpha1.BIOSVersionList{}
+	if err := v.List(ctx, list); err != nil {
+		return nil, fmt.Errorf("failed to list BIOSVersions: %w", err)
+	}
+	return nil, checkDuplicateBIOSVersions(list, newObj)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type BIOSVersion.
@@ -78,33 +83,6 @@ func (v *BIOSVersionCustomValidator) ValidateDelete(ctx context.Context, obj *me
 
 	if obj.Status.State == metalv1alpha1.BIOSVersionStateInProgress && !ShouldAllowForceDeleteInProgress(obj) {
 		return nil, apierrors.NewBadRequest("The BIOS version is in progress and cannot be deleted")
-	}
-	return nil, nil
-}
-
-func checkForDuplicateBIOSVersionRefToServer(versions *metalv1alpha1.BIOSVersionList, version *metalv1alpha1.BIOSVersion) (admission.Warnings, error) {
-	if version.Spec.ServerRef == nil {
-		return nil, nil
-	}
-
-	for _, bv := range versions.Items {
-		if version.Name == bv.Name {
-			continue
-		}
-		if bv.Spec.ServerRef == nil {
-			continue
-		}
-		if version.Spec.ServerRef.Name == bv.Spec.ServerRef.Name {
-			err := fmt.Errorf("server (%s) referred in %s is duplicate of server (%s) referred in %s",
-				version.Spec.ServerRef.Name,
-				version.Name,
-				bv.Spec.ServerRef.Name,
-				bv.Name,
-			)
-			return nil, apierrors.NewInvalid(
-				schema.GroupKind{Group: version.GroupVersionKind().Group, Kind: version.Kind},
-				version.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("serverRef").Child("name"), err)})
-		}
 	}
 	return nil, nil
 }

--- a/internal/webhook/v1alpha1/bmcsettings_webhook.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook.go
@@ -45,9 +45,6 @@ type BMCSettingsCustomValidator struct {
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type BMCSettings.
 func (v *BMCSettingsCustomValidator) ValidateCreate(ctx context.Context, obj *metalv1alpha1.BMCSettings) (admission.Warnings, error) {
 	bmcsettingslog.Info("Validation for BMCSettings upon creation", "name", obj.GetName())
-	if errs := validateDriftPolicy(obj, obj.Spec.DriftPolicy); len(errs) > 0 {
-		return nil, apierrors.NewInvalid(schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind}, obj.GetName(), errs)
-	}
 	list := &metalv1alpha1.BMCSettingsList{}
 	if err := v.Client.List(ctx, list); err != nil {
 		return nil, fmt.Errorf("failed to list BMCSettings: %w", err)
@@ -77,10 +74,6 @@ func (v *BMCSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 				schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: oldObj.Kind},
 				newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), msg.Error())})
 		}
-	}
-
-	if errs := validateDriftPolicy(newObj, newObj.Spec.DriftPolicy); len(errs) > 0 {
-		return nil, apierrors.NewInvalid(schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind}, newObj.GetName(), errs)
 	}
 
 	list := &metalv1alpha1.BMCSettingsList{}

--- a/internal/webhook/v1alpha1/bmcsettings_webhook.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook.go
@@ -44,12 +44,14 @@ type BMCSettingsCustomValidator struct {
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type BMCSettings.
 func (v *BMCSettingsCustomValidator) ValidateCreate(ctx context.Context, obj *metalv1alpha1.BMCSettings) (admission.Warnings, error) {
 	bmcsettingslog.Info("Validation for BMCSettings upon creation", "name", obj.GetName())
-
-	bmcSettingsList := &metalv1alpha1.BMCSettingsList{}
-	if err := v.Client.List(ctx, bmcSettingsList); err != nil {
+	if errs := validateDriftPolicy(obj, obj.Spec.DriftPolicy); len(errs) > 0 {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind}, obj.GetName(), errs)
+	}
+	list := &metalv1alpha1.BMCSettingsList{}
+	if err := v.Client.List(ctx, list); err != nil {
 		return nil, fmt.Errorf("failed to list BMCSettings: %w", err)
 	}
-	return checkForDuplicateBMCSettingsRefToBMC(bmcSettingsList, obj)
+	return nil, checkDuplicateBMCSettings(list, obj)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type BMCSettings.
@@ -66,11 +68,15 @@ func (v *BMCSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 			newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), err.Error())})
 	}
 
-	bmcSettingsList := &metalv1alpha1.BMCSettingsList{}
-	if err := v.Client.List(ctx, bmcSettingsList); err != nil {
+	if errs := validateDriftPolicy(newObj, newObj.Spec.DriftPolicy); len(errs) > 0 {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind}, newObj.GetName(), errs)
+	}
+
+	list := &metalv1alpha1.BMCSettingsList{}
+	if err := v.Client.List(ctx, list); err != nil {
 		return nil, fmt.Errorf("failed to list BMCSettings: %w", err)
 	}
-	return checkForDuplicateBMCSettingsRefToBMC(bmcSettingsList, newObj)
+	return nil, checkDuplicateBMCSettings(list, newObj)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type BMCSettings.
@@ -81,24 +87,5 @@ func (v *BMCSettingsCustomValidator) ValidateDelete(ctx context.Context, obj *me
 		return nil, apierrors.NewBadRequest("The BMC settings in progress, unable to delete")
 	}
 
-	return nil, nil
-}
-
-func checkForDuplicateBMCSettingsRefToBMC(settingsList *metalv1alpha1.BMCSettingsList, settings *metalv1alpha1.BMCSettings) (admission.Warnings, error) {
-	for _, bs := range settingsList.Items {
-		if settings.Name == bs.Name {
-			continue
-		}
-		if bs.Spec.BMCRef.Name == settings.Spec.BMCRef.Name {
-			err := fmt.Errorf("BMC (%s) referred in %s is duplicate of BMC (%s) referred in %s",
-				settings.Spec.BMCRef.Name,
-				settings.Name,
-				bs.Spec.BMCRef.Name,
-				bs.Name)
-			return nil, apierrors.NewInvalid(
-				schema.GroupKind{Group: settings.GroupVersionKind().Group, Kind: settings.Kind},
-				settings.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("bmcRef"), err)})
-		}
-	}
 	return nil, nil
 }

--- a/internal/webhook/v1alpha1/bmcsettings_webhook_test.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook_test.go
@@ -31,7 +31,7 @@ var _ = Describe("BMCSettings Webhook", func() {
 				BMCRef: &v1.LocalObjectReference{Name: "foo"},
 				BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 					Version:                 "P70 v1.45 (12/06/2017)",
-					SettingsMap:             map[string]string{},
+					SettingsFlow:            []metalv1alpha1.SettingsFlowItem{},
 					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 				}},
 		}
@@ -59,8 +59,8 @@ var _ = Describe("BMCSettings Webhook", func() {
 				Spec: metalv1alpha1.BMCSettingsSpec{
 					BMCRef: &v1.LocalObjectReference{Name: "foo"},
 					BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
-						Version:                 "1.45.455b66-rev4",
-						SettingsMap:             map[string]string{},
+						Version:                 "P70 v1.45 (12/06/2017)",
+						SettingsFlow:            []metalv1alpha1.SettingsFlowItem{},
 						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 					}},
 			}
@@ -78,7 +78,7 @@ var _ = Describe("BMCSettings Webhook", func() {
 					BMCRef: &v1.LocalObjectReference{Name: "bar"},
 					BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 						Version:                 "P70 v1.45 (12/06/2017)",
-						SettingsMap:             map[string]string{},
+						SettingsFlow:            []metalv1alpha1.SettingsFlowItem{},
 						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 					}},
 			}
@@ -96,7 +96,7 @@ var _ = Describe("BMCSettings Webhook", func() {
 					BMCRef: &v1.LocalObjectReference{Name: "bar"},
 					BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 						Version:                 "P70 v1.45 (12/06/2017)",
-						SettingsMap:             map[string]string{},
+						SettingsFlow:            []metalv1alpha1.SettingsFlowItem{},
 						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 					}},
 			}
@@ -105,6 +105,7 @@ var _ = Describe("BMCSettings Webhook", func() {
 			By("Updating an BMCSettingsV2 to refer to existing BMC")
 			BMCSettingsV2Updated := BMCSettingsV2.DeepCopy()
 			BMCSettingsV2Updated.Spec.BMCRef = BMCSettingsV1.Spec.BMCRef
+			BMCSettingsV2Updated.Spec.Version = "P70 v1.45 (12/06/2017)"
 			Expect(validator.ValidateUpdate(ctx, BMCSettingsV2, BMCSettingsV2Updated)).Error().To(HaveOccurred())
 		})
 
@@ -119,7 +120,7 @@ var _ = Describe("BMCSettings Webhook", func() {
 					BMCRef: &v1.LocalObjectReference{Name: "bar"},
 					BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
 						Version:                 "P70 v1.45 (12/06/2017)",
-						SettingsMap:             map[string]string{},
+						SettingsFlow:            []metalv1alpha1.SettingsFlowItem{},
 						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 					}},
 			}
@@ -144,7 +145,7 @@ var _ = Describe("BMCSettings Webhook", func() {
 			})).Should(Succeed())
 			By("Updating an bmcSettings V1 spec, should fail to update when inProgress")
 			bmcSettingsV1Updated := BMCSettingsV1.DeepCopy()
-			bmcSettingsV1Updated.Spec.SettingsMap = map[string]string{"test": "value"}
+			bmcSettingsV1Updated.Spec.SettingsFlow = []metalv1alpha1.SettingsFlowItem{{Name: "settings", Priority: 1, Settings: map[string]string{"test": "value"}}}
 			Expect(validator.ValidateUpdate(ctx, BMCSettingsV1, bmcSettingsV1Updated)).Error().To(HaveOccurred())
 			By("Updating an bmcSettings V1 spec, should pass to update when inProgress with ForceUpdateResource finalizer")
 			bmcSettingsV1Updated.Annotations = map[string]string{metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationForceUpdateInProgress}

--- a/internal/webhook/v1alpha1/bmcversion_webhook.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook.go
@@ -43,9 +43,6 @@ type BMCVersionCustomValidator struct {
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type BMCVersion.
 func (v *BMCVersionCustomValidator) ValidateCreate(ctx context.Context, obj *metalv1alpha1.BMCVersion) (admission.Warnings, error) {
 	bmcversionlog.Info("Validation for BMCVersion upon creation", "name", obj.GetName())
-	if errs := validateDriftPolicy(obj, obj.Spec.DriftPolicy); len(errs) > 0 {
-		return nil, apierrors.NewInvalid(schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind}, obj.GetName(), errs)
-	}
 	list := &metalv1alpha1.BMCVersionList{}
 	if err := v.Client.List(ctx, list); err != nil {
 		return nil, fmt.Errorf("failed to list BMCVersions: %w", err)
@@ -69,10 +66,6 @@ func (v *BMCVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj, 
 				schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind},
 				newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), msg.Error())})
 		}
-	}
-
-	if errs := validateDriftPolicy(newObj, newObj.Spec.DriftPolicy); len(errs) > 0 {
-		return nil, apierrors.NewInvalid(schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind}, newObj.GetName(), errs)
 	}
 
 	list := &metalv1alpha1.BMCVersionList{}

--- a/internal/webhook/v1alpha1/bmcversion_webhook.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook.go
@@ -42,11 +42,14 @@ type BMCVersionCustomValidator struct {
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type BMCVersion.
 func (v *BMCVersionCustomValidator) ValidateCreate(ctx context.Context, obj *metalv1alpha1.BMCVersion) (admission.Warnings, error) {
 	bmcversionlog.Info("Validation for BMCVersion upon creation", "name", obj.GetName())
-	bmcVersionList := &metalv1alpha1.BMCVersionList{}
-	if err := v.Client.List(ctx, bmcVersionList); err != nil {
+	if errs := validateDriftPolicy(obj, obj.Spec.DriftPolicy); len(errs) > 0 {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind}, obj.GetName(), errs)
+	}
+	list := &metalv1alpha1.BMCVersionList{}
+	if err := v.Client.List(ctx, list); err != nil {
 		return nil, fmt.Errorf("failed to list BMCVersions: %w", err)
 	}
-	return checkForDuplicateBMCVersionsRefToBMC(bmcVersionList, obj)
+	return nil, checkDuplicateBMCVersions(list, obj)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type BMCVersion.
@@ -63,12 +66,15 @@ func (v *BMCVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj, 
 			newObj.GetName(), field.ErrorList{field.Forbidden(field.NewPath("spec"), err.Error())})
 	}
 
-	bmcVersionList := &metalv1alpha1.BMCVersionList{}
-	if err := v.Client.List(ctx, bmcVersionList); err != nil {
-		return nil, fmt.Errorf("failed to list BMCVersions: %w", err)
+	if errs := validateDriftPolicy(newObj, newObj.Spec.DriftPolicy); len(errs) > 0 {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: newObj.GroupVersionKind().Group, Kind: newObj.Kind}, newObj.GetName(), errs)
 	}
 
-	return checkForDuplicateBMCVersionsRefToBMC(bmcVersionList, newObj)
+	list := &metalv1alpha1.BMCVersionList{}
+	if err := v.Client.List(ctx, list); err != nil {
+		return nil, fmt.Errorf("failed to list BMCVersions: %w", err)
+	}
+	return nil, checkDuplicateBMCVersions(list, newObj)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type BMCVersion.
@@ -88,24 +94,5 @@ func (v *BMCVersionCustomValidator) ValidateDelete(ctx context.Context, obj *met
 		return nil, apierrors.NewBadRequest("Unable to delete BMCVersion as it is in progress")
 	}
 
-	return nil, nil
-}
-
-func checkForDuplicateBMCVersionsRefToBMC(versionList *metalv1alpha1.BMCVersionList, version *metalv1alpha1.BMCVersion) (admission.Warnings, error) {
-	for _, v := range versionList.Items {
-		if version.Name == v.Name {
-			continue
-		}
-		if v.Spec.BMCRef.Name == version.Spec.BMCRef.Name {
-			err := fmt.Errorf("BMC (%s) referred in %s is duplicate of BMC (%s) referred in %s",
-				version.Spec.BMCRef.Name,
-				version.Name,
-				v.Spec.BMCRef.Name,
-				v.Name)
-			return nil, apierrors.NewInvalid(
-				schema.GroupKind{Group: version.GroupVersionKind().Group, Kind: version.Kind},
-				version.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("bmcRef"), err)})
-		}
-	}
 	return nil, nil
 }

--- a/internal/webhook/v1alpha1/bmcversion_webhook_test.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook_test.go
@@ -58,8 +58,8 @@ var _ = Describe("BMCVersion Webhook", func() {
 				},
 				Spec: metalv1alpha1.BMCVersionSpec{
 					BMCVersionTemplate: metalv1alpha1.BMCVersionTemplate{
-						Version:                 "P71 v1.45 (12/06/2017)",
-						Image:                   metalv1alpha1.ImageSpec{URI: "P71 v1.45 (12/06/2017)"},
+						Version:                 "P70 v1.45 (12/06/2017)",
+						Image:                   metalv1alpha1.ImageSpec{URI: "P70 v1.45 (12/06/2017)"},
 						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 					},
 					BMCRef: &v1.LocalObjectReference{Name: "foo"},
@@ -96,8 +96,8 @@ var _ = Describe("BMCVersion Webhook", func() {
 				},
 				Spec: metalv1alpha1.BMCVersionSpec{
 					BMCVersionTemplate: metalv1alpha1.BMCVersionTemplate{
-						Version:                 "P71 v1.45 (12/06/2017)",
-						Image:                   metalv1alpha1.ImageSpec{URI: "P71 v1.45 (12/06/2017)"},
+						Version:                 "P70 v1.45 (12/06/2017)",
+						Image:                   metalv1alpha1.ImageSpec{URI: "P70 v1.45 (12/06/2017)"},
 						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 					},
 					BMCRef: &v1.LocalObjectReference{Name: "bar"},

--- a/internal/webhook/v1alpha1/helper.go
+++ b/internal/webhook/v1alpha1/helper.go
@@ -29,21 +29,6 @@ func ShouldAllowForceDeleteInProgress(obj client.Object) bool {
 	return val == metalv1alpha1.OperationAnnotationForceUpdateOrDeleteInProgress
 }
 
-// validateDriftPolicy returns a validation error if driftPolicy is set on an object
-// that has no owner references. driftPolicy is managed exclusively by the parent CRD
-// and must not be set on standalone resources.
-func validateDriftPolicy(obj client.Object, driftPolicy metalv1alpha1.DriftPolicy) field.ErrorList {
-	if driftPolicy == "" || len(obj.GetOwnerReferences()) > 0 {
-		return nil
-	}
-	return field.ErrorList{
-		field.Forbidden(
-			field.NewPath("spec").Child("driftPolicy"),
-			"driftPolicy may only be set by the parent CRD via an owner reference; must not be set manually",
-		),
-	}
-}
-
 // checkDuplicateBMCSettings returns an error if another BMCSettings in the list targets
 // the same BMC and the same version as obj — a true conflict. Two objects for the same BMC
 // but different versions (e.g. hop stages) are permitted.

--- a/internal/webhook/v1alpha1/helper.go
+++ b/internal/webhook/v1alpha1/helper.go
@@ -5,6 +5,9 @@ package v1alpha1
 
 import (
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -24,4 +27,104 @@ func ShouldAllowForceDeleteInProgress(obj client.Object) bool {
 		return false
 	}
 	return val == metalv1alpha1.OperationAnnotationForceUpdateOrDeleteInProgress
+}
+
+// validateDriftPolicy returns a validation error if driftPolicy is set on an object
+// that has no owner references. driftPolicy is managed exclusively by the parent CRD
+// and must not be set on standalone resources.
+func validateDriftPolicy(obj client.Object, driftPolicy metalv1alpha1.DriftPolicy) field.ErrorList {
+	if driftPolicy == "" || len(obj.GetOwnerReferences()) > 0 {
+		return nil
+	}
+	return field.ErrorList{
+		field.Forbidden(
+			field.NewPath("spec").Child("driftPolicy"),
+			"driftPolicy may only be set by the parent CRD via an owner reference; must not be set manually",
+		),
+	}
+}
+
+// checkDuplicateBMCSettings returns an error if another BMCSettings in the list targets
+// the same BMC and the same version as obj — a true conflict. Two objects for the same BMC
+// but different versions (e.g. hop stages) are permitted.
+func checkDuplicateBMCSettings(list *metalv1alpha1.BMCSettingsList, obj *metalv1alpha1.BMCSettings) error {
+	for _, existing := range list.Items {
+		if existing.Name == obj.Name {
+			continue
+		}
+		if existing.Spec.BMCRef.Name == obj.Spec.BMCRef.Name && existing.Spec.Version == obj.Spec.Version {
+			return apierrors.NewInvalid(
+				schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind},
+				obj.Name,
+				field.ErrorList{field.Duplicate(
+					field.NewPath("spec").Child("BMCRef"),
+					"a BMCSettings for the same BMC and version already exists: "+existing.Name,
+				)},
+			)
+		}
+	}
+	return nil
+}
+
+// checkDuplicateBIOSSettings returns an error if another BIOSSettings in the list targets
+// the same server and the same version as obj.
+func checkDuplicateBIOSSettings(list *metalv1alpha1.BIOSSettingsList, obj *metalv1alpha1.BIOSSettings) error {
+	for _, existing := range list.Items {
+		if existing.Name == obj.Name {
+			continue
+		}
+		if existing.Spec.ServerRef.Name == obj.Spec.ServerRef.Name && existing.Spec.Version == obj.Spec.Version {
+			return apierrors.NewInvalid(
+				schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind},
+				obj.Name,
+				field.ErrorList{field.Duplicate(
+					field.NewPath("spec").Child("serverRef"),
+					"a BIOSSettings for the same server and version already exists: "+existing.Name,
+				)},
+			)
+		}
+	}
+	return nil
+}
+
+// checkDuplicateBMCVersions returns an error if another BMCVersion in the list targets
+// the same BMC and the same version as obj.
+func checkDuplicateBMCVersions(list *metalv1alpha1.BMCVersionList, obj *metalv1alpha1.BMCVersion) error {
+	for _, existing := range list.Items {
+		if existing.Name == obj.Name {
+			continue
+		}
+		if existing.Spec.BMCRef.Name == obj.Spec.BMCRef.Name && existing.Spec.Version == obj.Spec.Version {
+			return apierrors.NewInvalid(
+				schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind},
+				obj.Name,
+				field.ErrorList{field.Duplicate(
+					field.NewPath("spec").Child("bmcRef"),
+					"a BMCVersion for the same BMC and version already exists: "+existing.Name,
+				)},
+			)
+		}
+	}
+	return nil
+}
+
+// checkDuplicateBIOSVersions returns an error if another BIOSVersion in the list targets
+// the same server and the same version as obj.
+func checkDuplicateBIOSVersions(list *metalv1alpha1.BIOSVersionList, obj *metalv1alpha1.BIOSVersion) error {
+	for _, existing := range list.Items {
+		if existing.Name == obj.Name {
+			continue
+		}
+		if existing.Spec.ServerRef.Name == obj.Spec.ServerRef.Name && existing.Spec.Version == obj.Spec.Version {
+			return apierrors.NewInvalid(
+				schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.Kind},
+				obj.Name,
+				field.ErrorList{field.Duplicate(
+					field.NewPath("spec").Child("serverRef"),
+					"a BIOSVersion for the same server and version already exists: "+existing.Name,
+				)},
+			)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
# Proposed Changes

- SettingsFlow (list of named, prioritized setting groups) replacing the flat SettingsMap on BMCSettings/BIOSSettings
- BMCSettingsRefs/BIOSSettingsRefs (slice) replacing the single BMCSettingRef/BIOSSettingsRef on BMC/Server
- DriftPolicy field (Observe/Suspend) added to BMCSettings and BIOSSettings
- Controller migration logic (deprecated field → new field, fall-through behavior for ref patching)
- Webhook duplicate check now requires both ServerRef/BMCRef AND Version to match due to spec changes
- Test updates throughout

Fixes ironcore-dev/metal-maintenance-operator#175
Fixes ironcore-dev/metal-maintenance-operator#142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ordered settings flows in BMC settings, including multi-step settings groups.
  * Added support for multiple BIOS and BMC settings references on servers and BMCs.

* **Bug Fixes**
  * Tightened validation so required references and versions must be provided.
  * Improved cleanup and reconciliation so related settings are handled correctly when resources are updated or deleted.

* **Documentation**
  * Updated API docs to reflect deprecated single-reference fields and the new multi-reference and settings-flow formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->