### PR TITLE
Split BMC into capability interfaces and an open vendor registry

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -183,12 +183,6 @@ type EventSubscriber interface {
 	DeleteEventSubscription(ctx context.Context, uri string) error
 }
 
-// Logouter closes the BMC client connection.
-type Logouter interface {
-	// Logout closes the BMC client connection by logging out.
-	Logout()
-}
-
 // BMC is the union of every capability a Redfish BMC client may offer. It
 // exists so that constructors can return a single fully-featured value;
 // individual consumers should depend on the narrower capability interfaces
@@ -203,17 +197,20 @@ type BMC interface {
 	ManagerController
 	AccountManager
 	EventSubscriber
-	Logouter
+
+	// Logout closes the BMC client connection by logging out.
+	Logout()
 }
 
 // VendorFactory wraps a *RedfishBaseBMC in a vendor-specific implementation.
-// External packages can supply their own factories via Options.Vendors to
-// extend the BMC client with new manufacturers without modifying this package.
+// External packages can supply their own factories via Options.AdditionalVendors
+// to extend the BMC client with new manufacturers, or to override a built-in,
+// without modifying this package.
 type VendorFactory func(base *RedfishBaseBMC) BMC
 
 // DefaultVendors returns the built-in vendor factories for Dell, HPE, Lenovo
 // and Supermicro. Callers can copy and extend this map, or build their own
-// from scratch, and pass the result through Options.Vendors.
+// from scratch, and pass the extras through Options.AdditionalVendors.
 func DefaultVendors() map[Manufacturer]VendorFactory {
 	return map[Manufacturer]VendorFactory{
 		ManufacturerDell:       func(b *RedfishBaseBMC) BMC { return &DellRedfishBMC{RedfishBaseBMC: b} },

--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -32,8 +32,15 @@ const (
 	ComponentTypeBIOS ComponentType = "BIOS"
 )
 
-// BMC defines an interface for interacting with a Baseboard Management Controller.
-type BMC interface {
+// The BMC interface is intentionally split into smaller, capability-focused
+// interfaces below. Each consumer should accept the narrowest combination of
+// interfaces it actually uses, following the "accept interfaces, return
+// structs" idiom and io.Reader-style interface segregation. BMC itself is
+// retained as the union of all capabilities for callers (such as the BMC
+// factory) that need to hand out a fully-featured client.
+
+// PowerController manages the power state of a system.
+type PowerController interface {
 	// PowerOn powers on the system.
 	PowerOn(ctx context.Context, systemURI string) error
 
@@ -46,6 +53,12 @@ type BMC interface {
 	// Reset performs a reset on the system.
 	Reset(ctx context.Context, systemURI string, resetType schemas.ResetType) error
 
+	// WaitForServerPowerState waits for the server to reach the specified power state.
+	WaitForServerPowerState(ctx context.Context, systemURI string, powerState schemas.PowerState) error
+}
+
+// BootController manages boot overrides and boot order for a system.
+type BootController interface {
 	// SetBootOverride configures the system to network-boot on its next
 	// power-on, bypassing the persistent boot order. If persistent is false
 	// the override applies to a single boot only; if true it applies to every
@@ -57,26 +70,32 @@ type BMC interface {
 	// is currently set.
 	ClearBootOverride(ctx context.Context, systemURI string) error
 
+	// GetBootOrder retrieves the boot order for the system.
+	GetBootOrder(ctx context.Context, systemURI string) ([]string, error)
+
+	// SetBootOrder sets the boot order for the system.
+	SetBootOrder(ctx context.Context, systemURI string, order []string) error
+}
+
+// SystemInspector reads inventory information from the managed systems.
+type SystemInspector interface {
+	// GetSystems returns the managed systems.
+	GetSystems(ctx context.Context) ([]Server, error)
+
 	// GetSystemInfo retrieves information about the system.
 	GetSystemInfo(ctx context.Context, systemURI string) (SystemInfo, error)
 
-	// Logout closes the BMC client connection by logging out
-	Logout()
+	// GetProcessors retrieves processor information for the system.
+	GetProcessors(ctx context.Context, systemURI string) ([]Processor, error)
 
-	// GetSystems returns the managed systems
-	GetSystems(ctx context.Context) ([]Server, error)
+	// GetStorages retrieves storage information for the system.
+	GetStorages(ctx context.Context, systemURI string) ([]Storage, error)
+}
 
-	// GetManager returns the manager
-	GetManager(UUID string) (*schemas.Manager, error)
-
-	// DiscoverManager returns the first manager that exposes graphical console capabilities.
-	DiscoverManager(ctx context.Context) (*schemas.Manager, error)
-
-	// ResetManager performs a reset on the Manager.
-	ResetManager(ctx context.Context, UUID string, resetType schemas.ResetType) error
-
-	// GetBootOrder retrieves the boot order for the system.
-	GetBootOrder(ctx context.Context, systemURI string) ([]string, error)
+// BIOSManager reads and updates BIOS attributes on a system.
+type BIOSManager interface {
+	// GetBiosVersion retrieves the BIOS version for the system.
+	GetBiosVersion(ctx context.Context, systemURI string) (string, error)
 
 	// GetBiosAttributeValues retrieves BIOS attribute values for the system.
 	GetBiosAttributeValues(ctx context.Context, systemURI string, attributes []string) (schemas.SettingsAttributes, error)
@@ -84,47 +103,38 @@ type BMC interface {
 	// GetBiosPendingAttributeValues retrieves pending BIOS attribute values for the system.
 	GetBiosPendingAttributeValues(ctx context.Context, systemURI string) (schemas.SettingsAttributes, error)
 
+	// SetBiosAttributesOnReset sets BIOS attributes on the system and applies them on the next reset.
+	SetBiosAttributesOnReset(ctx context.Context, systemURI string, attributes schemas.SettingsAttributes) (err error)
+
+	// CheckBiosAttributes checks if the BIOS attributes are valid and returns whether a reset is required.
+	CheckBiosAttributes(attrs schemas.SettingsAttributes) (reset bool, err error)
+}
+
+// BMCSettingsManager reads and updates BMC attributes (manager settings).
+type BMCSettingsManager interface {
+	// GetBMCVersion retrieves the BMC version for the system.
+	GetBMCVersion(ctx context.Context, UUID string) (string, error)
+
 	// GetBMCAttributeValues retrieves BMC attribute values for the system.
 	GetBMCAttributeValues(ctx context.Context, UUID string, attributes map[string]string) (schemas.SettingsAttributes, error)
 
 	// GetBMCPendingAttributeValues retrieves pending BMC attribute values for the system.
 	GetBMCPendingAttributeValues(ctx context.Context, UUID string) (result schemas.SettingsAttributes, err error)
 
-	// CheckBiosAttributes checks if the BIOS attributes are valid and returns whether a reset is required.
-	CheckBiosAttributes(attrs schemas.SettingsAttributes) (reset bool, err error)
-
-	// CheckBMCAttributes checks if the BMC attributes are valid and returns whether a reset is required.
-	CheckBMCAttributes(ctx context.Context, UUID string, attrs schemas.SettingsAttributes) (reset bool, err error)
-
-	// SetBiosAttributesOnReset sets BIOS attributes on the system and applies them on the next reset.
-	SetBiosAttributesOnReset(ctx context.Context, systemURI string, attributes schemas.SettingsAttributes) (err error)
-
 	// SetBMCAttributesImmediately sets BMC attributes on the system and applies them immediately.
 	SetBMCAttributesImmediately(ctx context.Context, UUID string, attributes schemas.SettingsAttributes) (err error)
 
-	// GetBiosVersion retrieves the BIOS version for the system.
-	GetBiosVersion(ctx context.Context, systemURI string) (string, error)
+	// CheckBMCAttributes checks if the BMC attributes are valid and returns whether a reset is required.
+	CheckBMCAttributes(ctx context.Context, UUID string, attrs schemas.SettingsAttributes) (reset bool, err error)
+}
 
-	// GetBMCVersion retrieves the BMC version for the system.
-	GetBMCVersion(ctx context.Context, UUID string) (string, error)
-
-	// SetBootOrder sets the boot order for the system.
-	SetBootOrder(ctx context.Context, systemURI string, order []string) error
-
-	// GetStorages retrieves storage information for the system.
-	GetStorages(ctx context.Context, systemURI string) ([]Storage, error)
-
-	// GetProcessors retrieves processor information for the system.
-	GetProcessors(ctx context.Context, systemURI string) ([]Processor, error)
-
+// FirmwareUpdater drives BIOS and BMC firmware upgrades.
+type FirmwareUpdater interface {
 	// UpgradeBiosVersion upgrades the BIOS version for the system.
 	UpgradeBiosVersion(ctx context.Context, manufacturer string, parameters *schemas.UpdateServiceSimpleUpdateParameters) (string, bool, error)
 
 	// GetBiosUpgradeTask retrieves the task for the BIOS upgrade.
 	GetBiosUpgradeTask(ctx context.Context, manufacturer string, taskURI string) (*schemas.Task, error)
-
-	// WaitForServerPowerState waits for the server to reach the specified power state.
-	WaitForServerPowerState(ctx context.Context, systemURI string, powerState schemas.PowerState) error
 
 	// UpgradeBMCVersion upgrades the BMC version for the system.
 	UpgradeBMCVersion(ctx context.Context, manufacturer string, parameters *schemas.UpdateServiceSimpleUpdateParameters) (string, bool, error)
@@ -132,12 +142,25 @@ type BMC interface {
 	// GetBMCUpgradeTask retrieves the task for the BMC upgrade.
 	GetBMCUpgradeTask(ctx context.Context, manufacturer string, taskURI string) (*schemas.Task, error)
 
-	// CreateEventSubscription creates an event subscription for the manager.
-	CreateEventSubscription(ctx context.Context, destination string, eventType schemas.EventFormatType, protocol schemas.DeliveryRetryPolicy) (string, error)
+	// CheckBMCPendingComponentUpgrade checks if there are pending/staged firmware upgrades
+	// for the given component type.
+	CheckBMCPendingComponentUpgrade(ctx context.Context, componentType ComponentType) (bool, error)
+}
 
-	// DeleteEventSubscription deletes an event subscription for the manager.
-	DeleteEventSubscription(ctx context.Context, uri string) error
+// ManagerController interacts with the BMC's own Manager resource.
+type ManagerController interface {
+	// GetManager returns the manager.
+	GetManager(UUID string) (*schemas.Manager, error)
 
+	// DiscoverManager returns the first manager that exposes graphical console capabilities.
+	DiscoverManager(ctx context.Context) (*schemas.Manager, error)
+
+	// ResetManager performs a reset on the Manager.
+	ResetManager(ctx context.Context, UUID string, resetType schemas.ResetType) error
+}
+
+// AccountManager manages BMC user accounts.
+type AccountManager interface {
 	// CreateOrUpdateAccount creates or updates a BMC user account.
 	CreateOrUpdateAccount(ctx context.Context, userName, role, password string, enabled bool) error
 
@@ -149,11 +172,67 @@ type BMC interface {
 
 	// GetAccountService retrieves the account service.
 	GetAccountService() (*schemas.AccountService, error)
-
-	// CheckBMCPendingComponentUpgrade checks if there are pending/staged firmware upgrades
-	// for the given component type.
-	CheckBMCPendingComponentUpgrade(ctx context.Context, componentType ComponentType) (bool, error)
 }
+
+// EventSubscriber manages Redfish event subscriptions on the BMC.
+type EventSubscriber interface {
+	// CreateEventSubscription creates an event subscription for the manager.
+	CreateEventSubscription(ctx context.Context, destination string, eventType schemas.EventFormatType, protocol schemas.DeliveryRetryPolicy) (string, error)
+
+	// DeleteEventSubscription deletes an event subscription for the manager.
+	DeleteEventSubscription(ctx context.Context, uri string) error
+}
+
+// Logouter closes the BMC client connection.
+type Logouter interface {
+	// Logout closes the BMC client connection by logging out.
+	Logout()
+}
+
+// BMC is the union of every capability a Redfish BMC client may offer. It
+// exists so that constructors can return a single fully-featured value;
+// individual consumers should depend on the narrower capability interfaces
+// above whenever possible.
+type BMC interface {
+	PowerController
+	BootController
+	SystemInspector
+	BIOSManager
+	BMCSettingsManager
+	FirmwareUpdater
+	ManagerController
+	AccountManager
+	EventSubscriber
+	Logouter
+}
+
+// VendorFactory wraps a *RedfishBaseBMC in a vendor-specific implementation.
+// External packages can supply their own factories via Options.Vendors to
+// extend the BMC client with new manufacturers without modifying this package.
+type VendorFactory func(base *RedfishBaseBMC) BMC
+
+// DefaultVendors returns the built-in vendor factories for Dell, HPE, Lenovo
+// and Supermicro. Callers can copy and extend this map, or build their own
+// from scratch, and pass the result through Options.Vendors.
+func DefaultVendors() map[Manufacturer]VendorFactory {
+	return map[Manufacturer]VendorFactory{
+		ManufacturerDell:       func(b *RedfishBaseBMC) BMC { return &DellRedfishBMC{RedfishBaseBMC: b} },
+		ManufacturerHPE:        func(b *RedfishBaseBMC) BMC { return &HPERedfishBMC{RedfishBaseBMC: b} },
+		ManufacturerLenovo:     func(b *RedfishBaseBMC) BMC { return &LenovoRedfishBMC{RedfishBaseBMC: b} },
+		ManufacturerSupermicro: func(b *RedfishBaseBMC) BMC { return &SupermicroRedfishBMC{RedfishBaseBMC: b} },
+	}
+}
+
+// Compile-time guarantees that every built-in implementation continues to
+// satisfy the full BMC union. New vendor structs added to this package should
+// extend this list so regressions surface at build time, not on first call.
+var (
+	_ BMC = (*RedfishBaseBMC)(nil)
+	_ BMC = (*DellRedfishBMC)(nil)
+	_ BMC = (*HPERedfishBMC)(nil)
+	_ BMC = (*LenovoRedfishBMC)(nil)
+	_ BMC = (*SupermicroRedfishBMC)(nil)
+)
 
 type Entity struct {
 	// ID uniquely identifies the resource.

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -57,12 +57,13 @@ type Options struct {
 	PowerPollingInterval    time.Duration
 	PowerPollingTimeout     time.Duration
 
-	// Vendors maps a manufacturer string (as reported by Redfish) to a
-	// factory that wraps the base Redfish client in a vendor-specific
-	// implementation. When nil, NewRedfishBMCClient uses DefaultVendors().
-	// To extend the set with a private OEM, copy DefaultVendors() and add
-	// the additional entries.
-	Vendors map[Manufacturer]VendorFactory
+	// AdditionalVendors maps a manufacturer string (as reported by Redfish)
+	// to a factory that wraps the base Redfish client in a vendor-specific
+	// implementation. Entries are merged on top of DefaultVendors() by
+	// NewRedfishBMCClient, so callers only need to supply the extra OEMs
+	// they want to add. Existing built-in manufacturers can be overridden
+	// by registering the same key.
+	AdditionalVendors map[Manufacturer]VendorFactory
 }
 
 // RedfishBaseBMC is the base implementation of the BMC interface for Redfish.
@@ -121,9 +122,10 @@ func newRedfishBaseBMCClient(ctx context.Context, options Options) (*RedfishBase
 
 // NewRedfishBMCClient creates a vendor-specific BMC client by connecting to the
 // Redfish endpoint, detecting the manufacturer, and dispatching through the
-// vendor registry in options.Vendors (defaulting to DefaultVendors() when nil).
-// If no factory matches the detected manufacturer, the base Redfish
-// implementation is returned.
+// vendor registry. DefaultVendors() is used as the base and merged with any
+// entries in options.AdditionalVendors (which may override built-ins). If no
+// factory matches the detected manufacturer, the base Redfish implementation
+// is returned.
 func NewRedfishBMCClient(ctx context.Context, options Options) (BMC, error) {
 	base, err := newRedfishBaseBMCClient(ctx, options)
 	if err != nil {
@@ -138,9 +140,12 @@ func NewRedfishBMCClient(ctx context.Context, options Options) (BMC, error) {
 	}
 	base.manufacturer = manufacturer
 
-	vendors := options.Vendors
-	if vendors == nil {
-		vendors = DefaultVendors()
+	vendors := DefaultVendors()
+	for k, v := range options.AdditionalVendors {
+		if v == nil {
+			return nil, fmt.Errorf("nil vendor factory registered for manufacturer %q", k)
+		}
+		vendors[k] = v
 	}
 	if factory, ok := vendors[Manufacturer(manufacturer)]; ok {
 		if factory == nil {
@@ -148,6 +153,8 @@ func NewRedfishBMCClient(ctx context.Context, options Options) (BMC, error) {
 		}
 		return factory(base), nil
 	}
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("No vendor factory registered for manufacturer, using base Redfish implementation", "manufacturer", manufacturer)
 	return base, nil
 }
 
@@ -158,16 +165,16 @@ func (r *RedfishBaseBMC) Client() *gofish.APIClient {
 	return r.client
 }
 
-// ClientOptions Options returns the options the client was constructed with.
-func (r *RedfishBaseBMC) ClientOptions() Options {
+// Options returns the options the client was constructed with.
+func (r *RedfishBaseBMC) Options() Options {
 	return r.options
 }
 
 // Manufacturer returns the manufacturer detected during connect, or the empty
 // string when detection failed (for example because no Systems were exposed
 // during endpoint discovery).
-func (r *RedfishBaseBMC) Manufacturer() string {
-	return r.manufacturer
+func (r *RedfishBaseBMC) Manufacturer() Manufacturer {
+	return Manufacturer(r.manufacturer)
 }
 
 // Logout closes the BMC client connection by logging out

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -151,7 +151,11 @@ func NewRedfishBMCClient(ctx context.Context, options Options) (BMC, error) {
 		if factory == nil {
 			return nil, fmt.Errorf("nil vendor factory registered for manufacturer %q", manufacturer)
 		}
-		return factory(base), nil
+		client := factory(base)
+		if client == nil {
+			return nil, fmt.Errorf("vendor factory for manufacturer %q returned nil", manufacturer)
+		}
+		return client, nil
 	}
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("No vendor factory registered for manufacturer, using base Redfish implementation", "manufacturer", manufacturer)

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -27,8 +27,9 @@ import (
 )
 
 // RedfishBaseBMC implements all standard Redfish BMC methods.
-// Vendor-specific structs embed this and override methods as needed.
-var _ BMC = (*RedfishBaseBMC)(nil)
+// Vendor-specific structs embed this and override methods as needed. The
+// compile-time assertion that *RedfishBaseBMC satisfies BMC lives in bmc.go
+// alongside the per-vendor assertions.
 
 const (
 	// DefaultResourcePollingInterval is the default interval for polling resources.
@@ -55,6 +56,13 @@ type Options struct {
 	ResourcePollingTimeout  time.Duration
 	PowerPollingInterval    time.Duration
 	PowerPollingTimeout     time.Duration
+
+	// Vendors maps a manufacturer string (as reported by Redfish) to a
+	// factory that wraps the base Redfish client in a vendor-specific
+	// implementation. When nil, NewRedfishBMCClient uses DefaultVendors().
+	// To extend the set with a private OEM, copy DefaultVendors() and add
+	// the additional entries.
+	Vendors map[Manufacturer]VendorFactory
 }
 
 // RedfishBaseBMC is the base implementation of the BMC interface for Redfish.
@@ -112,9 +120,10 @@ func newRedfishBaseBMCClient(ctx context.Context, options Options) (*RedfishBase
 }
 
 // NewRedfishBMCClient creates a vendor-specific BMC client by connecting to the
-// Redfish endpoint, detecting the manufacturer, and returning the appropriate
-// vendor-specific struct. The returned BMC interface implementation will have
-// vendor-specific method overrides where needed.
+// Redfish endpoint, detecting the manufacturer, and dispatching through the
+// vendor registry in options.Vendors (defaulting to DefaultVendors() when nil).
+// If no factory matches the detected manufacturer, the base Redfish
+// implementation is returned.
 func NewRedfishBMCClient(ctx context.Context, options Options) (BMC, error) {
 	base, err := newRedfishBaseBMCClient(ctx, options)
 	if err != nil {
@@ -129,18 +138,33 @@ func NewRedfishBMCClient(ctx context.Context, options Options) (BMC, error) {
 	}
 	base.manufacturer = manufacturer
 
-	switch Manufacturer(manufacturer) {
-	case ManufacturerDell:
-		return &DellRedfishBMC{RedfishBaseBMC: base}, nil
-	case ManufacturerHPE:
-		return &HPERedfishBMC{RedfishBaseBMC: base}, nil
-	case ManufacturerLenovo:
-		return &LenovoRedfishBMC{RedfishBaseBMC: base}, nil
-	case ManufacturerSupermicro:
-		return &SupermicroRedfishBMC{RedfishBaseBMC: base}, nil
-	default:
-		return base, nil
+	vendors := options.Vendors
+	if vendors == nil {
+		vendors = DefaultVendors()
 	}
+	if factory, ok := vendors[Manufacturer(manufacturer)]; ok {
+		return factory(base), nil
+	}
+	return base, nil
+}
+
+// Client returns the underlying gofish API client. External vendor
+// implementations that embed *RedfishBaseBMC use this to perform OEM-specific
+// HTTP requests without re-establishing the connection.
+func (r *RedfishBaseBMC) Client() *gofish.APIClient {
+	return r.client
+}
+
+// ClientOptions Options returns the options the client was constructed with.
+func (r *RedfishBaseBMC) ClientOptions() Options {
+	return r.options
+}
+
+// Manufacturer returns the manufacturer detected during connect, or the empty
+// string when detection failed (for example because no Systems were exposed
+// during endpoint discovery).
+func (r *RedfishBaseBMC) Manufacturer() string {
+	return r.manufacturer
 }
 
 // Logout closes the BMC client connection by logging out

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -143,6 +143,9 @@ func NewRedfishBMCClient(ctx context.Context, options Options) (BMC, error) {
 		vendors = DefaultVendors()
 	}
 	if factory, ok := vendors[Manufacturer(manufacturer)]; ok {
+		if factory == nil {
+			return nil, fmt.Errorf("nil vendor factory registered for manufacturer %q", manufacturer)
+		}
 		return factory(base), nil
 	}
 	return base, nil

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -163,7 +163,11 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, endpoint *metalv1alp
 	}
 	log.V(1).Info("Reconciled Endpoint")
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{
+		Requeue:      false,
+		RequeueAfter: 0,
+		Priority:     nil,
+	}, nil
 }
 
 func (r *EndpointReconciler) applyBMC(ctx context.Context, bmcClient bmc.BMC, endpoint *metalv1alpha1.Endpoint, secret *metalv1alpha1.BMCSecret, m macdb.MacPrefix) error {

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -163,11 +163,7 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, endpoint *metalv1alp
 	}
 	log.V(1).Info("Reconciled Endpoint")
 
-	return ctrl.Result{
-		Requeue:      false,
-		RequeueAfter: 0,
-		Priority:     nil,
-	}, nil
+	return ctrl.Result{}, nil
 }
 
 func (r *EndpointReconciler) applyBMC(ctx context.Context, bmcClient bmc.BMC, endpoint *metalv1alpha1.Endpoint, secret *metalv1alpha1.BMCSecret, m macdb.MacPrefix) error {

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -235,7 +235,7 @@ func enqueueFromChildObjUpdatesExceptAnnotation(e event.UpdateEvent) bool {
 	return true
 }
 
-func resetBMCOfServer(ctx context.Context, kClient client.Client, server *metalv1alpha1.Server, bmcClient bmc.BMC) error {
+func resetBMCOfServer(ctx context.Context, kClient client.Client, server *metalv1alpha1.Server, bmcClient bmc.ManagerController) error {
 	log := ctrl.LoggerFrom(ctx)
 	if server.Spec.BMCRef != nil {
 		key := client.ObjectKey{Name: server.Spec.BMCRef.Name}

--- a/internal/serverevents/subscription.go
+++ b/internal/serverevents/subscription.go
@@ -12,7 +12,7 @@ import (
 )
 
 // SubscribeMetricsReport subscribes to Redfish metric reporting events for the given hostname and callback URL.
-func SubscribeMetricsReport(ctx context.Context, url, hostname string, bmcClient bmc.BMC) (string, error) {
+func SubscribeMetricsReport(ctx context.Context, url, hostname string, bmcClient bmc.EventSubscriber) (string, error) {
 	link, err := bmcClient.CreateEventSubscription(
 		ctx,
 		fmt.Sprintf("%s/serverevents/metricsreport/%s", url, hostname),
@@ -26,7 +26,7 @@ func SubscribeMetricsReport(ctx context.Context, url, hostname string, bmcClient
 }
 
 // SubscribeEvents creates a Redfish event subscription for events.
-func SubscribeEvents(ctx context.Context, url, hostname string, bmcClient bmc.BMC) (string, error) {
+func SubscribeEvents(ctx context.Context, url, hostname string, bmcClient bmc.EventSubscriber) (string, error) {
 	link, err := bmcClient.CreateEventSubscription(
 		ctx,
 		fmt.Sprintf("%s/serverevents/alerts/%s", url, hostname),


### PR DESCRIPTION
# Proposed Changes

## Motivation

The `bmc` package had two extensibility problems:

1. **Closed for new vendors.** `NewRedfishBMCClient` hard-coded a switch over Dell/HPE/Lenovo/Supermicro. Adding a vendor or overriding one for a private OEM meant forking the package.
2. **One fat interface.** Every consumer took the full `BMC` interface even when it only needed a handful of methods. Vendor implementations had to satisfy the entire surface even to override a single method.

This change applies two Go interface segregations and an explicit registry passed through `Options`.

## What changes

Split `BMC` into capability interfaces (`PowerController`, `BootController`, `SystemInspector`, `BIOSManager`, `BMCSettingsManager`, `FirmwareUpdater`, `ManagerController`, `AccountManager`, `EventSubscriber`) and keep `BMC` as their union (plus `Logout()`) for backward compatibility.

Replace the hard-coded vendor switch with `Options.AdditionalVendors`, a `map[Manufacturer]VendorFactory` that is merged on top of `DefaultVendors()` inside `NewRedfishBMCClient`. Callers only need to supply the extra OEMs they want to add; registering the same key as a built-in overrides it. Export `Client()`, `Options()` and `Manufacturer()` on `RedfishBaseBMC` so third-party vendor implementations can embed it without reaching into unexported fields.

Narrow the consumers where it conveys a real role (`serverevents` on `EventSubscriber`, `helper` on `ManagerController`); leave the rest on `bmc.BMC`.

## Extending an existing vendor or adding a new one

```go
type ACMEBMC struct{ *bmc.RedfishBaseBMC }

var _ bmc.BMC = (*ACMEBMC)(nil)

// Override an existing method (delegate + patch, or roll your own against r.Client()).
func (r *ACMEBMC) GetSystemInfo(ctx context.Context, uri string) (bmc.SystemInfo, error) {
    info, err := r.RedfishBaseBMC.GetSystemInfo(ctx, uri)
    if err != nil {
      return info, err
    }
    if info.SKU == "" {
        info.SKU = "ACME-" + info.SerialNumber[:4]
    }
    return info, nil
}

// Add a new OEM-only method which is not part of bmc.BMC.
// Publish an extension interface so callers can discover it via type assertion.
type ThermalProfileGetter interface {
    GetACMEThermalProfile(ctx context.Context) (ThermalProfile, error)
}

func (r *ACMEBMC) GetACMEThermalProfile(ctx context.Context) (ThermalProfile, error) {
    // OEM-specific Redfish call via r.Client()
}
```

Register through `Options`. The built-in Dell/HPE/Lenovo/Supermicro factories stay active automatically:

```go
opts := bmc.Options{
  Endpoint: "...", Username: "...", Password: "...",
  AdditionalVendors: map[bmc.Manufacturer]bmc.VendorFactory{
      "ACME Corp": func(b *bmc.RedfishBaseBMC) bmc.BMC {
          return &ACMEBMC{RedfishBaseBMC: b}
      },
  },
}
client, _ := bmc.NewRedfishBMCClient(ctx, opts)

if tp, ok := client.(ThermalProfileGetter); ok {
    profile, _ := tp.GetACMEThermalProfile(ctx)
}
```

Fixes #967
