### PR TITLE
Keep BootSourceOverrideTarget as Pxe when clearing override

### DIFF
--- a/bmc/redfish_hpe.go
+++ b/bmc/redfish_hpe.go
@@ -20,6 +20,36 @@ type HPERedfishBMC struct {
 	*RedfishBaseBMC
 }
 
+// hpeClearedBootOverride disables the boot override using Pxe as the target.
+var hpeClearedBootOverride = schemas.Boot{
+	BootSourceOverrideEnabled: schemas.DisabledBootSourceOverrideEnabled,
+	// HPE iLO rejects setting BootSourceOverrideEnabled while the target is
+	// unset/None. The target is irrelevant once Disabled, so keep Pxe to satisfy
+	// iLO's ordering requirement.
+	BootSourceOverrideTarget: schemas.PxeBootSource,
+}
+
+// ClearBootOverride overrides the base implementation because HPE iLO rejects a
+// PATCH that sets BootSourceOverrideEnabled while BootSourceOverrideTarget is
+// None or unset ("BootSourceOverrideEnabled cannot be set before
+// BootSourceOverrideTarget is set"). Disable the override with Pxe as the
+// target, which iLO accepts.
+func (r *HPERedfishBMC) ClearBootOverride(ctx context.Context, systemURI string) error {
+	system, err := r.getSystemFromUri(ctx, systemURI)
+	if err != nil {
+		return fmt.Errorf("failed to get systems: %w", err)
+	}
+	if system.Boot.BootSourceOverrideEnabled == "" ||
+		system.Boot.BootSourceOverrideEnabled == schemas.DisabledBootSourceOverrideEnabled {
+		return nil
+	}
+
+	if err := system.SetBoot(&hpeClearedBootOverride); err != nil {
+		return fmt.Errorf("failed to clear boot override: %w", err)
+	}
+	return nil
+}
+
 // --- BMC interface method overrides ---
 
 func (r *HPERedfishBMC) GetBMCAttributeValues(ctx context.Context, req GetBMCAttributeValuesRequest) (schemas.SettingsAttributes, error) {


### PR DESCRIPTION
# Proposed Changes

HPE iLO rejects setting BootSourceOverrideEnabled while the target is unset/None, which surfaced when the maintenance override stopped being re-asserted every reconcile. Keep Pxe (ignored once Disabled) to satisfy iLO's ordering requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot override clearing compatibility with HPE iLO systems.
  * Disabling a boot override now preserves PXE as the boot target instead of sending an unsupported “None” value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->