### PR TITLE
Align the go-install-tool in Makefile with upstream kubebuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,15 +397,15 @@ $(YQ): $(LOCALBIN)
 # $2 - package url which can be installed
 # $3 - specific version of package
 define go-install-tool
-@[ -f "$(1)-$(3)" ] || { \
+@[ -f "$(1)-$(3)" ] && [ "$$(readlink -- "$(1)" 2>/dev/null)" = "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
-rm -f "$(1)" || true ;\
+rm -f "$(1)" ;\
 GOBIN="$(LOCALBIN)" go install "$${package}" ;\
-mv "$(1)" "$(1)-$(3)" ;\
+mv "$(LOCALBIN)/$$(basename "$(1)")" "$(1)-$(3)" ;\
 } ;\
-ln -sf "$(1)-$(3)" "$(1)"
+ln -sf "$$(realpath "$(1)-$(3)")" "$(1)"
 endef
 
 ## --------------------------------------


### PR DESCRIPTION
# Proposed Changes

Align the go-install-tool in Makefile with upstream kubebuilder.