### PR TITLE
Treat HPE UnableToModifyDuringSystemPOST as retriable in boot override

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -15,6 +15,11 @@ import (
 // ErrNotSupported is returned when a BMC operation is not supported by the vendor.
 var ErrNotSupported = errors.New("operation not supported by this vendor")
 
+// ErrBootOverrideBusy is returned by SetBootOverride / ClearBootOverride when
+// the BMC transiently refuses a boot override write (e.g. host in POST).
+// Callers should retry on the next reconcile.
+var ErrBootOverrideBusy = errors.New("BMC refused boot override write, retry later")
+
 type Manufacturer string
 
 const (

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -79,6 +79,28 @@ var clearedBootOverride = schemas.Boot{
 	BootSourceOverrideTarget:  schemas.NoneBootSource,
 }
 
+// bootOverrideBusyMessageIDs lists Redfish MessageIds indicating a transient
+// BMC refusal of a boot override write (retry on next reconcile).
+var bootOverrideBusyMessageIDs = []string{
+	// HPE iLO, host in POST: iLO.2.37.UnableToModifyDuringSystemPOST
+	"UnableToModifyDuringSystemPOST",
+}
+
+// isBootOverrideBusyError substring-matches known busy MessageIds in the
+// gofish error body (which embeds the raw response payload).
+func isBootOverrideBusyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, id := range bootOverrideBusyMessageIDs {
+		if strings.Contains(msg, id) {
+			return true
+		}
+	}
+	return false
+}
+
 type InvalidBIOSSettingsError struct {
 	SettingName  string
 	SettingValue any
@@ -310,6 +332,9 @@ func (r *RedfishBaseBMC) SetBootOverride(ctx context.Context, systemURI string, 
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Setting boot override", "SystemURI", systemURI, "Boot settings", setBoot)
 	if err := system.SetBoot(&setBoot); err != nil {
+		if isBootOverrideBusyError(err) {
+			return fmt.Errorf("%w: %v", ErrBootOverrideBusy, err)
+		}
 		return fmt.Errorf("failed to set boot override: %w", err)
 	}
 	return nil
@@ -332,6 +357,9 @@ func (r *RedfishBaseBMC) ClearBootOverride(ctx context.Context, systemURI string
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Clearing boot override", "SystemURI", systemURI, "Boot settings", setBoot)
 	if err := system.SetBoot(&setBoot); err != nil {
+		if isBootOverrideBusyError(err) {
+			return fmt.Errorf("%w: %v", ErrBootOverrideBusy, err)
+		}
 		return fmt.Errorf("failed to clear boot override: %w", err)
 	}
 	return nil

--- a/bmc/redfish_supermicro.go
+++ b/bmc/redfish_supermicro.go
@@ -48,6 +48,9 @@ func (r *SupermicroRedfishBMC) SetBootOverride(ctx context.Context, systemURI st
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Setting boot override (Supermicro)", "SystemURI", systemURI, "Boot settings", setBoot)
 	if err := system.SetBoot(setBoot); err != nil {
+		if isBootOverrideBusyError(err) {
+			return fmt.Errorf("%w: %v", ErrBootOverrideBusy, err)
+		}
 		return fmt.Errorf("failed to set boot override: %w", err)
 	}
 	return nil

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -647,12 +647,17 @@ func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient
 		}
 		return r.patchServerState(ctx, server, metalv1alpha1.ServerStateReserved)
 	}
-	// Re-assert the persistent network-boot override on every reconcile while in Maintenance.
-	// This protects against reboots not driven by metal-operator (e.g. a vendor BIOS
-	// upgrade task rebooting the system itself) falling through to disk and starting
-	// the production OS while the host is still being worked on.
+	// Re-assert the persistent network-boot override while in Maintenance so
+	// reboots not driven by metal-operator (e.g. vendor BIOS upgrade tasks)
+	// don't fall through to disk. Some BMCs (HPE iLO) refuse writes while the
+	// host is in POST; we log-and-continue on ErrBootOverrideBusy so the rest
+	// of the maintenance reconcile can still make progress.
 	if err := bmcClient.SetBootOverride(ctx, server.Spec.SystemURI, true); err != nil {
-		return false, fmt.Errorf("failed to set persistent network boot for maintenance: %w", err)
+		if errors.Is(err, bmc.ErrBootOverrideBusy) {
+			log.V(1).Info("BMC busy, deferring persistent boot override re-assert", "err", err)
+		} else {
+			return false, fmt.Errorf("failed to set persistent network boot for maintenance: %w", err)
+		}
 	}
 	if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
 		return false, fmt.Errorf("failed to ensure server power state: %w", err)


### PR DESCRIPTION
# Proposed Changes

Treat HPE UnableToModifyDuringSystemPOST as retriable in boot override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporary boot override refusals during maintenance operations.
  - Maintenance reconciliation now continues when the management controller is briefly busy, rather than failing immediately.
  - Boot override errors are classified more clearly, helping systems retry the operation during the next reconciliation cycle.
  - Other boot override failures continue to be reported normally for visibility and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->