### PR TITLE
Update concept documentation

### DIFF
--- a/docs/concepts/bmcsecrets.md
+++ b/docs/concepts/bmcsecrets.md
@@ -10,7 +10,7 @@ interact with BMCs.
 An example of how to define an `BMCSecret` resource:
 
 ```yaml
-apiVersion: v1alpha1
+apiVersion: metal.ironcore.dev/v1alpha1
 kind: BMCSecret
 metadata:
   name: my-bmc-secret

--- a/docs/concepts/servers.md
+++ b/docs/concepts/servers.md
@@ -22,12 +22,12 @@ spec:
     - name: PXE
       priority: 1
       device: Network
-  BIOS:
-    - version: "1.0.3"
-      settings:
-        BootMode: UEFI
-        Virtualization: Enabled
+  biosSettingsRef:
+    name: my-server-bios
 ```
+
+BIOS configuration is expressed as a separate [`BIOSSettings`](biossettings.md) resource
+referenced from `spec.biosSettingsRef`, rather than inline on the `Server`.
 
 ## Usage
 
@@ -146,29 +146,27 @@ spec:
     - name: PXE
       priority: 1
       device: Network
-  BIOS:
-    - version: "1.0.3"
-      settings:
-        BootMode: UEFI
-        HyperThreading: Enabled
+  biosSettingsRef:
+    name: server-with-bmc-ref-bios
 ```
 
-Inline Configuration: Use the `bmc` field to provide direct BMC access details.
+Inline Configuration: Use the `bmc` field to provide direct BMC access details on the
+`Server` itself, without a separate `BMC` or `Endpoint` resource. The `bmcSecretRef` still
+points to a [`BMCSecret`](bmcsecrets.md) that carries the credentials.
 
 ```yaml
-apiVersion: v1alpha1
-kind: BMC
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: Server
 metadata:
-  name: my-bmc
+  name: server-with-inline-bmc
 spec:
-  endpointRef:
-    name: my-bmc-endpoint
-  bmcSecretRef:
-    name: my-bmc-secret
-  protocol:
-    name: Redfish
-    port: 8000
-  consoleProtocol:
-    name: SSH
-    port: 22
+  systemUUID: "123e4567-e89b-12d3-a456-426614174000"
+  power: "On"
+  bmc:
+    protocol:
+      name: Redfish
+      port: 8000
+    address: "192.168.100.10"
+    bmcSecretRef:
+      name: my-bmc-secret
 ```


### PR DESCRIPTION
# Proposed Changes

Update concept doc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example `BMCSecret` manifest to use the current API version format.
  * Revised server documentation examples to show BIOS configuration through a reference field instead of inline settings.
  * Aligned related example content with the new reference-based approach for clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->