### PR TITLE
Complete all `ServerMaintenances` before removing the maintenance approval

### DIFF
--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -600,10 +600,6 @@ func (r *ServerReconciler) hasPendingMaintenances(ctx context.Context, server *m
 		}
 	}
 
-	// For OwnerApproval maintenances, only stay in Maintenance if they can actually proceed.
-	// With no ServerClaim, they are auto-approved (same as Enforced). With a ServerClaim,
-	// check that the approval label is still present — if revoked externally, exit Maintenance
-	// to avoid getting stuck.
 	if pendingOwnerApproval {
 		if server.Spec.ServerClaimRef == nil {
 			return true, nil
@@ -626,16 +622,12 @@ func (r *ServerReconciler) hasPendingMaintenances(ctx context.Context, server *m
 func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if server.Spec.ServerMaintenanceRef == nil {
-		// Before exiting maintenance, check if other maintenances are queued for this server.
-		// If so, stay in Maintenance so the next one can claim the ref without a Reserved -> maintenance state bounce.
 		hasPending, err := r.hasPendingMaintenances(ctx, server)
 		if err != nil {
 			return false, fmt.Errorf("failed to check pending maintenances: %w", err)
 		}
 		if hasPending {
 			log.V(1).Info("Other maintenances are pending, staying in Maintenance state", "Server", server.Name)
-			// Refresh system info between maintenances so the next one sees up-to-date
-			// hardware state (e.g. BIOS version after a firmware update).
 			if err := r.updateServerStatusFromSystemInfo(ctx, bmcClient, server); err != nil {
 				return false, fmt.Errorf("failed to update server status system info between maintenances: %w", err)
 			}

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -580,9 +580,68 @@ func (r *ServerReconciler) handleReleasedState(ctx context.Context, bmcClient bm
 	return r.patchServerState(ctx, server, metalv1alpha1.ServerStateAvailable)
 }
 
+func (r *ServerReconciler) hasPendingMaintenances(ctx context.Context, server *metalv1alpha1.Server) (bool, error) {
+	maintenanceList := &metalv1alpha1.ServerMaintenanceList{}
+	if err := r.List(ctx, maintenanceList, client.MatchingFields{serverRefField: server.Name}); err != nil {
+		return false, fmt.Errorf("failed to list ServerMaintenances: %w", err)
+	}
+
+	var pendingOwnerApproval bool
+	for i := range maintenanceList.Items {
+		m := &maintenanceList.Items[i]
+		if !m.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if m.Spec.Policy == metalv1alpha1.ServerMaintenancePolicyEnforced {
+			return true, nil
+		}
+		if m.Spec.Policy == metalv1alpha1.ServerMaintenancePolicyOwnerApproval {
+			pendingOwnerApproval = true
+		}
+	}
+
+	// For OwnerApproval maintenances, only stay in Maintenance if they can actually proceed.
+	// With no ServerClaim, they are auto-approved (same as Enforced). With a ServerClaim,
+	// check that the approval label is still present — if revoked externally, exit Maintenance
+	// to avoid getting stuck.
+	if pendingOwnerApproval {
+		if server.Spec.ServerClaimRef == nil {
+			return true, nil
+		}
+		serverClaim := &metalv1alpha1.ServerClaim{}
+		if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.ServerClaimRef.Name, Namespace: server.Spec.ServerClaimRef.Namespace}, serverClaim); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get ServerClaim: %w", err)
+		}
+		if _, hasApproval := serverClaim.Labels[metalv1alpha1.ServerMaintenanceApprovedLabelKey]; hasApproval {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if server.Spec.ServerMaintenanceRef == nil {
+		// Before exiting maintenance, check if other maintenances are queued for this server.
+		// If so, stay in Maintenance so the next one can claim the ref without a Reserved -> maintenance state bounce.
+		hasPending, err := r.hasPendingMaintenances(ctx, server)
+		if err != nil {
+			return false, fmt.Errorf("failed to check pending maintenances: %w", err)
+		}
+		if hasPending {
+			log.V(1).Info("Other maintenances are pending, staying in Maintenance state", "Server", server.Name)
+			// Refresh system info between maintenances so the next one sees up-to-date
+			// hardware state (e.g. BIOS version after a firmware update).
+			if err := r.updateServerStatusFromSystemInfo(ctx, bmcClient, server); err != nil {
+				return false, fmt.Errorf("failed to update server status system info between maintenances: %w", err)
+			}
+			return false, nil
+		}
+
 		log.V(1).Info("Server is in Maintenance state, but no ServerMaintenanceRef is set, transitioning back to previous state")
 		// update system info in case the server was changed during Maintenance state (hardwere changes, biosVersion etc.)
 		if err := r.updateServerStatusFromSystemInfo(ctx, bmcClient, server); err != nil {

--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -452,10 +452,10 @@ func (r *ServerMaintenanceReconciler) cleanup(ctx context.Context, maintenance *
 				metalv1alpha1.ServerMaintenanceNeededLabelKey,
 			})
 			if err := r.Patch(ctx, serverClaim, client.MergeFrom(serverClaimBase)); err != nil {
-				return fmt.Errorf("failed to patch ServerClaim annotations: %w", err)
+				return fmt.Errorf("failed to patch ServerClaim labels: %w", err)
 			}
 		} else {
-			log.V(1).Info("Postponning the removal of approval annotation as other maintenances are in queue", "Server", server.Name)
+			log.V(1).Info("Postponing the removal of approval labels as other maintenances are in queue", "Server", server.Name)
 		}
 
 	}

--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -429,18 +429,21 @@ func (r *ServerMaintenanceReconciler) cleanup(ctx context.Context, maintenance *
 			return nil
 		}
 		serverMaintenancesList := &metalv1alpha1.ServerMaintenanceList{}
-		if err := clientutils.ListAndFilter(ctx, r.Client, serverMaintenancesList, func(object client.Object) (bool, error) {
-			serverMaintenance := object.(*metalv1alpha1.ServerMaintenance)
-			if serverMaintenance.Name == maintenance.Name && serverMaintenance.Namespace == maintenance.Namespace {
-				return false, nil
-			}
-			if !serverMaintenance.DeletionTimestamp.IsZero() {
-				return false, nil
-			}
-			return serverMaintenance.Spec.ServerRef != nil && serverMaintenance.Spec.ServerRef.Name == server.Name, nil
-		}); err != nil {
+		if err := r.List(ctx, serverMaintenancesList, client.MatchingFields{serverRefField: server.Name}); err != nil {
 			return fmt.Errorf("failed to list ServerMaintenances for Server %s: %w", server.Name, err)
 		}
+		activeItems := serverMaintenancesList.Items[:0]
+		for i := range serverMaintenancesList.Items {
+			m := &serverMaintenancesList.Items[i]
+			if m.Name == maintenance.Name && m.Namespace == maintenance.Namespace {
+				continue
+			}
+			if !m.DeletionTimestamp.IsZero() {
+				continue
+			}
+			activeItems = append(activeItems, *m)
+		}
+		serverMaintenancesList.Items = activeItems
 		if len(serverMaintenancesList.Items) == 0 {
 			serverClaim := &metalv1alpha1.ServerClaim{}
 			if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.ServerClaimRef.Name, Namespace: server.Spec.ServerClaimRef.Namespace}, serverClaim); err != nil {

--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -428,18 +428,36 @@ func (r *ServerMaintenanceReconciler) cleanup(ctx context.Context, maintenance *
 		if server.Spec.ServerClaimRef == nil {
 			return nil
 		}
-		serverClaim := &metalv1alpha1.ServerClaim{}
-		if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.ServerClaimRef.Name, Namespace: server.Spec.ServerClaimRef.Namespace}, serverClaim); err != nil {
-			return fmt.Errorf("failed to get ServerClaim: %w", err)
+		serverMaintenancesList := &metalv1alpha1.ServerMaintenanceList{}
+		if err := clientutils.ListAndFilter(ctx, r.Client, serverMaintenancesList, func(object client.Object) (bool, error) {
+			serverMaintenance := object.(*metalv1alpha1.ServerMaintenance)
+			if serverMaintenance.Name == maintenance.Name && serverMaintenance.Namespace == maintenance.Namespace {
+				return false, nil
+			}
+			if !serverMaintenance.DeletionTimestamp.IsZero() {
+				return false, nil
+			}
+			return serverMaintenance.Spec.ServerRef != nil && serverMaintenance.Spec.ServerRef.Name == server.Name, nil
+		}); err != nil {
+			return fmt.Errorf("failed to list ServerMaintenances for Server %s: %w", server.Name, err)
 		}
-		serverClaimBase := serverClaim.DeepCopy()
-		metautils.DeleteLabels(serverClaim, []string{
-			metalv1alpha1.ServerMaintenanceApprovedLabelKey,
-			metalv1alpha1.ServerMaintenanceNeededLabelKey,
-		})
-		if err := r.Patch(ctx, serverClaim, client.MergeFrom(serverClaimBase)); err != nil {
-			return fmt.Errorf("failed to patch ServerClaim annotations: %w", err)
+		if len(serverMaintenancesList.Items) == 0 {
+			serverClaim := &metalv1alpha1.ServerClaim{}
+			if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.ServerClaimRef.Name, Namespace: server.Spec.ServerClaimRef.Namespace}, serverClaim); err != nil {
+				return fmt.Errorf("failed to get ServerClaim: %w", err)
+			}
+			serverClaimBase := serverClaim.DeepCopy()
+			metautils.DeleteLabels(serverClaim, []string{
+				metalv1alpha1.ServerMaintenanceApprovedLabelKey,
+				metalv1alpha1.ServerMaintenanceNeededLabelKey,
+			})
+			if err := r.Patch(ctx, serverClaim, client.MergeFrom(serverClaimBase)); err != nil {
+				return fmt.Errorf("failed to patch ServerClaim annotations: %w", err)
+			}
+		} else {
+			log.V(1).Info("Postponning the removal of approval annotation as other maintenances are in queue", "Server", server.Name)
 		}
+
 	}
 	return nil
 }

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -438,11 +438,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		Expect(k8sClient.Delete(ctx, highPriorityMaintenance)).To(Succeed())
 		// check that the high-priority maintenance is deleted before checking the low-priority maintenance
 		Eventually(Get(highPriorityMaintenance)).Should(Satisfy(apierrors.IsNotFound))
-		By("Approving lowPriorityMaintenance on the ServerClaim")
-		Eventually(Update(serverClaim, func() {
-			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
-		})).Should(Succeed())
-		By("Ensuring low-priority maintenance can proceed afterwards")
+		By("Ensuring low-priority maintenance can proceed with the existing approval")
 		Eventually(Object(lowPriorityMaintenance)).Should(HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance))
 
 		By("Deleting low-priority maintenance")
@@ -532,12 +528,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 		Expect(k8sClient.Delete(ctx, setPriorityMaintenance)).To(Succeed())
 		Eventually(Get(setPriorityMaintenance)).Should(Satisfy(apierrors.IsNotFound))
 
-		By("Approving lowPriorityMaintenance on the ServerClaim")
-		Eventually(Update(serverClaim, func() {
-			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
-		})).Should(Succeed())
-
-		By("Ensuring unset-priority maintenance can proceed afterwards")
+		By("Ensuring unset-priority maintenance can proceed with the existing approval")
 		Eventually(Object(unsetPriorityMaintenance)).Should(HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance))
 
 		By("Deleting unset-priority maintenance")
@@ -657,6 +648,167 @@ var _ = Describe("ServerMaintenance Controller", func() {
 
 		By("Deleting the second ServerMaintenance")
 		Expect(k8sClient.Delete(ctx, serverMaintenance02)).To(Succeed())
+		Eventually(Get(serverMaintenance02)).ShouldNot(Succeed())
+	})
+
+	It("should keep server in Maintenance throughout all queued Enforced maintenances without state bounce", func(ctx SpecContext) {
+		By("Creating two Enforced ServerMaintenance objects")
+		maintenance01 := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-no-bounce-enforced-01",
+				Namespace: ns.Name,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				ServerRef:   &corev1.LocalObjectReference{Name: server.Name},
+				Policy:      metalv1alpha1.ServerMaintenancePolicyEnforced,
+				ServerPower: metalv1alpha1.PowerOff,
+			},
+		}
+		maintenance02 := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-no-bounce-enforced-02",
+				Namespace: ns.Name,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				ServerRef:   &corev1.LocalObjectReference{Name: server.Name},
+				Policy:      metalv1alpha1.ServerMaintenancePolicyEnforced,
+				ServerPower: metalv1alpha1.PowerOff,
+			},
+		}
+		Expect(k8sClient.Create(ctx, maintenance01)).To(Succeed())
+		Expect(k8sClient.Create(ctx, maintenance02)).To(Succeed())
+
+		By("Waiting for the first maintenance to be active and server to be in Maintenance")
+		Eventually(Object(server)).Should(HaveField("Spec.ServerMaintenanceRef.Name", maintenance01.Name))
+		Eventually(Object(maintenance01)).Should(HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance))
+		Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateMaintenance))
+
+		By("Ensuring the second maintenance is pending while first is active")
+		Eventually(Object(maintenance02)).Should(HaveField("Status.State", metalv1alpha1.ServerMaintenanceStatePending))
+
+		By("Completing the first maintenance")
+		Expect(k8sClient.Delete(ctx, maintenance01)).To(Succeed())
+
+		By("Verifying server stays in Maintenance while second maintenance takes over (no state bounce)")
+		Consistently(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateMaintenance))
+		Eventually(Object(server)).Should(HaveField("Spec.ServerMaintenanceRef.Name", maintenance02.Name))
+		Eventually(Object(maintenance02)).Should(HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance))
+
+		By("Completing the second maintenance")
+		Expect(k8sClient.Delete(ctx, maintenance02)).To(Succeed())
+		Eventually(Get(maintenance02)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("Verifying server exits Maintenance only after all maintenances are done")
+		Eventually(Object(server)).Should(SatisfyAll(
+			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
+			HaveField("Spec.ServerMaintenanceRef", BeNil()),
+		))
+	})
+
+	It("should keep reserved server in Maintenance throughout all queued OwnerApproval maintenances and return to Reserved only after all are done", func(ctx SpecContext) {
+		By("Patching server to Available state")
+		Eventually(UpdateStatus(server, func() {
+			server.Status.State = metalv1alpha1.ServerStateAvailable
+		})).Should(Succeed())
+
+		By("Creating an Ignition secret")
+		ignitionSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-",
+			},
+			Data: map[string][]byte{"foo": []byte("bar")},
+		}
+		Expect(k8sClient.Create(ctx, ignitionSecret)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, ignitionSecret)
+
+		By("Creating a ServerClaim to reserve the server")
+		serverClaim := &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-",
+			},
+			Spec: metalv1alpha1.ServerClaimSpec{
+				Power:             powerOpOff,
+				ServerRef:         &corev1.LocalObjectReference{Name: server.Name},
+				IgnitionSecretRef: &corev1.LocalObjectReference{Name: ignitionSecret.Name},
+				Image:             "foo:latest",
+			},
+		}
+		Expect(k8sClient.Create(ctx, serverClaim)).To(Succeed())
+		Eventually(Object(server)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
+			HaveField("Spec.ServerClaimRef.Name", serverClaim.Name),
+		))
+
+		By("Creating two OwnerApproval ServerMaintenance objects")
+		maintenance01 := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-no-bounce-approval-01",
+				Namespace: ns.Name,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				ServerRef:   &corev1.LocalObjectReference{Name: server.Name},
+				Policy:      metalv1alpha1.ServerMaintenancePolicyOwnerApproval,
+				Priority:    10,
+				ServerPower: metalv1alpha1.PowerOff,
+			},
+		}
+		maintenance02 := &metalv1alpha1.ServerMaintenance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-no-bounce-approval-02",
+				Namespace: ns.Name,
+			},
+			Spec: metalv1alpha1.ServerMaintenanceSpec{
+				ServerRef:   &corev1.LocalObjectReference{Name: server.Name},
+				Policy:      metalv1alpha1.ServerMaintenancePolicyOwnerApproval,
+				Priority:    5,
+				ServerPower: metalv1alpha1.PowerOff,
+			},
+		}
+		Expect(k8sClient.Create(ctx, maintenance01)).To(Succeed())
+		Expect(k8sClient.Create(ctx, maintenance02)).To(Succeed())
+		Eventually(Object(maintenance01)).Should(HaveField("Status.State", metalv1alpha1.ServerMaintenanceStatePending))
+		Eventually(Object(maintenance02)).Should(HaveField("Status.State", metalv1alpha1.ServerMaintenanceStatePending))
+
+		By("Approving maintenance on the ServerClaim (single approval covers all queued maintenances)")
+		Eventually(Update(serverClaim, func() {
+			metautils.SetLabel(serverClaim, metalv1alpha1.ServerMaintenanceApprovedLabelKey, trueValue)
+		})).Should(Succeed())
+
+		By("Ensuring the higher-priority maintenance starts first")
+		Eventually(Object(server)).Should(HaveField("Spec.ServerMaintenanceRef.Name", maintenance01.Name))
+		Eventually(Object(maintenance01)).Should(HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance))
+		Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateMaintenance))
+		Consistently(Object(maintenance02)).Should(HaveField("Status.State", metalv1alpha1.ServerMaintenanceStatePending))
+
+		By("Completing the first maintenance")
+		Expect(k8sClient.Delete(ctx, maintenance01)).To(Succeed())
+		Eventually(Get(maintenance01)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("Verifying server stays in Maintenance while second maintenance takes over (no bounce to Reserved)")
+		Consistently(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateMaintenance))
+		Eventually(Object(server)).Should(HaveField("Spec.ServerMaintenanceRef.Name", maintenance02.Name))
+		Eventually(Object(maintenance02)).Should(HaveField("Status.State", metalv1alpha1.ServerMaintenanceStateInMaintenance))
+
+		By("Completing the second maintenance")
+		Expect(k8sClient.Delete(ctx, maintenance02)).To(Succeed())
+		Eventually(Get(maintenance02)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("Verifying server returns to Reserved only after all maintenances are done")
+		Eventually(Object(server)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
+			HaveField("Spec.ServerMaintenanceRef", BeNil()),
+		))
+
+		By("Verifying approval and maintenance-needed labels are cleaned up on the ServerClaim")
+		Eventually(Object(serverClaim)).Should(SatisfyAll(
+			HaveField("ObjectMeta.Labels", Not(HaveKey(metalv1alpha1.ServerMaintenanceApprovedLabelKey))),
+			HaveField("ObjectMeta.Labels", Not(HaveKey(metalv1alpha1.ServerMaintenanceNeededLabelKey))),
+		))
+
+		By("Deleting the ServerClaim")
+		Expect(k8sClient.Delete(ctx, serverClaim)).To(Succeed())
 	})
 
 	It("should skip cleanup and remove finalizer when no finalizer is present on deletion", func(ctx SpecContext) {


### PR DESCRIPTION
# Proposed Changes
consistent behavior when multiple maintenances are in queue when server is in available/reserved state

Fixes #989 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved maintenance handling so queued maintenance requests are processed in sequence without briefly leaving Maintenance between items.
  * Prevented maintenance labels from being cleared too early when other pending maintenances still exist.
  * Preserved the server’s current state more reliably during maintenance handoffs, including reserved and approval-based workflows.

* **Tests**
  * Updated and expanded automated coverage for queued maintenance scenarios to verify continuous Maintenance behavior and correct label cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->