### PR TITLE
Add ApplyResult type and update BMC interface signatures for ETag-based drift detection

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -116,13 +116,14 @@ type BMCSettingsManager interface {
 	GetBMCVersion(ctx context.Context, UUID string) (string, error)
 
 	// GetBMCAttributeValues retrieves BMC attribute values for the system.
-	GetBMCAttributeValues(ctx context.Context, UUID string, attributes map[string]string) (schemas.SettingsAttributes, error)
+	GetBMCAttributeValues(ctx context.Context, req GetBMCAttributeValuesRequest) (schemas.SettingsAttributes, error)
 
 	// GetBMCPendingAttributeValues retrieves pending BMC attribute values for the system.
 	GetBMCPendingAttributeValues(ctx context.Context, UUID string) (result schemas.SettingsAttributes, err error)
 
 	// SetBMCAttributesImmediately sets BMC attributes on the system and applies them immediately.
-	SetBMCAttributesImmediately(ctx context.Context, UUID string, attributes schemas.SettingsAttributes) (err error)
+	// Returns a map of attribute keys to ApplyResult containing URI and ETag from the response.
+	SetBMCAttributesImmediately(ctx context.Context, UUID string, attributes schemas.SettingsAttributes) (map[string]ApplyResult, error)
 
 	// CheckBMCAttributes checks if the BMC attributes are valid and returns whether a reset is required.
 	CheckBMCAttributes(ctx context.Context, UUID string, attrs schemas.SettingsAttributes) (reset bool, err error)
@@ -394,4 +395,24 @@ type Manager struct {
 	State           string
 	MACAddress      string
 	OemLinks        json.RawMessage
+}
+
+// ApplyResult holds the outcome of a single settings apply operation.
+type ApplyResult struct {
+	// URI is the resource URI. For POST: Location header (created resource); for PATCH: request URI.
+	URI string
+	// ETag from the response header or follow-up GET.
+	// May be a real ETag (e.g. "W/\"abc\"") or a body hash (prefixed "hash:sha256:").
+	ETag string
+}
+
+// GetBMCAttributeValuesRequest bundles the inputs for GetBMCAttributeValues.
+type GetBMCAttributeValuesRequest struct {
+	// UUID identifies the BMC manager resource.
+	UUID string
+	// Attributes is the set of attribute keys to retrieve, mapped to their expected values.
+	Attributes map[string]string
+	// StoredETags provides previously captured ETags for ETag-based drift detection.
+	// May be nil when no prior apply results are available.
+	StoredETags map[string]ApplyResult
 }

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -513,7 +513,8 @@ func (r *RedfishBaseBMC) GetBiosAttributeValues(ctx context.Context, systemURI s
 	return result, err
 }
 
-func (r *RedfishBaseBMC) GetBMCAttributeValues(_ context.Context, _ string, attributes map[string]string) (schemas.SettingsAttributes, error) {
+func (r *RedfishBaseBMC) GetBMCAttributeValues(_ context.Context, req GetBMCAttributeValuesRequest) (schemas.SettingsAttributes, error) {
+	attributes := req.Attributes
 	if len(attributes) == 0 {
 		return nil, nil
 	}
@@ -606,11 +607,11 @@ func (r *RedfishBaseBMC) SetBiosAttributesOnReset(ctx context.Context, systemURI
 	return bios.UpdateBiosAttributesApplyAt(attrs, schemas.OnResetSettingsApplyTime)
 }
 
-func (r *RedfishBaseBMC) SetBMCAttributesImmediately(_ context.Context, _ string, attributes schemas.SettingsAttributes) error {
+func (r *RedfishBaseBMC) SetBMCAttributesImmediately(_ context.Context, _ string, attributes schemas.SettingsAttributes) (map[string]ApplyResult, error) {
 	if len(attributes) == 0 {
-		return nil
+		return nil, nil
 	}
-	return fmt.Errorf("BMC attribute operations not supported for manufacturer %q", r.manufacturer)
+	return nil, fmt.Errorf("BMC attribute operations not supported for manufacturer %q", r.manufacturer)
 }
 
 // SetBootOrder sets bios boot order

--- a/bmc/redfish_dell.go
+++ b/bmc/redfish_dell.go
@@ -201,7 +201,8 @@ func (r *DellRedfishBMC) getFilteredBMCRegistryAttributes(manager *schemas.Manag
 
 // --- BMC interface method overrides ---
 
-func (r *DellRedfishBMC) GetBMCAttributeValues(ctx context.Context, bmcUUID string, attributes map[string]string) (schemas.SettingsAttributes, error) {
+func (r *DellRedfishBMC) GetBMCAttributeValues(ctx context.Context, req GetBMCAttributeValuesRequest) (schemas.SettingsAttributes, error) {
+	attributes := req.Attributes
 	if len(attributes) == 0 {
 		return nil, nil
 	}
@@ -348,19 +349,19 @@ func (r *DellRedfishBMC) GetBMCPendingAttributeValues(ctx context.Context, bmcUU
 	return mergedPendingBMCAttributes, nil
 }
 
-func (r *DellRedfishBMC) SetBMCAttributesImmediately(ctx context.Context, bmcUUID string, attributes schemas.SettingsAttributes) error {
+func (r *DellRedfishBMC) SetBMCAttributesImmediately(ctx context.Context, bmcUUID string, attributes schemas.SettingsAttributes) (map[string]ApplyResult, error) {
 	if len(attributes) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	manager, err := r.getManagerForOEM()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	bmcAttrValues, err := r.getCurrentBMCSettingAttribute(manager)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	payloads := make(map[string]schemas.SettingsAttributes, len(bmcAttrValues))
@@ -415,10 +416,10 @@ func (r *DellRedfishBMC) SetBMCAttributesImmediately(ctx context.Context, bmcUUI
 			}
 		}
 		if len(errs) > 0 {
-			return fmt.Errorf("some settings failed to apply %v", errs)
+			return nil, fmt.Errorf("some settings failed to apply %v", errs)
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (r *DellRedfishBMC) CheckBMCAttributes(ctx context.Context, bmcUUID string, attrs schemas.SettingsAttributes) (bool, error) {

--- a/bmc/redfish_hpe.go
+++ b/bmc/redfish_hpe.go
@@ -22,7 +22,8 @@ type HPERedfishBMC struct {
 
 // --- BMC interface method overrides ---
 
-func (r *HPERedfishBMC) GetBMCAttributeValues(ctx context.Context, bmcUUID string, attributes map[string]string) (schemas.SettingsAttributes, error) {
+func (r *HPERedfishBMC) GetBMCAttributeValues(ctx context.Context, req GetBMCAttributeValuesRequest) (schemas.SettingsAttributes, error) {
+	attributes := req.Attributes
 	if len(attributes) == 0 {
 		return nil, nil
 	}
@@ -33,11 +34,12 @@ func (r *HPERedfishBMC) GetBMCPendingAttributeValues(_ context.Context, _ string
 	return schemas.SettingsAttributes{}, nil
 }
 
-func (r *HPERedfishBMC) SetBMCAttributesImmediately(ctx context.Context, _ string, attributes schemas.SettingsAttributes) error {
+func (r *HPERedfishBMC) SetBMCAttributesImmediately(ctx context.Context, _ string, attributes schemas.SettingsAttributes) (map[string]ApplyResult, error) {
 	if len(attributes) == 0 {
-		return nil
+		return nil, nil
 	}
-	return httpBasedUpdateBMCAttributes(r.client.GetService().GetClient(), attributes, schemas.ImmediateSettingsApplyTime)
+	err := httpBasedUpdateBMCAttributes(r.client.GetService().GetClient(), attributes, schemas.ImmediateSettingsApplyTime)
+	return nil, err
 }
 
 func (r *HPERedfishBMC) CheckBMCAttributes(_ context.Context, _ string, _ schemas.SettingsAttributes) (bool, error) {

--- a/bmc/redfish_lenovo.go
+++ b/bmc/redfish_lenovo.go
@@ -22,7 +22,8 @@ type LenovoRedfishBMC struct {
 
 // --- BMC interface method overrides ---
 
-func (r *LenovoRedfishBMC) GetBMCAttributeValues(ctx context.Context, bmcUUID string, attributes map[string]string) (schemas.SettingsAttributes, error) {
+func (r *LenovoRedfishBMC) GetBMCAttributeValues(ctx context.Context, req GetBMCAttributeValuesRequest) (schemas.SettingsAttributes, error) {
+	attributes := req.Attributes
 	if len(attributes) == 0 {
 		return nil, nil
 	}
@@ -39,11 +40,12 @@ func (r *LenovoRedfishBMC) GetBMCPendingAttributeValues(_ context.Context, _ str
 	return schemas.SettingsAttributes{}, nil
 }
 
-func (r *LenovoRedfishBMC) SetBMCAttributesImmediately(ctx context.Context, _ string, attributes schemas.SettingsAttributes) error {
+func (r *LenovoRedfishBMC) SetBMCAttributesImmediately(ctx context.Context, _ string, attributes schemas.SettingsAttributes) (map[string]ApplyResult, error) {
 	if len(attributes) == 0 {
-		return nil
+		return nil, nil
 	}
-	return httpBasedUpdateBMCAttributes(r.client.GetService().GetClient(), attributes, schemas.ImmediateSettingsApplyTime)
+	err := httpBasedUpdateBMCAttributes(r.client.GetService().GetClient(), attributes, schemas.ImmediateSettingsApplyTime)
+	return nil, err
 }
 
 func (r *LenovoRedfishBMC) CheckBMCAttributes(_ context.Context, _ string, _ schemas.SettingsAttributes) (bool, error) {

--- a/bmc/redfish_local.go
+++ b/bmc/redfish_local.go
@@ -68,19 +68,19 @@ func (r *RedfishLocalBMC) GetBiosUpgradeTask(ctx context.Context, _ string, task
 
 // SetBMCAttributesImmediately sets BMC attributes via HTTP PATCH to the BMC Settings endpoint.
 // Navigates from the manager's @Redfish.Settings.SettingsObject link, mirroring the Dell pattern.
-func (r *RedfishLocalBMC) SetBMCAttributesImmediately(ctx context.Context, bmcUUID string, attributes schemas.SettingsAttributes) error {
+func (r *RedfishLocalBMC) SetBMCAttributesImmediately(ctx context.Context, bmcUUID string, attributes schemas.SettingsAttributes) (map[string]ApplyResult, error) {
 	if len(attributes) == 0 {
-		return nil
+		return nil, nil
 	}
 	manager, err := r.GetManager(bmcUUID)
 	if err != nil {
-		return fmt.Errorf("failed to get manager: %w", err)
+		return nil, fmt.Errorf("failed to get manager: %w", err)
 	}
 	var managerData struct {
 		Settings schemas.Settings `json:"@Redfish.Settings"`
 	}
 	if err := json.Unmarshal(manager.RawData, &managerData); err != nil {
-		return fmt.Errorf("failed to parse manager data: %w", err)
+		return nil, fmt.Errorf("failed to parse manager data: %w", err)
 	}
 	data := map[string]any{
 		"Attributes":                 attributes,
@@ -88,18 +88,19 @@ func (r *RedfishLocalBMC) SetBMCAttributesImmediately(ctx context.Context, bmcUU
 	}
 	resp, err := manager.GetClient().Patch(managerData.Settings.SettingsObject, data)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close() // nolint: errcheck
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("PATCH %s returned status %d", managerData.Settings.SettingsObject, resp.StatusCode)
+		return nil, fmt.Errorf("PATCH %s returned status %d", managerData.Settings.SettingsObject, resp.StatusCode)
 	}
-	return nil
+	return nil, nil
 }
 
 // GetBMCAttributeValues retrieves specific BMC attribute values via HTTP from the BMC manager.
 // Integer-typed attributes are converted from float64 (JSON default) to int to match controller expectations.
-func (r *RedfishLocalBMC) GetBMCAttributeValues(ctx context.Context, UUID string, attributes map[string]string) (schemas.SettingsAttributes, error) {
+func (r *RedfishLocalBMC) GetBMCAttributeValues(ctx context.Context, req GetBMCAttributeValuesRequest) (schemas.SettingsAttributes, error) {
+	UUID, attributes := req.UUID, req.Attributes
 	if len(attributes) == 0 {
 		return nil, nil
 	}

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -435,7 +435,7 @@ func (r *BMCSettingsReconciler) updateSettingsAndVerify(ctx context.Context, set
 				return ctrl.Result{}, fmt.Errorf("failed to check BMC settings provided: %w", err)
 			}
 
-			err = bmcClient.SetBMCAttributesImmediately(ctx, bmcObj.Spec.BMCUUID, settingsDiff)
+			_, err = bmcClient.SetBMCAttributesImmediately(ctx, bmcObj.Spec.BMCUUID, settingsDiff)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to set BMC settings: %w", err)
 			}
@@ -813,7 +813,10 @@ func (r *BMCSettingsReconciler) getBMCSettingsDifference(ctx context.Context, se
 	}
 	effectiveSettingsMap := ApplyVariables(settings.Spec.SettingsMap, resolvedVars)
 
-	currentSettings, err := bmcClient.GetBMCAttributeValues(ctx, bmcObj.Spec.BMCUUID, effectiveSettingsMap)
+	currentSettings, err := bmcClient.GetBMCAttributeValues(ctx, bmc.GetBMCAttributeValuesRequest{
+		UUID:       bmcObj.Spec.BMCUUID,
+		Attributes: effectiveSettingsMap,
+	})
 	if err != nil {
 		return diff, fmt.Errorf("failed to get BMC settings: %w", err)
 	}


### PR DESCRIPTION
## Proposed Changes

This PR prepares the BMC interface for follow-up ETag-based drift detection work.

Changes in this PR:

- add a new `ApplyResult` type representing the outcome of a settings apply operation
- update `SetBMCAttributesImmediately` to return `(map[string]ApplyResult, error)`
- update `GetBMCAttributeValues` to accept `storedETags map[string]ApplyResult`
- update BMC implementations and controller call sites to compile against the new signatures

Notes:

- this PR does not add ETag capture, persistence, or drift detection yet
- current implementations only adapt to the new signatures and return `nil` apply results where appropriate
- controller call sites pass `nil` for `storedETags` for now
- storage and use of these values are introduced in follow-up work

Fixes [#914](https://github.com/ironcore-dev/metal-operator/issues/914)
Part of [#858](https://github.com/ironcore-dev/metal-maintenance-operator/issues/176)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - BMC setting updates now provide per-attribute application results, including resource locations and ETags when available.
  - BMC setting retrieval supports request options for expected attributes and stored ETags, enabling drift detection.
  - Empty setting requests are handled consistently without unnecessary operations.

- **Refactor**
  - Standardized BMC setting retrieval and update interfaces across supported Redfish platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->