### PR TITLE
Use --skip-metadata on ctr image pull

### DIFF
--- a/config/manager/ignition-template.yaml
+++ b/config/manager/ignition-template.yaml
@@ -36,7 +36,7 @@ systemd:
         [Service]
         Restart=on-failure
         RestartSec=20
-        ExecStartPre=/usr/bin/ctr images pull {{.Image}}
+        ExecStartPre=/usr/bin/ctr images pull --skip-metadata {{.Image}}
         ExecStartPre=-/usr/bin/ctr tasks delete --force metalprobe
         ExecStartPre=-/usr/bin/ctr containers delete metalprobe
         ExecStart=/usr/bin/ctr run --rm --net-host --privileged {{.Image}} metalprobe ./launch.sh {{.Flags}}

--- a/config/manager/ignition-template.yaml
+++ b/config/manager/ignition-template.yaml
@@ -36,6 +36,7 @@ systemd:
         [Service]
         Restart=on-failure
         RestartSec=20
+        # --skip-metadata skips fetching platform manifests not needed locally; requires containerd >= 1.4
         ExecStartPre=/usr/bin/ctr images pull --skip-metadata {{.Image}}
         ExecStartPre=-/usr/bin/ctr tasks delete --force metalprobe
         ExecStartPre=-/usr/bin/ctr containers delete metalprobe

--- a/internal/ignition/default_test.go
+++ b/internal/ignition/default_test.go
@@ -103,6 +103,14 @@ systemd:
 		})
 	})
 
+	Context("default ignition-template.yaml", func() {
+		It("should contain the ctr pull command with --skip-metadata flag", func() {
+			data, err := GenerateIgnitionDataFromFile("../../config/manager/ignition-template.yaml", testConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).To(ContainSubstring("ctr images pull --skip-metadata test-image:latest"))
+		})
+	})
+
 	Context("generateIgnitionDataFromTemplate", func() {
 		It("should render custom template correctly", func() {
 			customTemplate := `


### PR DESCRIPTION
# Proposed Changes

- Use `--skip-metadata` flag on `ctr images pull` to skip fetching manifests for unused platforms
- Fixes image pull failures on mirror registries that do not host manifests for all architectures
