### PR TITLE
Fix webhook-related races in local dev setup

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -103,6 +103,13 @@ if new_args:
     print("default metal yaml {}\n".format(yaml_metal))
 k8s_yaml(yaml_metal)
 
+k8s_resource('metal-operator-controller-manager')
+k8s_resource(
+    new_name='metal-operator-validating-webhook-configuration',
+    objects=['metal-operator-validating-webhook-configuration'],
+    resource_deps=['metal-operator-controller-manager'],
+)
+
 if settings.get("local_boot_operator") != "":
     local_boot_operator = settings.get("local_boot_operator")
     print("Using local boot-operator from {}".format(local_boot_operator))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -699,6 +699,12 @@ func main() { // nolint: gocyclo
 		setupLog.Error(err, "Failed to set up ready check")
 		os.Exit(1)
 	}
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
+			setupLog.Error(err, "Failed to set up webhook ready check")
+			os.Exit(1)
+		}
+	}
 
 	ctx := ctrl.SetupSignalHandler()
 	if err := controller.RegisterIndexFields(ctx, mgr.GetFieldIndexer()); err != nil {


### PR DESCRIPTION
# Proposed Changes

- Add a dependency to the `ValidatingWebhookConfiguration` that leads to creation only after the operator is ready
- Bind the webhook server's startup to the readiness check of the operator

Fixes #1010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook readiness reporting so deployments expose whether the webhook server is ready.
  * Webhook readiness checks are enabled automatically unless webhooks are explicitly disabled.

* **Bug Fixes**
  * Improved startup validation by stopping initialization when the webhook readiness check cannot be registered.

* **Development Experience**
  * Improved local deployment orchestration so webhook configuration is applied in the correct order relative to the controller manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->