### PR TITLE
Include metaldata in the images published via GHA

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -28,6 +28,8 @@ jobs:
           target: manager
         - name: metalprobe
           target: probe
+        - name: metaldata
+          target: metaldata
     permissions:
       contents: read
       packages: write

--- a/Makefile
+++ b/Makefile
@@ -246,11 +246,13 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${CONTROLLER_IMG}
+	cd config/metaldata && "$(KUSTOMIZE)" edit set image metaldata=${METALDATA_IMG}
 	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" apply -f -
 
 .PHONY: e2e-deploy
 e2e-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${CONTROLLER_IMG}
+	cd config/metaldata && "$(KUSTOMIZE)" edit set image metaldata=${METALDATA_IMG}
 	"$(KUSTOMIZE)" build config/e2e-metrics-validation | "$(KUBECTL)" apply -f -
 
 .PHONY: undeploy


### PR DESCRIPTION
Resolves: https://github.com/ironcore-dev/metal-operator/issues/1008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and publishing the `metaldata` Docker image.
  * Included the new image in the automated Docker release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->