### PR TITLE
Revert maintenance boot-override persistence and ClearBootOverride

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -59,16 +59,10 @@ type PowerController interface {
 
 // BootController manages boot overrides and boot order for a system.
 type BootController interface {
-	// SetBootOverride configures the system to network-boot on its next
-	// power-on, bypassing the persistent boot order. If persistent is false
-	// the override applies to a single boot only; if true it applies to every
-	// subsequent boot until ClearBootOverride is called.
-	SetBootOverride(ctx context.Context, systemURI string, persistent bool) error
-
-	// ClearBootOverride removes any active boot override so the system uses
-	// its persistent boot order on the next power-on. No-op when no override
-	// is currently set.
-	ClearBootOverride(ctx context.Context, systemURI string) error
+	// SetBootOverride sets the boot device to network boot for the next system
+	// power-on, bypassing the persistent boot order. The override applies to a
+	// single boot only.
+	SetBootOverride(ctx context.Context, systemURI string) error
 
 	// GetBootOrder retrieves the boot order for the system.
 	GetBootOrder(ctx context.Context, systemURI string) ([]string, error)

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -74,11 +74,6 @@ type RedfishBaseBMC struct {
 	manufacturer string
 }
 
-var clearedBootOverride = schemas.Boot{
-	BootSourceOverrideEnabled: schemas.DisabledBootSourceOverrideEnabled,
-	BootSourceOverrideTarget:  schemas.NoneBootSource,
-}
-
 type InvalidBIOSSettingsError struct {
 	SettingName  string
 	SettingValue any
@@ -274,65 +269,29 @@ func (r *RedfishBaseBMC) GetSystems(ctx context.Context) ([]Server, error) {
 	return servers, nil
 }
 
-// SetBootOverride sets a Redfish boot source override targeting network boot.
-// With persistent=false it sets BootSourceOverrideEnabled=Once; with
-// persistent=true it sets Continuous, which is preserved across power cycles.
-// When the requested persistent override already matches the current state
-// the call is a no-op.
-func (r *RedfishBaseBMC) SetBootOverride(ctx context.Context, systemURI string, persistent bool) error {
+// SetBootOverride sets the boot device to network boot for the next system boot
+// using Redfish. Only set BootSourceOverrideMode when the BMC reports it; older
+// BMCs that don't expose it will reject the field.
+func (r *RedfishBaseBMC) SetBootOverride(ctx context.Context, systemURI string) error {
 	system, err := r.getSystemFromUri(ctx, systemURI)
 	if err != nil {
 		return fmt.Errorf("failed to get systems: %w", err)
 	}
-	wantEnabled := schemas.OnceBootSourceOverrideEnabled
-	if persistent {
-		wantEnabled = schemas.ContinuousBootSourceOverrideEnabled
-		if system.Boot.BootSourceOverrideEnabled == schemas.ContinuousBootSourceOverrideEnabled &&
-			system.Boot.BootSourceOverrideTarget == schemas.PxeBootSource &&
-			(system.Boot.BootSourceOverrideMode == "" ||
-				system.Boot.BootSourceOverrideMode == schemas.UEFIBootSourceOverrideMode) {
-			return nil
-		}
-	}
 
 	setBoot := schemas.Boot{
-		BootSourceOverrideEnabled: wantEnabled,
+		BootSourceOverrideEnabled: schemas.OnceBootSourceOverrideEnabled,
 		BootSourceOverrideTarget:  schemas.PxeBootSource,
 	}
 	// TODO: cover setting BootSourceOverrideMode with BIOS settings profile
-	// Only set BootSourceOverrideMode when the BMC reports it; older BMCs that
-	// don't expose it will reject the field.
 	if system.Boot.BootSourceOverrideMode != "" && system.Boot.BootSourceOverrideMode != schemas.UEFIBootSourceOverrideMode {
 		setBoot.BootSourceOverrideMode = schemas.UEFIBootSourceOverrideMode
 	}
 
 	// TODO: pass logging context from caller
 	log := ctrl.LoggerFrom(ctx)
-	log.V(2).Info("Setting boot override", "SystemURI", systemURI, "Boot settings", setBoot)
+	log.V(2).Info("Setting PXE boot once", "SystemURI", systemURI, "Boot settings", setBoot)
 	if err := system.SetBoot(&setBoot); err != nil {
-		return fmt.Errorf("failed to set boot override: %w", err)
-	}
-	return nil
-}
-
-// ClearBootOverride disables any active Redfish boot source override so the
-// system uses its persistent boot order on the next power-on. No SetBoot call
-// is issued when the override is already disabled.
-func (r *RedfishBaseBMC) ClearBootOverride(ctx context.Context, systemURI string) error {
-	system, err := r.getSystemFromUri(ctx, systemURI)
-	if err != nil {
-		return fmt.Errorf("failed to get systems: %w", err)
-	}
-	if system.Boot.BootSourceOverrideEnabled == "" ||
-		system.Boot.BootSourceOverrideEnabled == schemas.DisabledBootSourceOverrideEnabled {
-		return nil
-	}
-
-	setBoot := clearedBootOverride
-	log := ctrl.LoggerFrom(ctx)
-	log.V(2).Info("Clearing boot override", "SystemURI", systemURI, "Boot settings", setBoot)
-	if err := system.SetBoot(&setBoot); err != nil {
-		return fmt.Errorf("failed to clear boot override: %w", err)
+		return fmt.Errorf("failed to set the boot order: %w", err)
 	}
 	return nil
 }

--- a/bmc/redfish_hpe.go
+++ b/bmc/redfish_hpe.go
@@ -20,36 +20,6 @@ type HPERedfishBMC struct {
 	*RedfishBaseBMC
 }
 
-// hpeClearedBootOverride disables the boot override using Pxe as the target.
-var hpeClearedBootOverride = schemas.Boot{
-	BootSourceOverrideEnabled: schemas.DisabledBootSourceOverrideEnabled,
-	// HPE iLO rejects setting BootSourceOverrideEnabled while the target is
-	// unset/None. The target is irrelevant once Disabled, so keep Pxe to satisfy
-	// iLO's ordering requirement.
-	BootSourceOverrideTarget: schemas.PxeBootSource,
-}
-
-// ClearBootOverride overrides the base implementation because HPE iLO rejects a
-// PATCH that sets BootSourceOverrideEnabled while BootSourceOverrideTarget is
-// None or unset ("BootSourceOverrideEnabled cannot be set before
-// BootSourceOverrideTarget is set"). Disable the override with Pxe as the
-// target, which iLO accepts.
-func (r *HPERedfishBMC) ClearBootOverride(ctx context.Context, systemURI string) error {
-	system, err := r.getSystemFromUri(ctx, systemURI)
-	if err != nil {
-		return fmt.Errorf("failed to get systems: %w", err)
-	}
-	if system.Boot.BootSourceOverrideEnabled == "" ||
-		system.Boot.BootSourceOverrideEnabled == schemas.DisabledBootSourceOverrideEnabled {
-		return nil
-	}
-
-	if err := system.SetBoot(&hpeClearedBootOverride); err != nil {
-		return fmt.Errorf("failed to clear boot override: %w", err)
-	}
-	return nil
-}
-
 // --- BMC interface method overrides ---
 
 func (r *HPERedfishBMC) GetBMCAttributeValues(ctx context.Context, req GetBMCAttributeValuesRequest) (schemas.SettingsAttributes, error) {

--- a/bmc/redfish_local.go
+++ b/bmc/redfish_local.go
@@ -261,16 +261,14 @@ func (r *RedfishLocalBMC) CheckBMCPendingComponentUpgrade(_ context.Context, _ C
 	return false, nil
 }
 
-// SetBootOverride sets the network-boot override and, for one-shot overrides
-// only, simulates probe registration by posting dummy network data to the
-// configured registryURL in a background goroutine. The persistent override
-// path skips the registration simulation since maintenance flows do not go
-// through discovery.
-func (r *RedfishLocalBMC) SetBootOverride(ctx context.Context, systemURI string, persistent bool) error {
-	if err := r.RedfishBaseBMC.SetBootOverride(ctx, systemURI, persistent); err != nil {
+// SetBootOverride sets the boot device for the next system boot using Redfish.
+// When a registryURL is configured, it additionally simulates probe registration
+// by posting dummy network data to the registry in a background goroutine.
+func (r *RedfishLocalBMC) SetBootOverride(ctx context.Context, systemURI string) error {
+	if err := r.RedfishBaseBMC.SetBootOverride(ctx, systemURI); err != nil {
 		return err
 	}
-	if persistent || r.registryURL == "" {
+	if r.registryURL == "" {
 		return nil
 	}
 	go func() {

--- a/bmc/redfish_supermicro.go
+++ b/bmc/redfish_supermicro.go
@@ -16,29 +16,19 @@ type SupermicroRedfishBMC struct {
 	*RedfishBaseBMC
 }
 
-// SetBootOverride sets a network-boot override on Supermicro hardware. Newer
-// Supermicro BMCs require BootSourceOverrideMode=UEFI to be sent explicitly for
-// the override to take effect; older boards (e.g. X10-series with Redfish
-// ComputerSystem v1_3_0) don't expose the property at all and reject the whole
-// PATCH when it's included.
-func (r *SupermicroRedfishBMC) SetBootOverride(ctx context.Context, systemURI string, persistent bool) error {
+// SetBootOverride sets the boot device to network boot for the next system boot
+// on Supermicro hardware. Newer Supermicro BMCs require BootSourceOverrideMode=UEFI
+// to be sent explicitly for the override to take effect; older boards (e.g.
+// X10-series with Redfish ComputerSystem v1_3_0) don't expose the property at
+// all and reject the whole PATCH when it's included.
+func (r *SupermicroRedfishBMC) SetBootOverride(ctx context.Context, systemURI string) error {
 	system, err := r.getSystemFromUri(ctx, systemURI)
 	if err != nil {
 		return fmt.Errorf("failed to get systems: %w", err)
 	}
-	wantEnabled := schemas.OnceBootSourceOverrideEnabled
-	if persistent {
-		wantEnabled = schemas.ContinuousBootSourceOverrideEnabled
-		if system.Boot.BootSourceOverrideEnabled == schemas.ContinuousBootSourceOverrideEnabled &&
-			system.Boot.BootSourceOverrideTarget == schemas.PxeBootSource &&
-			(system.Boot.BootSourceOverrideMode == "" ||
-				system.Boot.BootSourceOverrideMode == schemas.UEFIBootSourceOverrideMode) {
-			return nil
-		}
-	}
 
 	setBoot := &schemas.Boot{
-		BootSourceOverrideEnabled: wantEnabled,
+		BootSourceOverrideEnabled: schemas.OnceBootSourceOverrideEnabled,
 		BootSourceOverrideTarget:  schemas.PxeBootSource,
 	}
 	if system.Boot.BootSourceOverrideMode != "" {
@@ -46,9 +36,9 @@ func (r *SupermicroRedfishBMC) SetBootOverride(ctx context.Context, systemURI st
 	}
 
 	log := ctrl.LoggerFrom(ctx)
-	log.V(2).Info("Setting boot override (Supermicro)", "SystemURI", systemURI, "Boot settings", setBoot)
+	log.V(2).Info("Setting PXE boot once (Supermicro)", "SystemURI", systemURI, "Boot settings", setBoot)
 	if err := system.SetBoot(setBoot); err != nil {
-		return fmt.Errorf("failed to set boot override: %w", err)
+		return fmt.Errorf("failed to set the boot order: %w", err)
 	}
 	return nil
 }

--- a/bmc/redfish_supermicro_test.go
+++ b/bmc/redfish_supermicro_test.go
@@ -81,7 +81,7 @@ var _ = Describe("SupermicroRedfishBMC SetBootOverride", func() {
 		defer server.Close()
 
 		bmc := newTestSupermicroBMC(server)
-		Expect(bmc.SetBootOverride(ctx, systemURI, false)).To(Succeed())
+		Expect(bmc.SetBootOverride(ctx, systemURI)).To(Succeed())
 
 		mu.Lock()
 		body := append(json.RawMessage(nil), *patched...)
@@ -111,7 +111,7 @@ var _ = Describe("SupermicroRedfishBMC SetBootOverride", func() {
 		defer server.Close()
 
 		bmc := newTestSupermicroBMC(server)
-		Expect(bmc.SetBootOverride(ctx, systemURI, true)).To(Succeed())
+		Expect(bmc.SetBootOverride(ctx, systemURI)).To(Succeed())
 
 		mu.Lock()
 		body := append(json.RawMessage(nil), *patched...)
@@ -123,96 +123,7 @@ var _ = Describe("SupermicroRedfishBMC SetBootOverride", func() {
 		}
 		Expect(json.Unmarshal(body, &typed)).To(Succeed())
 		Expect(typed.Boot.BootSourceOverrideMode).To(Equal(schemas.UEFIBootSourceOverrideMode))
-		Expect(typed.Boot.BootSourceOverrideEnabled).To(Equal(schemas.ContinuousBootSourceOverrideEnabled))
+		Expect(typed.Boot.BootSourceOverrideEnabled).To(Equal(schemas.OnceBootSourceOverrideEnabled))
 		Expect(typed.Boot.BootSourceOverrideTarget).To(Equal(schemas.PxeBootSource))
-	})
-
-	It("should no-op when the persistent override is already in the desired state", func(ctx SpecContext) {
-		var patchCount int
-		var mu sync.Mutex
-		mux := http.NewServeMux()
-		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(serviceRootJSON()) //nolint:errcheck
-		})
-		mux.HandleFunc("/redfish/v1/Systems/1", func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPatch {
-				mu.Lock()
-				patchCount++
-				mu.Unlock()
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-			// Already-persistent PXE + UEFI Continuous.
-			sys := map[string]any{
-				"@odata.id":   "/redfish/v1/Systems/1",
-				"@odata.type": "#ComputerSystem.v1_3_0.ComputerSystem",
-				"Id":          "1",
-				"Name":        "System 1",
-				"UUID":        "00000000-0000-0000-0000-000000000001",
-				"Boot": map[string]any{
-					"BootSourceOverrideEnabled": "Continuous",
-					"BootSourceOverrideTarget":  "Pxe",
-					"BootSourceOverrideMode":    "UEFI",
-				},
-			}
-			b, _ := json.Marshal(sys)
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(b) //nolint:errcheck
-		})
-
-		server := httptest.NewServer(mux)
-		defer server.Close()
-
-		bmc := newTestSupermicroBMC(server)
-		Expect(bmc.SetBootOverride(ctx, systemURI, true)).To(Succeed())
-
-		mu.Lock()
-		defer mu.Unlock()
-		Expect(patchCount).To(Equal(0), "SetBootOverride should not PATCH when the state already matches")
-	})
-
-	It("should no-op when persistent PXE is already configured and the BMC does not report a mode", func(ctx SpecContext) {
-		var patchCount int
-		var mu sync.Mutex
-		mux := http.NewServeMux()
-		mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(serviceRootJSON()) //nolint:errcheck
-		})
-		mux.HandleFunc("/redfish/v1/Systems/1", func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPatch {
-				mu.Lock()
-				patchCount++
-				mu.Unlock()
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-			sys := map[string]any{
-				"@odata.id":   "/redfish/v1/Systems/1",
-				"@odata.type": "#ComputerSystem.v1_3_0.ComputerSystem",
-				"Id":          "1",
-				"Name":        "System 1",
-				"UUID":        "00000000-0000-0000-0000-000000000001",
-				"Boot": map[string]any{
-					"BootSourceOverrideEnabled": "Continuous",
-					"BootSourceOverrideTarget":  "Pxe",
-					// BootSourceOverrideMode intentionally omitted.
-				},
-			}
-			b, _ := json.Marshal(sys)
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(b) //nolint:errcheck
-		})
-
-		server := httptest.NewServer(mux)
-		defer server.Close()
-
-		bmc := newTestSupermicroBMC(server)
-		Expect(bmc.SetBootOverride(ctx, systemURI, true)).To(Succeed())
-
-		mu.Lock()
-		defer mu.Unlock()
-		Expect(patchCount).To(Equal(0), "SetBootOverride should not PATCH on BMCs without BootSourceOverrideMode when Continuous/Pxe is already set")
 	})
 })

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -243,15 +243,6 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 	log.V(1).Info("Ensured finalizer has been added")
 
 	if server.Status.State != metalv1alpha1.ServerStateInitial && server.Spec.ServerMaintenanceRef != nil {
-		// Set the persistent network-boot override once at maintenance entry. A
-		// Continuous override survives reboots, so re-asserting each reconcile is
-		// redundant and races with mid-POST, which Redfish (e.g. HPE iLO) rejects.
-		// It is cleared on exit in handleMaintenanceState.
-		if server.Status.State != metalv1alpha1.ServerStateMaintenance {
-			if err := bmcClient.SetBootOverride(ctx, server.Spec.SystemURI, true); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to set persistent network boot for maintenance: %w", err)
-			}
-		}
 		if modified, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateMaintenance); err != nil || modified {
 			return ctrl.Result{}, err
 		}
@@ -433,12 +424,6 @@ func (r *ServerReconciler) handleDiscoveryState(ctx context.Context, bmcClient b
 
 func (r *ServerReconciler) handleAvailableState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	// Self-heal: drop any boot override that may have been left set by a
-	// previous Maintenance cycle that ended unexpectedly. ClearBootOverride
-	// is a no-op when no override is active.
-	if err := bmcClient.ClearBootOverride(ctx, server.Spec.SystemURI); err != nil {
-		return false, fmt.Errorf("failed to clear boot override: %w", err)
-	}
 	serverBase := server.DeepCopy()
 	if server.Status.PowerState != metalv1alpha1.ServerOffPowerState {
 		server.Spec.Power = metalv1alpha1.PowerOff
@@ -484,12 +469,6 @@ func (r *ServerReconciler) handleAvailableState(ctx context.Context, bmcClient b
 
 func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	// Self-heal: drop any boot override that may have been left set by a
-	// previous Maintenance cycle that ended unexpectedly. ClearBootOverride
-	// is a no-op when no override is active.
-	if err := bmcClient.ClearBootOverride(ctx, server.Spec.SystemURI); err != nil {
-		return false, fmt.Errorf("failed to clear boot override: %w", err)
-	}
 	serverClaimRef := server.Spec.ServerClaimRef
 	if serverClaimRef == nil {
 		if modified, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateAvailable); err != nil || modified {
@@ -648,16 +627,11 @@ func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient
 		if err := r.updateServerStatusFromSystemInfo(ctx, bmcClient, server); err != nil {
 			return false, fmt.Errorf("failed to update server status system info: %w", err)
 		}
-		if err := bmcClient.ClearBootOverride(ctx, server.Spec.SystemURI); err != nil {
-			return false, fmt.Errorf("failed to clear boot override on maintenance exit: %w", err)
-		}
 		if server.Spec.ServerClaimRef == nil {
 			return r.patchServerState(ctx, server, metalv1alpha1.ServerStateInitial)
 		}
 		return r.patchServerState(ctx, server, metalv1alpha1.ServerStateReserved)
 	}
-	// The persistent network-boot override is set once at maintenance entry (in
-	// reconcile) and cleared below on exit; it is not re-asserted here.
 	if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
 		return false, fmt.Errorf("failed to ensure server power state: %w", err)
 	}
@@ -991,7 +965,7 @@ func (r *ServerReconciler) pxeBootServer(ctx context.Context, bmcClient bmc.BMC,
 		return fmt.Errorf("can only PXE boot server with valid BMC ref or inline BMC configuration")
 	}
 
-	if err := bmcClient.SetBootOverride(ctx, server.Spec.SystemURI, false); err != nil {
+	if err := bmcClient.SetBootOverride(ctx, server.Spec.SystemURI); err != nil {
 		return fmt.Errorf("failed to set PXE boot one for server: %w", err)
 	}
 	return nil


### PR DESCRIPTION
# Proposed Changes

The server controller no longer sets a persistent network-boot override on maintenance entry or clears boot overrides on available/reserved/maintenance-exit. `SetBootOverride` collapses back to a single-shot signature and `ClearBootOverride` is removed from the BootController interface and all implementations.

Reverts the persistence feature from #939 and the follow-ups that built on it (#985 persistent no-op, #996 set-once-at-entry, #998 HPE ClearBootOverride).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * PXE boot overrides now apply only to the next power-on.
  * Removed support for persistent boot overrides and explicit override clearing.
  * Maintenance transitions no longer automatically set or clear boot overrides.
  * Local and hardware-specific Redfish implementations now follow the one-time PXE boot behavior.
* **Tests**
  * Updated boot override coverage to verify one-time PXE boot configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->