### PR TITLE
Ignore errors for read only settings which already have the correct values

### DIFF
--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -488,9 +488,15 @@ func (r *RedfishBaseBMC) GetBiosAttributeValues(ctx context.Context, systemURI s
 	if err != nil {
 		return nil, err
 	}
+	readOnlyAttr, err := r.getFilteredBiosRegistryAttributes(true, false)
+	if err != nil {
+		return nil, err
+	}
 	result := make(schemas.SettingsAttributes, len(attributes))
 	for _, name := range attributes {
 		if _, ok := filteredAttr[name]; ok {
+			result[name] = bios.Attributes[name]
+		} else if _, ok := readOnlyAttr[name]; ok {
 			result[name] = bios.Attributes[name]
 		}
 	}


### PR DESCRIPTION
# Proposed Changes
Allow skipping erroring out when read only attribute is already at desired value.

Fixes #984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BIOS settings now include values for read-only attributes as well as editable ones, so more attribute values are shown consistently when viewing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->