### PR TITLE
Add metaldata image build in tilt setup

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -95,6 +95,7 @@ deploy_cert_manager()
 
 docker_build('controller', '.', target = 'manager')
 docker_build('mock-server', '.', target = 'mock-server')
+docker_build('metaldata', '.', target = 'metaldata')
 
 yaml_metal = kustomize('./config/dev')
 new_args = settings.get("new_args").get("metal")


### PR DESCRIPTION
Signed-off-by: simontesar <simon@simontesar.com>

# Proposed Changes

- Build and thus import the `metaldata` image via Tilt

Fixes the already closed #1008 , #1026 did not solve the `make tilt-up` path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building the Metaldata container image through the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->