### PR TITLE
Prevent `ServerMaintenance` from evicting other `ServerMaintenances` 

### DIFF
--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -362,7 +362,7 @@ func (r *ServerMaintenanceReconciler) delete(ctx context.Context, maintenance *m
 	}
 	server, err := GetServerByName(ctx, r.Client, maintenance.Spec.ServerRef.Name)
 	if err == nil {
-		if err := r.cleanup(ctx, server); err != nil {
+		if err := r.cleanup(ctx, maintenance, server); err != nil {
 			return ctrl.Result{}, err
 		}
 	} else if apierrors.IsNotFound(err) {
@@ -384,50 +384,50 @@ func (r *ServerMaintenanceReconciler) delete(ctx context.Context, maintenance *m
 	return ctrl.Result{}, nil
 }
 
-func (r *ServerMaintenanceReconciler) cleanup(ctx context.Context, server *metalv1alpha1.Server) error {
+func (r *ServerMaintenanceReconciler) cleanup(ctx context.Context, maintenance *metalv1alpha1.ServerMaintenance, server *metalv1alpha1.Server) error {
 	log := ctrl.LoggerFrom(ctx)
 	if server == nil {
 		return nil
 	}
 
-	if server.Spec.ServerMaintenanceRef != nil {
+	if ref := server.Spec.ServerMaintenanceRef; ref != nil && ref.Name == maintenance.Name && ref.Namespace == maintenance.Namespace {
 		if err := r.removeMaintenanceRefFromServer(ctx, server); err != nil {
 			return fmt.Errorf("failed to remove ServerMaintenance ref from Server: %w", err)
 		}
-	}
-	if server.Spec.MaintenanceBootConfigurationRef != nil {
-		config := &metalv1alpha1.ServerBootConfiguration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      server.Spec.MaintenanceBootConfigurationRef.Name,
-				Namespace: server.Spec.MaintenanceBootConfigurationRef.Namespace,
-			},
-		}
-		if err := r.Delete(ctx, config); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to delete ServerBootConfiguration: %w", err)
+		if server.Spec.MaintenanceBootConfigurationRef != nil {
+			config := &metalv1alpha1.ServerBootConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      server.Spec.MaintenanceBootConfigurationRef.Name,
+					Namespace: server.Spec.MaintenanceBootConfigurationRef.Namespace,
+				},
 			}
-			log.V(1).Info("ServerBootConfiguration already deleted", "Config", client.ObjectKeyFromObject(config))
+			if err := r.Delete(ctx, config); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("failed to delete ServerBootConfiguration: %w", err)
+				}
+				log.V(1).Info("ServerBootConfiguration already deleted", "Config", client.ObjectKeyFromObject(config))
+			}
+			if err := r.removeBootConfigRefFromServer(ctx, config, server); err != nil {
+				return fmt.Errorf("failed to remove ServerMaintenance boot config ref from Server: %w", err)
+			}
+			log.V(1).Info("Removed ServerMaintenance boot configuration ref from Server", "Server", server.Name)
 		}
-		if err := r.removeBootConfigRefFromServer(ctx, config, server); err != nil {
-			return fmt.Errorf("failed to remove ServerMaintenance boot config ref from Server: %w", err)
-		}
-		log.V(1).Info("Removed ServerMaintenance boot configuration ref from Server", "Server", server.Name)
-	}
 
-	if server.Spec.ServerClaimRef == nil {
-		return nil
-	}
-	serverClaim := &metalv1alpha1.ServerClaim{}
-	if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.ServerClaimRef.Name, Namespace: server.Spec.ServerClaimRef.Namespace}, serverClaim); err != nil {
-		return fmt.Errorf("failed to get ServerClaim: %w", err)
-	}
-	serverClaimBase := serverClaim.DeepCopy()
-	metautils.DeleteLabels(serverClaim, []string{
-		metalv1alpha1.ServerMaintenanceApprovedLabelKey,
-		metalv1alpha1.ServerMaintenanceNeededLabelKey,
-	})
-	if err := r.Patch(ctx, serverClaim, client.MergeFrom(serverClaimBase)); err != nil {
-		return fmt.Errorf("failed to patch ServerClaim annotations: %w", err)
+		if server.Spec.ServerClaimRef == nil {
+			return nil
+		}
+		serverClaim := &metalv1alpha1.ServerClaim{}
+		if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.ServerClaimRef.Name, Namespace: server.Spec.ServerClaimRef.Namespace}, serverClaim); err != nil {
+			return fmt.Errorf("failed to get ServerClaim: %w", err)
+		}
+		serverClaimBase := serverClaim.DeepCopy()
+		metautils.DeleteLabels(serverClaim, []string{
+			metalv1alpha1.ServerMaintenanceApprovedLabelKey,
+			metalv1alpha1.ServerMaintenanceNeededLabelKey,
+		})
+		if err := r.Patch(ctx, serverClaim, client.MergeFrom(serverClaimBase)); err != nil {
+			return fmt.Errorf("failed to patch ServerClaim annotations: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -77,6 +77,21 @@ func (r *ServerMaintenanceReconciler) reconcile(ctx context.Context, maintenance
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get Server: %w", err)
 	}
+	// This needs to be checked because "Enforced" Maintenance Policy evicts the server from the current maintenance and assigns it to itself
+	// causing some other maintenance to be InMaintenance.
+	// In this case, we should not reconcile the maintenance because it is not the one holding the maintenance on server.
+	if server.Spec.ServerMaintenanceRef != nil {
+		if server.Spec.ServerMaintenanceRef.Name != maintenance.Name || server.Spec.ServerMaintenanceRef.Namespace != maintenance.Namespace {
+			log.V(1).Info("Server is already in maintenance with other tasks", "Server", server.Name)
+			if maintenance.Status.State != metalv1alpha1.ServerMaintenanceStatePending {
+				if modified, err := r.patchMaintenanceState(ctx, maintenance, metalv1alpha1.ServerMaintenanceStatePending); err != nil || modified {
+					return ctrl.Result{}, err
+				}
+			}
+			return ctrl.Result{}, nil
+		}
+	}
+
 	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, maintenance, serverMaintenanceFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}
@@ -112,20 +127,13 @@ func (r *ServerMaintenanceReconciler) handlePendingState(ctx context.Context, ma
 		return ctrl.Result{}, err
 	}
 
-	if server.Spec.ServerMaintenanceRef != nil {
-		if server.Spec.ServerMaintenanceRef.Name != maintenance.Name || server.Spec.ServerMaintenanceRef.Namespace != maintenance.Namespace {
-			log.V(1).Info("Server is already in maintenance", "Server", server.Name)
-			return ctrl.Result{}, nil
-		}
-	} else {
-		deferMaintenance, err := r.shouldDeferToHigherPriorityMaintenance(ctx, maintenance)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		if deferMaintenance {
-			log.V(1).Info("Deferring maintenance because higher-priority maintenance is pending", "Server", server.Name, "Priority", maintenance.Spec.Priority)
-			return ctrl.Result{}, nil
-		}
+	deferMaintenance, err := r.shouldDeferToHigherPriorityMaintenance(ctx, maintenance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if deferMaintenance {
+		log.V(1).Info("Deferring maintenance because higher-priority maintenance is pending", "Server", server.Name, "Priority", maintenance.Spec.Priority)
+		return ctrl.Result{}, nil
 	}
 
 	if server.Spec.ServerClaimRef == nil {
@@ -222,6 +230,9 @@ func (r *ServerMaintenanceReconciler) shouldDeferToHigherPriorityMaintenance(ctx
 func shouldRunBefore(a, b *metalv1alpha1.ServerMaintenance) bool {
 	if a.Spec.Priority != b.Spec.Priority {
 		return a.Spec.Priority > b.Spec.Priority
+	}
+	if a.Spec.Policy != b.Spec.Policy {
+		return a.Spec.Policy == metalv1alpha1.ServerMaintenancePolicyEnforced
 	}
 	if !a.CreationTimestamp.Equal(&b.CreationTimestamp) {
 		return a.CreationTimestamp.Before(&b.CreationTimestamp)

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -574,6 +574,88 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		Eventually(Get(serverMaintenance)).ShouldNot(Succeed())
 	})
 
+	It("should not allow an Enforced maintenance to steal the ref from an already-active maintenance", func(ctx SpecContext) {
+		By("Creating first ServerMaintenance with Enforced policy")
+		serverMaintenance01 := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-enforced-maintenance-active",
+				Namespace: ns.Name,
+				Annotations: map[string]string{
+					metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "first-maintenance",
+				},
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				ServerRef:   &corev1.LocalObjectReference{Name: server.Name},
+				Policy:      metalv1alpha1.ServerMaintenancePolicyEnforced,
+				ServerPower: metalv1alpha1.PowerOff,
+			},
+		}
+		Expect(k8sClient.Create(ctx, serverMaintenance01)).To(Succeed())
+
+		By("Waiting for the first ServerMaintenance to reach InMaintenance state")
+		Eventually(Object(serverMaintenance01)).Should(
+			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance),
+		)
+		Consistently(Object(serverMaintenance01)).Should(
+			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance),
+		)
+
+		By("Verifying the Server's ServerMaintenanceRef points to the first maintenance")
+		Eventually(Object(server)).Should(
+			HaveField("Spec.ServerMaintenanceRef.Name", serverMaintenance01.Name),
+		)
+		Consistently(Object(server)).Should(
+			HaveField("Spec.ServerMaintenanceRef.Name", serverMaintenance01.Name),
+		)
+
+		By("Creating second Enforced ServerMaintenance for the same server")
+		serverMaintenance02 := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-enforced-maintenance-challenger",
+				Namespace: ns.Name,
+				Annotations: map[string]string{
+					metalv1alpha1.ServerMaintenanceReasonAnnotationKey: "second-maintenance",
+				},
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				ServerRef:   &corev1.LocalObjectReference{Name: server.Name},
+				Policy:      metalv1alpha1.ServerMaintenancePolicyEnforced,
+				ServerPower: metalv1alpha1.PowerOff,
+			},
+		}
+		Expect(k8sClient.Create(ctx, serverMaintenance02)).To(Succeed())
+
+		By("Ensuring the second Enforced maintenance stays Pending and does not steal the ref")
+		Eventually(Object(serverMaintenance02)).Should(
+			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStatePending),
+		)
+		Consistently(Object(serverMaintenance02)).Should(
+			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStatePending),
+		)
+
+		By("Verifying the first maintenance remains InMaintenance (not evicted to Pending)")
+		Consistently(Object(serverMaintenance01)).Should(
+			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance),
+		)
+
+		By("Verifying the Server's ServerMaintenanceRef is still held by the first maintenance")
+		Consistently(Object(server)).Should(
+			HaveField("Spec.ServerMaintenanceRef.Name", serverMaintenance01.Name),
+		)
+
+		By("Deleting the first ServerMaintenance to release the server")
+		Expect(k8sClient.Delete(ctx, serverMaintenance01)).To(Succeed())
+		Eventually(Get(serverMaintenance01)).ShouldNot(Succeed())
+
+		By("Verifying the second maintenance can now proceed to InMaintenance")
+		Eventually(Object(serverMaintenance02)).Should(
+			HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance),
+		)
+
+		By("Deleting the second ServerMaintenance")
+		Expect(k8sClient.Delete(ctx, serverMaintenance02)).To(Succeed())
+	})
+
 	It("should skip cleanup and remove finalizer when no finalizer is present on deletion", func(ctx SpecContext) {
 		By("Creating a ServerMaintenance object without going through reconciliation (no finalizer)")
 		serverMaintenance := &metalv1alpha1.ServerMaintenance{


### PR DESCRIPTION
Fixes #969

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved maintenance handling when a server is already linked to another active maintenance, preventing it from being incorrectly reassigned.
  * Pending maintenance now defers more reliably when a higher-priority maintenance is already in progress.
  * When priorities are tied, enforced maintenance now takes precedence over other policies.
  * Deletion cleanup now preserves the server’s maintenance reference unless it matches the maintenance being removed, reducing unintended state changes.
  * Added coverage for overlapping enforced maintenance scenarios to confirm correct pending and takeover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->