### PR TITLE
Updating webhooks for maintenance plan

### DIFF
--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -1023,6 +1023,9 @@ func (r *BIOSSettingsReconciler) handleAppliedState(ctx context.Context, bmcClie
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get BIOS version and settings diff: %w", err)
 	}
+	if settings.Status.State == metalv1alpha1.BIOSSettingsStateApplied && len(settingsDiff) == 0 {
+		return ctrl.Result{}, nil
+	}
 	if len(settingsDiff) > 0 {
 		log.V(1).Info("Found BIOS setting difference after applied state", "SettingsDiff", settingsDiff)
 		return ctrl.Result{}, r.updateStatus(ctx, settings, metalv1alpha1.BIOSSettingsStatePending, nil)
@@ -1490,9 +1493,7 @@ func (r *BIOSSettingsReconciler) enqueueBiosSettingsByServerRefs(ctx context.Con
 		if settings.Spec.ServerMaintenanceRef == nil ||
 			(server.Spec.ServerMaintenanceRef != nil &&
 				(server.Spec.ServerMaintenanceRef.Name != settings.Spec.ServerMaintenanceRef.Name ||
-					server.Spec.ServerMaintenanceRef.Namespace != settings.Spec.ServerMaintenanceRef.Namespace)) ||
-			settings.Status.State == metalv1alpha1.BIOSSettingsStateApplied ||
-			settings.Status.State == metalv1alpha1.BIOSSettingsStateFailed {
+					server.Spec.ServerMaintenanceRef.Namespace != settings.Spec.ServerMaintenanceRef.Namespace)) {
 			continue
 		}
 		reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: settings.Name}})

--- a/internal/controller/biosversion_controller.go
+++ b/internal/controller/biosversion_controller.go
@@ -614,7 +614,11 @@ func (r *BIOSVersionReconciler) cleanup(ctx context.Context, bmcClient bmc.BMC, 
 	if err != nil {
 		return err
 	}
-
+	if biosVersion.Status.State == metalv1alpha1.BIOSVersionStateCompleted &&
+		currentBiosVersion == biosVersion.Spec.Version &&
+		biosVersion.Spec.ServerMaintenanceRef == nil {
+		return nil
+	}
 	if currentBiosVersion == biosVersion.Spec.Version {
 		if err := r.cleanupServerMaintenanceReferences(ctx, biosVersion); err != nil {
 			return err
@@ -988,9 +992,7 @@ func (r *BIOSVersionReconciler) enqueueBiosVersionByServerRefs(ctx context.Conte
 			continue
 		}
 		// states where we do not need to requeue for host changes
-		if biosVersion.Spec.ServerMaintenanceRef == nil ||
-			biosVersion.Status.State == metalv1alpha1.BIOSVersionStateCompleted ||
-			biosVersion.Status.State == metalv1alpha1.BIOSVersionStateFailed {
+		if biosVersion.Spec.ServerMaintenanceRef == nil {
 			return nil
 		}
 		if biosVersion.Spec.ServerMaintenanceRef.Name != host.Spec.ServerMaintenanceRef.Name {

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -221,6 +221,10 @@ func (r *BMCSettingsReconciler) reconcile(ctx context.Context, settings *metalv1
 
 	bmcObj, err := r.getBMC(ctx, settings)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("Referred BMC object not found, skipping")
+			return ctrl.Result{}, nil
+		}
 		log.V(1).Info("Failed to fetch referred BMC object")
 		return ctrl.Result{}, err
 	}
@@ -580,6 +584,9 @@ func (r *BMCSettingsReconciler) handleSettingAppliedState(ctx context.Context, s
 	settingsDiff, err := r.getBMCSettingsDifference(ctx, settings, bmcObj, bmcClient)
 	if err != nil {
 		return fmt.Errorf("failed to fetch and check BMCSettings: %w", err)
+	}
+	if settings.Status.State == metalv1alpha1.BMCSettingsStateApplied && len(settingsDiff) == 0 {
+		return nil
 	}
 	if len(settingsDiff) > 0 {
 		// Drift detected — reset all conditions and state so the next reconcile
@@ -1268,9 +1275,6 @@ func (r *BMCSettingsReconciler) enqueueBMCSettingsByBMCRefs(ctx context.Context,
 	var requests []ctrl.Request
 	for _, settings := range settingsList.Items {
 		if settings.Spec.BMCRef != nil && settings.Spec.BMCRef.Name == bmcObj.Name {
-			if settings.Status.State == metalv1alpha1.BMCSettingsStateApplied || settings.Status.State == metalv1alpha1.BMCSettingsStateFailed {
-				continue
-			}
 			requests = append(requests, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: settings.Namespace, Name: settings.Name}})
 		}
 	}

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -179,6 +179,10 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 	log := ctrl.LoggerFrom(ctx)
 	bmcObj, err := r.getBMCFromBMCVersion(ctx, bmcVersion)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("Referred BMC object not found, skipping", "BMCVersion", bmcVersion.Name)
+			return ctrl.Result{}, nil
+		}
 		log.V(1).Info("Referred BMC object could not be fetched", "BMCVersion", bmcVersion.Name)
 		return ctrl.Result{}, err
 	}
@@ -263,7 +267,7 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 		}
 
 		if ok, err := r.resetBMC(ctx, bmcVersion, bmcObj, ConditionResetIssued); !ok || err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reset bmc %s: %w", client.ObjectKeyFromObject(bmcObj), err)
+			return ctrl.Result{}, err
 		}
 
 		return r.handleUpgradeInProgressState(ctx, bmcVersion, bmcClient, bmcObj)
@@ -560,6 +564,11 @@ func (r *BMCVersionReconciler) removeServerMaintenanceRefAndResetConditions(
 	currentBMCVersion, err := r.getBMCVersionFromBMC(ctx, bmcClient, BMC)
 	if err != nil {
 		return err
+	}
+	if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateCompleted &&
+		currentBMCVersion == bmcVersion.Spec.Version &&
+		len(bmcVersion.Spec.ServerMaintenanceRefs) == 0 {
+		return nil
 	}
 	state := metalv1alpha1.BMCVersionStateInProgress
 	if currentBMCVersion == bmcVersion.Spec.Version {
@@ -1223,8 +1232,13 @@ func (r *BMCVersionReconciler) enqueueBMCVersionByBMCRefs(ctx context.Context, o
 
 	for _, bmcVersion := range bmcVersionList.Items {
 		if bmcVersion.Spec.BMCRef != nil && bmcVersion.Spec.BMCRef.Name == bmcObj.Name {
+			// For Completed/Failed BMCVersions, only re-enqueue if the BMC firmware version
+			// has actually changed away from spec.version — indicating genuine hardware drift.
+			// Routine BMC status updates (polling, maintenance activity) must not retrigger them.
 			if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateCompleted || bmcVersion.Status.State == metalv1alpha1.BMCVersionStateFailed {
-				return nil
+				if bmcObj.Status.FirmwareVersion == bmcVersion.Spec.Version {
+					continue
+				}
 			}
 			return []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: bmcVersion.Namespace, Name: bmcVersion.Name}}}
 		}

--- a/internal/controller/bmcversion_controller_test.go
+++ b/internal/controller/bmcversion_controller_test.go
@@ -636,6 +636,55 @@ var _ = Describe("BMCVersion Controller", func() {
 		// cleanup
 		Expect(k8sClient.Delete(ctx, bmcVersion)).To(Succeed())
 	})
+	It("should re-upgrade BMC when firmware is rolled back after completion", func(ctx SpecContext) {
+		By("Updating the server state to Available with power off for maintenance")
+		Eventually(UpdateStatus(server, func() {
+			server.Status.State = metalv1alpha1.ServerStateAvailable
+			server.Status.PowerState = metalv1alpha1.ServerOffPowerState
+		})).Should(Succeed())
+
+		By("Creating a BMCVersion targeting the upgraded version")
+		bmcVersion := &metalv1alpha1.BMCVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+			Spec: metalv1alpha1.BMCVersionSpec{
+				BMCRef: &v1.LocalObjectReference{Name: bmcObj.Name},
+				BMCVersionTemplate: metalv1alpha1.BMCVersionTemplate{
+					Version:                 upgradeServerBMCVersion,
+					Image:                   metalv1alpha1.ImageSpec{URI: upgradeServerBMCVersion},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcVersion)).To(Succeed())
+
+		By("Waiting for BMCVersion to reach Completed state")
+		Eventually(Object(bmcVersion), "60s").Should(
+			HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
+		)
+
+		By("Simulating a firmware rollback on the mock BMC")
+		mockServers[0].ResetUpgradeTask("/redfish/v1/Managers/BMC")
+
+		By("Triggering a BMC watch event to prompt re-reconciliation")
+		Eventually(Update(bmcObj, func() {
+			metautils.SetAnnotation(bmcObj, "trigger-reconcile", "rollback-test")
+		})).Should(Succeed())
+
+		By("Ensuring BMCVersion transitions back to InProgress after detecting the rollback")
+		Eventually(Object(bmcVersion), "30s").Should(
+			HaveField("Status.State", metalv1alpha1.BMCVersionStateInProgress),
+		)
+
+		By("Ensuring BMCVersion reaches Completed again after re-upgrade")
+		Eventually(Object(bmcVersion), "60s").Should(
+			HaveField("Status.State", metalv1alpha1.BMCVersionStateCompleted),
+		)
+
+		Expect(k8sClient.Delete(ctx, bmcVersion)).To(Succeed())
+	})
+
 })
 
 func ensureBMCVersionConditionTransition(acc *conditionutils.Accessor, bmcVersion *metalv1alpha1.BMCVersion) {

--- a/internal/webhook/v1alpha1/biossettings_webhook.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook.go
@@ -69,6 +69,13 @@ func (v *BIOSSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj
 		}
 	}
 
+	// If neither the serverRef nor the version changed, no new duplicate can be introduced.
+	if oldObj.Spec.ServerRef != nil && newObj.Spec.ServerRef != nil &&
+		oldObj.Spec.ServerRef.Name == newObj.Spec.ServerRef.Name &&
+		oldObj.Spec.Version == newObj.Spec.Version {
+		return nil, nil
+	}
+
 	settingsList := &metalv1alpha1.BIOSSettingsList{}
 	if err := v.List(ctx, settingsList); err != nil {
 		return nil, fmt.Errorf("failed to list BIOSSettings: %w", err)
@@ -100,16 +107,23 @@ func checkForDuplicateBIOSSettingsRefToServer(settingsList *metalv1alpha1.BIOSSe
 		if settings.Name == bs.Name {
 			continue
 		}
-		if settings.Spec.ServerRef.Name == bs.Spec.ServerRef.Name {
-			err := fmt.Errorf("server (%s) referred in %s is duplicate of server (%s) referred in %s",
-				settings.Spec.ServerRef.Name,
-				settings.Name,
-				bs.Spec.ServerRef.Name,
-				bs.Name)
-			return nil, apierrors.NewInvalid(
-				schema.GroupKind{Group: settings.GroupVersionKind().Group, Kind: settings.Kind},
-				settings.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("serverRef"), err)})
+		if settings.Spec.ServerRef == nil || bs.Spec.ServerRef == nil {
+			continue
 		}
+		if settings.Spec.ServerRef.Name != bs.Spec.ServerRef.Name {
+			continue
+		}
+		if bs.Spec.Version != settings.Spec.Version {
+			continue
+		}
+		err := fmt.Errorf("server (%s) referred in %s is duplicate of server (%s) referred in %s",
+			settings.Spec.ServerRef.Name,
+			settings.Name,
+			bs.Spec.ServerRef.Name,
+			bs.Name)
+		return nil, apierrors.NewInvalid(
+			schema.GroupKind{Group: settings.GroupVersionKind().Group, Kind: settings.Kind},
+			settings.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("serverRef"), err)})
 	}
 	return nil, nil
 }

--- a/internal/webhook/v1alpha1/biossettings_webhook_test.go
+++ b/internal/webhook/v1alpha1/biossettings_webhook_test.go
@@ -98,7 +98,7 @@ var _ = Describe("BIOSSettings Webhook", func() {
 		Expect(k8sClient.Create(ctx, biosSettingsV2)).To(Succeed())
 	})
 
-	It("should deny update if spec.serverRef is duplicate", func() {
+	It("should deny update if spec.serverRef and version are both duplicate", func() {
 		By("Creating a BIOSSettings with different ServerRef")
 		biosSettingsV2 := &metalv1alpha1.BIOSSettings{
 			ObjectMeta: metav1.ObjectMeta{
@@ -119,10 +119,65 @@ var _ = Describe("BIOSSettings Webhook", func() {
 		}
 		Expect(k8sClient.Create(ctx, biosSettingsV2)).To(Succeed())
 
-		By("Updating an biosSettingsV2 with a conflicting ServerRef")
+		By("Updating biosSettingsV2 with both a conflicting ServerRef and matching version")
 		biosSettingsV2Updated := biosSettingsV2.DeepCopy()
 		biosSettingsV2Updated.Spec.ServerRef = &v1.LocalObjectReference{Name: "foo"}
+		biosSettingsV2Updated.Spec.Version = defaultMockUpServerBiosVersion
 		Expect(validator.ValidateUpdate(ctx, biosSettingsV2, biosSettingsV2Updated)).Error().To(HaveOccurred())
+	})
+
+	It("should allow update if spec.serverRef changes to an existing one but version differs", func() {
+		By("Creating a BIOSSettings with different ServerRef")
+		biosSettingsV2 := &metalv1alpha1.BIOSSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+			Spec: metalv1alpha1.BIOSSettingsSpec{
+				ServerRef: &v1.LocalObjectReference{Name: "bar"},
+				BIOSSettingsTemplate: metalv1alpha1.BIOSSettingsTemplate{
+					Version: anotherMockUpServerBiosVersion,
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{
+						Settings: map[string]string{},
+						Priority: 1,
+						Name:     "one",
+					}},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, biosSettingsV2)).To(Succeed())
+
+		By("Updating biosSettingsV2 with a serverRef matching V1 but a different version")
+		biosSettingsV2Updated := biosSettingsV2.DeepCopy()
+		biosSettingsV2Updated.Spec.ServerRef = &v1.LocalObjectReference{Name: "foo"}
+		Expect(validator.ValidateUpdate(ctx, biosSettingsV2, biosSettingsV2Updated)).Error().ToNot(HaveOccurred())
+	})
+
+	It("should allow update when spec.serverRef is unchanged even if version now matches another record", func() {
+		By("Creating a BIOSSettings with different ServerRef")
+		biosSettingsV2 := &metalv1alpha1.BIOSSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+			Spec: metalv1alpha1.BIOSSettingsSpec{
+				ServerRef: &v1.LocalObjectReference{Name: "bar"},
+				BIOSSettingsTemplate: metalv1alpha1.BIOSSettingsTemplate{
+					Version: anotherMockUpServerBiosVersion,
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{
+						Settings: map[string]string{},
+						Priority: 1,
+						Name:     "one",
+					}},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, biosSettingsV2)).To(Succeed())
+
+		By("Updating biosSettingsV2 version to match V1 without changing serverRef")
+		biosSettingsV2Updated := biosSettingsV2.DeepCopy()
+		biosSettingsV2Updated.Spec.Version = defaultMockUpServerBiosVersion
+		Expect(validator.ValidateUpdate(ctx, biosSettingsV2, biosSettingsV2Updated)).Error().ToNot(HaveOccurred())
 	})
 
 	It("should allow update if a different field is duplicate", func() {

--- a/internal/webhook/v1alpha1/biosversion_webhook.go
+++ b/internal/webhook/v1alpha1/biosversion_webhook.go
@@ -69,6 +69,13 @@ func (v *BIOSVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 		}
 	}
 
+	// If neither the serverRef nor the version changed, no new duplicate can be introduced.
+	if oldObj.Spec.ServerRef != nil && newObj.Spec.ServerRef != nil &&
+		oldObj.Spec.ServerRef.Name == newObj.Spec.ServerRef.Name &&
+		oldObj.Spec.Version == newObj.Spec.Version {
+		return nil, nil
+	}
+
 	versions := &metalv1alpha1.BIOSVersionList{}
 	if err := v.List(ctx, versions); err != nil {
 		return nil, fmt.Errorf("failed to list BIOSVersion: %w", err)
@@ -106,17 +113,21 @@ func checkForDuplicateBIOSVersionRefToServer(versions *metalv1alpha1.BIOSVersion
 		if bv.Spec.ServerRef == nil {
 			continue
 		}
-		if version.Spec.ServerRef.Name == bv.Spec.ServerRef.Name {
-			err := fmt.Errorf("server (%s) referred in %s is duplicate of server (%s) referred in %s",
-				version.Spec.ServerRef.Name,
-				version.Name,
-				bv.Spec.ServerRef.Name,
-				bv.Name,
-			)
-			return nil, apierrors.NewInvalid(
-				schema.GroupKind{Group: version.GroupVersionKind().Group, Kind: version.Kind},
-				version.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("serverRef").Child("name"), err)})
+		if version.Spec.ServerRef.Name != bv.Spec.ServerRef.Name {
+			continue
 		}
+		if bv.Spec.Version != version.Spec.Version {
+			continue
+		}
+		err := fmt.Errorf("server (%s) referred in %s is duplicate of server (%s) referred in %s",
+			version.Spec.ServerRef.Name,
+			version.Name,
+			bv.Spec.ServerRef.Name,
+			bv.Name,
+		)
+		return nil, apierrors.NewInvalid(
+			schema.GroupKind{Group: version.GroupVersionKind().Group, Kind: version.Kind},
+			version.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("serverRef").Child("name"), err)})
 	}
 	return nil, nil
 }

--- a/internal/webhook/v1alpha1/biosversion_webhook_test.go
+++ b/internal/webhook/v1alpha1/biosversion_webhook_test.go
@@ -125,6 +125,52 @@ var _ = Describe("BIOSVersion Webhook", func() {
 		Expect(validator.ValidateUpdate(ctx, biosVersionV2, biosVersionV2Updated)).Error().ToNot(HaveOccurred())
 	})
 
+	It("should allow update if spec.serverRef changes to an existing one but version differs", func() {
+		By("Creating a BIOSVersion with different ServerRef and version")
+		biosVersionV2 := &metalv1alpha1.BIOSVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+			Spec: metalv1alpha1.BIOSVersionSpec{
+				BIOSVersionTemplate: metalv1alpha1.BIOSVersionTemplate{
+					Version:                 "P79 v1.45 (12/06/2017)",
+					Image:                   metalv1alpha1.ImageSpec{URI: "two"},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+				ServerRef: &v1.LocalObjectReference{Name: "bar"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, biosVersionV2)).To(Succeed())
+
+		By("Updating BIOSVersion V2 serverRef to match V1 while keeping a different version")
+		biosVersionV2Updated := biosVersionV2.DeepCopy()
+		biosVersionV2Updated.Spec.ServerRef = &v1.LocalObjectReference{Name: "foo"}
+		Expect(validator.ValidateUpdate(ctx, biosVersionV2, biosVersionV2Updated)).Error().ToNot(HaveOccurred())
+	})
+
+	It("should allow update when spec.serverRef is unchanged even if version now matches another record", func() {
+		By("Creating a BIOSVersion with different ServerRef")
+		biosVersionV2 := &metalv1alpha1.BIOSVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+			Spec: metalv1alpha1.BIOSVersionSpec{
+				BIOSVersionTemplate: metalv1alpha1.BIOSVersionTemplate{
+					Version:                 "P79 v1.45 (12/06/2017)",
+					Image:                   metalv1alpha1.ImageSpec{URI: "two"},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+				ServerRef: &v1.LocalObjectReference{Name: "bar"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, biosVersionV2)).To(Succeed())
+
+		By("Updating BIOSVersion V2 version to match V1 without changing serverRef")
+		biosVersionV2Updated := biosVersionV2.DeepCopy()
+		biosVersionV2Updated.Spec.Version = biosVersionV1.Spec.Version
+		Expect(validator.ValidateUpdate(ctx, biosVersionV2, biosVersionV2Updated)).Error().ToNot(HaveOccurred())
+	})
+
 	It("should allow update if a ServerRef field is not a duplicate", func() {
 		By("Creating a BIOSVersion with different ServerRef")
 		biosVersionV2 := &metalv1alpha1.BIOSVersion{

--- a/internal/webhook/v1alpha1/bmcsettings_webhook.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook.go
@@ -77,6 +77,13 @@ func (v *BMCSettingsCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 		}
 	}
 
+	// If neither the bmcRef nor the version changed, no new duplicate can be introduced.
+	if oldObj.Spec.BMCRef != nil && newObj.Spec.BMCRef != nil &&
+		oldObj.Spec.BMCRef.Name == newObj.Spec.BMCRef.Name &&
+		oldObj.Spec.Version == newObj.Spec.Version {
+		return nil, nil
+	}
+
 	bmcSettingsList := &metalv1alpha1.BMCSettingsList{}
 	if err := v.Client.List(ctx, bmcSettingsList); err != nil {
 		return nil, fmt.Errorf("failed to list BMCSettings: %w", err)
@@ -113,16 +120,20 @@ func checkForDuplicateBMCSettingsRefToBMC(settingsList *metalv1alpha1.BMCSetting
 		if settings.Name == bs.Name {
 			continue
 		}
-		if bs.Spec.BMCRef.Name == settings.Spec.BMCRef.Name {
-			err := fmt.Errorf("BMC (%s) referred in %s is duplicate of BMC (%s) referred in %s",
-				settings.Spec.BMCRef.Name,
-				settings.Name,
-				bs.Spec.BMCRef.Name,
-				bs.Name)
-			return nil, apierrors.NewInvalid(
-				schema.GroupKind{Group: settings.GroupVersionKind().Group, Kind: settings.Kind},
-				settings.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("bmcRef"), err)})
+		if bs.Spec.BMCRef.Name != settings.Spec.BMCRef.Name {
+			continue
 		}
+		if bs.Spec.Version != settings.Spec.Version {
+			continue
+		}
+		err := fmt.Errorf("BMC (%s) referred in %s is duplicate of BMC (%s) referred in %s",
+			settings.Spec.BMCRef.Name,
+			settings.Name,
+			bs.Spec.BMCRef.Name,
+			bs.Name)
+		return nil, apierrors.NewInvalid(
+			schema.GroupKind{Group: settings.GroupVersionKind().Group, Kind: settings.Kind},
+			settings.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("bmcRef"), err)})
 	}
 	return nil, nil
 }

--- a/internal/webhook/v1alpha1/bmcsettings_webhook_test.go
+++ b/internal/webhook/v1alpha1/bmcsettings_webhook_test.go
@@ -60,7 +60,7 @@ var _ = Describe("BMCSettings Webhook", func() {
 				Spec: metalv1alpha1.BMCSettingsSpec{
 					BMCRef: &v1.LocalObjectReference{Name: "foo"},
 					BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
-						Version:                 "1.45.455b66-rev4",
+						Version:                 "P70 v1.45 (12/06/2017)",
 						SettingsMap:             map[string]string{},
 						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 					}},
@@ -126,6 +126,73 @@ var _ = Describe("BMCSettings Webhook", func() {
 			By("Updating an BMCSettingsV2 to refer to new BMC")
 			BMCSettingsV2Updated := BMCSettingsV2.DeepCopy()
 			BMCSettingsV2Updated.Spec.BMCRef = &v1.LocalObjectReference{Name: "new-bmc2"}
+			Expect(validator.ValidateUpdate(ctx, BMCSettingsV2, BMCSettingsV2Updated)).Error().NotTo(HaveOccurred())
+		})
+
+		It("should deny update if both bmcRef and version match an existing record", func() {
+			By("Creating another BMCSetting with different BMCRef")
+			BMCSettingsV2 := &metalv1alpha1.BMCSettings{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+				Spec: metalv1alpha1.BMCSettingsSpec{
+					BMCRef: &v1.LocalObjectReference{Name: "bar"},
+					BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
+						Version:                 "other-version",
+						SettingsMap:             map[string]string{},
+						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+					}},
+			}
+			Expect(k8sClient.Create(ctx, BMCSettingsV2)).To(Succeed())
+
+			By("Updating BMCSettingsV2 to match both bmcRef and version of V1")
+			BMCSettingsV2Updated := BMCSettingsV2.DeepCopy()
+			BMCSettingsV2Updated.Spec.BMCRef = BMCSettingsV1.Spec.BMCRef
+			BMCSettingsV2Updated.Spec.Version = BMCSettingsV1.Spec.Version
+			Expect(validator.ValidateUpdate(ctx, BMCSettingsV2, BMCSettingsV2Updated)).Error().To(HaveOccurred())
+		})
+
+		It("should allow update if bmcRef changes to an existing one but version differs", func() {
+			By("Creating another BMCSetting with different BMCRef and version")
+			BMCSettingsV2 := &metalv1alpha1.BMCSettings{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+				Spec: metalv1alpha1.BMCSettingsSpec{
+					BMCRef: &v1.LocalObjectReference{Name: "bar"},
+					BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
+						Version:                 "other-version",
+						SettingsMap:             map[string]string{},
+						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+					}},
+			}
+			Expect(k8sClient.Create(ctx, BMCSettingsV2)).To(Succeed())
+
+			By("Updating BMCSettingsV2 bmcRef to match V1 while keeping a different version")
+			BMCSettingsV2Updated := BMCSettingsV2.DeepCopy()
+			BMCSettingsV2Updated.Spec.BMCRef = BMCSettingsV1.Spec.BMCRef
+			Expect(validator.ValidateUpdate(ctx, BMCSettingsV2, BMCSettingsV2Updated)).Error().NotTo(HaveOccurred())
+		})
+
+		It("should allow update when bmcRef is unchanged even if version now matches another record", func() {
+			By("Creating another BMCSetting with different BMCRef")
+			BMCSettingsV2 := &metalv1alpha1.BMCSettings{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+				Spec: metalv1alpha1.BMCSettingsSpec{
+					BMCRef: &v1.LocalObjectReference{Name: "bar"},
+					BMCSettingsTemplate: metalv1alpha1.BMCSettingsTemplate{
+						Version:                 "other-version",
+						SettingsMap:             map[string]string{},
+						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+					}},
+			}
+			Expect(k8sClient.Create(ctx, BMCSettingsV2)).To(Succeed())
+
+			By("Updating BMCSettingsV2 version to match V1 without changing bmcRef")
+			BMCSettingsV2Updated := BMCSettingsV2.DeepCopy()
+			BMCSettingsV2Updated.Spec.Version = BMCSettingsV1.Spec.Version
 			Expect(validator.ValidateUpdate(ctx, BMCSettingsV2, BMCSettingsV2Updated)).Error().NotTo(HaveOccurred())
 		})
 

--- a/internal/webhook/v1alpha1/bmcversion_webhook.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook.go
@@ -68,6 +68,13 @@ func (v *BMCVersionCustomValidator) ValidateUpdate(ctx context.Context, oldObj, 
 		}
 	}
 
+	// If neither the bmcRef nor the version changed, no new duplicate can be introduced.
+	if oldObj.Spec.BMCRef != nil && newObj.Spec.BMCRef != nil &&
+		oldObj.Spec.BMCRef.Name == newObj.Spec.BMCRef.Name &&
+		oldObj.Spec.Version == newObj.Spec.Version {
+		return nil, nil
+	}
+
 	bmcVersionList := &metalv1alpha1.BMCVersionList{}
 	if err := v.Client.List(ctx, bmcVersionList); err != nil {
 		return nil, fmt.Errorf("failed to list BMCVersions: %w", err)
@@ -95,20 +102,30 @@ func (v *BMCVersionCustomValidator) ValidateDelete(ctx context.Context, obj *met
 }
 
 func checkForDuplicateBMCVersionsRefToBMC(versionList *metalv1alpha1.BMCVersionList, version *metalv1alpha1.BMCVersion) (admission.Warnings, error) {
+	if version.Spec.BMCRef == nil {
+		return nil, nil
+	}
 	for _, v := range versionList.Items {
 		if version.Name == v.Name {
 			continue
 		}
-		if v.Spec.BMCRef.Name == version.Spec.BMCRef.Name {
-			err := fmt.Errorf("BMC (%s) referred in %s is duplicate of BMC (%s) referred in %s",
-				version.Spec.BMCRef.Name,
-				version.Name,
-				v.Spec.BMCRef.Name,
-				v.Name)
-			return nil, apierrors.NewInvalid(
-				schema.GroupKind{Group: version.GroupVersionKind().Group, Kind: version.Kind},
-				version.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("bmcRef"), err)})
+		if v.Spec.BMCRef == nil {
+			continue
 		}
+		if v.Spec.BMCRef.Name != version.Spec.BMCRef.Name {
+			continue
+		}
+		if v.Spec.Version != version.Spec.Version {
+			continue
+		}
+		err := fmt.Errorf("BMC (%s) referred in %s is duplicate of BMC (%s) referred in %s",
+			version.Spec.BMCRef.Name,
+			version.Name,
+			v.Spec.BMCRef.Name,
+			v.Name)
+		return nil, apierrors.NewInvalid(
+			schema.GroupKind{Group: version.GroupVersionKind().Group, Kind: version.Kind},
+			version.GetName(), field.ErrorList{field.Duplicate(field.NewPath("spec").Child("bmcRef"), err)})
 	}
 	return nil, nil
 }

--- a/internal/webhook/v1alpha1/bmcversion_webhook_test.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook_test.go
@@ -52,14 +52,14 @@ var _ = Describe("BMCVersion Webhook", func() {
 
 	Context("When creating or updating BMCVersion under Validating Webhook", func() {
 		It("should deny creation if a BMC referred is already referred by another", func(ctx SpecContext) {
-			By("Creating another BMCVersion with reference to existing referred BMC")
+			By("Creating another BMCVersion with reference to existing referred BMC and same version")
 			BMCVersionV2 := &metalv1alpha1.BMCVersion{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-bmc-ver",
 				},
 				Spec: metalv1alpha1.BMCVersionSpec{
 					BMCVersionTemplate: metalv1alpha1.BMCVersionTemplate{
-						Version:                 "P71 v1.45 (12/06/2017)",
+						Version:                 "P70 v1.45 (12/06/2017)",
 						Image:                   metalv1alpha1.ImageSpec{URI: "P71 v1.45 (12/06/2017)"},
 						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
 					},
@@ -87,7 +87,54 @@ var _ = Describe("BMCVersion Webhook", func() {
 			Expect(k8sClient.Create(ctx, BMCVersionV2)).To(Succeed())
 		})
 
-		It("should deny update if a BMC referred is already referred by another", func() {
+		It("should deny update if both bmcRef and version match an existing record", func() {
+			By("Creating another BMCVersion with different BMCRef and version")
+			BMCVersionV2 := &metalv1alpha1.BMCVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bmc-ver",
+				},
+				Spec: metalv1alpha1.BMCVersionSpec{
+					BMCVersionTemplate: metalv1alpha1.BMCVersionTemplate{
+						Version:                 "P71 v1.45 (12/06/2017)",
+						Image:                   metalv1alpha1.ImageSpec{URI: "P71 v1.45 (12/06/2017)"},
+						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+					},
+					BMCRef: &v1.LocalObjectReference{Name: "bar"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, BMCVersionV2)).To(Succeed())
+
+			By("Updating BMCVersionV2 to match both bmcRef and version of V1")
+			BMCVersionV2Updated := BMCVersionV2.DeepCopy()
+			BMCVersionV2Updated.Spec.BMCRef = BMCVersionV1.Spec.BMCRef
+			BMCVersionV2Updated.Spec.Version = BMCVersionV1.Spec.Version
+			Expect(validator.ValidateUpdate(ctx, BMCVersionV2, BMCVersionV2Updated)).Error().To(HaveOccurred())
+		})
+
+		It("should allow update if bmcRef changes to an existing one but version differs", func() {
+			By("Creating another BMCVersion with different BMCRef and version")
+			BMCVersionV2 := &metalv1alpha1.BMCVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-bmc-ver",
+				},
+				Spec: metalv1alpha1.BMCVersionSpec{
+					BMCVersionTemplate: metalv1alpha1.BMCVersionTemplate{
+						Version:                 "P71 v1.45 (12/06/2017)",
+						Image:                   metalv1alpha1.ImageSpec{URI: "P71 v1.45 (12/06/2017)"},
+						ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+					},
+					BMCRef: &v1.LocalObjectReference{Name: "bar"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, BMCVersionV2)).To(Succeed())
+
+			By("Updating BMCVersionV2 bmcRef to match V1 while keeping a different version")
+			BMCVersionV2Updated := BMCVersionV2.DeepCopy()
+			BMCVersionV2Updated.Spec.BMCRef = BMCVersionV1.Spec.BMCRef
+			Expect(validator.ValidateUpdate(ctx, BMCVersionV2, BMCVersionV2Updated)).Error().NotTo(HaveOccurred())
+		})
+
+		It("should allow update when bmcRef is unchanged even if version now matches another record", func() {
 			By("Creating another BMCVersion with different BMCRef")
 			BMCVersionV2 := &metalv1alpha1.BMCVersion{
 				ObjectMeta: metav1.ObjectMeta{
@@ -104,10 +151,10 @@ var _ = Describe("BMCVersion Webhook", func() {
 			}
 			Expect(k8sClient.Create(ctx, BMCVersionV2)).To(Succeed())
 
-			By("Updating an BMCVersionV2 to refer to existing BMC")
+			By("Updating BMCVersionV2 version to match V1 without changing bmcRef")
 			BMCVersionV2Updated := BMCVersionV2.DeepCopy()
-			BMCVersionV2Updated.Spec.BMCRef = BMCVersionV1.Spec.BMCRef
-			Expect(validator.ValidateUpdate(ctx, BMCVersionV1, BMCVersionV2Updated)).Error().To(HaveOccurred())
+			BMCVersionV2Updated.Spec.Version = BMCVersionV1.Spec.Version
+			Expect(validator.ValidateUpdate(ctx, BMCVersionV2, BMCVersionV2Updated)).Error().NotTo(HaveOccurred())
 		})
 
 		It("should update if a BMC referred is not referred by another", func() {


### PR DESCRIPTION
## Summary

This PR updates the validating webhooks for `BIOSSettings`, `BIOSVersion`, `BMCSettings`, and
`BMCVersion` to support the upcoming **metal-maintenance-operator**, which introduces a
`MaintenancePlanRun` controller that creates these CRs programmatically to drive firmware and
configuration upgrades across a fleet of servers.

### Problem

The existing webhook duplicate-detection logic blocked any two CRs from targeting the same server
or BMC ref, regardless of version. This was too strict for the maintenance plan use case, where the
operator needs to create a new CR for a _different target version_ on the same server — for example,
to upgrade BIOS firmware from `P71` to `P79`. The old logic would reject this as a duplicate.

Additionally, the webhooks were needlessly re-running the full duplicate check on every update even
when the `serverRef`/`bmcRef` field hadn't changed, which could never introduce a new duplicate and
was wasted work.

### Changes

**`biossettings_webhook.go`, `biosversion_webhook.go`, `bmcsettings_webhook.go`, `bmcversion_webhook.go`**

- **Dual-condition duplicate detection**: a CR is now only rejected as a duplicate when both the
  server/BMC ref **and** the target `version` match an existing record. Two CRs targeting the same
  server with different versions are explicitly allowed, enabling the maintenance plan operator to
  stage sequential upgrades.

- **Early return on unchanged ref**: `ValidateUpdate` now skips the duplicate check entirely when
  the `serverRef`/`bmcRef` has not changed between old and new object, since no new duplicate can
  be introduced in that case.

**`bmcversion_controller.go`**

- Minor: removes redundant error wrapping in the `resetBMC` call path (the inner error already
  contains sufficient context).

### Tests

All four webhook test files have been updated:

- Fixed existing tests that assumed the old single-condition duplicate logic
- Added new cases covering: deny when both ref and version match; allow when ref changes but version
  differs; allow when ref is unchanged but version changes

### Context

The `metal-maintenance-operator` `MaintenancePlanRun` controller creates `BIOSSettings`,
`BIOSVersion`, `BMCSettings`, and `BMCVersion` CRs on behalf of a `MaintenancePlan`. Each stage in
a plan targets a specific `version`, and multiple stages across a plan run may reference the same
server/BMC with different versions. Without this change, the webhooks would reject those creates and
block the maintenance pipeline entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined webhook validation so updates are only blocked when both the reference and version match an existing entry.
  * Allowed updates to keep the same reference without being incorrectly flagged as duplicates.
  * Improved error handling during BMC reconciliation to avoid returning misleading errors when no real failure occurred.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->