### PR TITLE
Require BMC-confirmed PowerState=Off before releasing a ServerClaim

### DIFF
--- a/bmc/mock/server/server.go
+++ b/bmc/mock/server/server.go
@@ -158,6 +158,11 @@ type MockServer struct {
 	actionHandlers    []actionHandler       // ordered POST action dispatch table (first match wins)
 	onCreate          map[string]memberHook // collection URL suffix → hook called after a member is added
 	onDelete          map[string]memberHook // collection URL suffix → hook called before a member is removed
+	// stuckPowerState pins the PowerState of a given system path to a specific
+	// value. Subsequent doPowerOff / doPowerOn / doPowerReset invocations on
+	// that path leave PowerState untouched, modelling an unhealthy BMC that
+	// accepts reset commands but never converges to the requested state.
+	stuckPowerState map[string]string
 }
 
 // loadAccountsFromEmbedded seeds the authentication store by reading the
@@ -200,6 +205,7 @@ func NewMockServer(log logr.Logger, addr string, opts ...Option) *MockServer {
 		overrides:         make(map[string]any),
 		upgradedResources: make(map[string]string),
 		accounts:          loadAccountsFromEmbedded(),
+		stuckPowerState:   make(map[string]string),
 		// onCreate hooks run after a new collection member is stored.
 		// Add an entry here to handle side-effects for additional collection types.
 		onCreate: map[string]memberHook{
@@ -839,6 +845,12 @@ func (s *MockServer) doPowerOff(systemPath string) {
 	defer s.mu.Unlock()
 
 	if base, ok := s.overrides[systemPath].(map[string]any); ok {
+		if stuck, pinned := s.stuckPowerState[systemPath]; pinned {
+			base["PowerState"] = stuck
+			s.setLocked(base, false)
+			s.log.Info("Simulated unhealthy BMC ignoring PowerOff", "PowerState", stuck)
+			return
+		}
 		base["PowerState"] = PowerOffState
 		s.setLocked(base, false)
 		s.log.Info("Powered off the system")
@@ -849,6 +861,13 @@ func (s *MockServer) doPowerOn(systemPath, basePath string) {
 	time.Sleep(150 * time.Millisecond)
 	s.mu.Lock()
 	if base, ok := s.overrides[systemPath].(map[string]any); ok {
+		if stuck, pinned := s.stuckPowerState[systemPath]; pinned {
+			base["PowerState"] = stuck
+			s.setLocked(base, false)
+			s.log.Info("Simulated unhealthy BMC ignoring PowerOn", "PowerState", stuck)
+			s.mu.Unlock()
+			return
+		}
 		base["PowerState"] = PowerOnState
 		s.setLocked(base, false)
 		s.log.Info("Powered on the system")
@@ -864,6 +883,13 @@ func (s *MockServer) doPowerReset(systemPath, basePath string) {
 	time.Sleep(150 * time.Millisecond)
 	s.mu.Lock()
 	if base, ok := s.overrides[systemPath].(map[string]any); ok {
+		if stuck, pinned := s.stuckPowerState[systemPath]; pinned {
+			base["PowerState"] = stuck
+			s.setLocked(base, false)
+			s.log.Info("Simulated unhealthy BMC ignoring Reset", "PowerState", stuck)
+			s.mu.Unlock()
+			return
+		}
 		base["PowerState"] = PowerOffState
 		s.log.Info("Powered off the system")
 	}
@@ -882,6 +908,53 @@ func (s *MockServer) doPowerReset(systemPath, basePath string) {
 	if err := s.applyPendingBiosSettings(basePath); err != nil {
 		s.log.Error(err, "Failed to apply pending BIOS settings")
 	}
+}
+
+// ForcePowerState pins the served PowerState of the system at systemPath to
+// powerState and prevents subsequent PowerOff / PowerOn / Reset actions from
+// changing it. Passing an empty powerState removes the pin and resets only
+// PowerState back to the embedded default (other overridden fields are kept),
+// so subsequent power actions behave normally again. Callers do not have to
+// trigger a Redfish read to observe the change.
+//
+// systemPath is the on-disk-style path used by the mock (e.g.
+// "data/Systems/437XR1138R2/index.json").
+//
+// It models an unhealthy BMC that accepts power commands but never converges
+// to the requested state.
+func (s *MockServer) ForcePowerState(systemPath, powerState string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if powerState == "" {
+		delete(s.stuckPowerState, systemPath)
+		// Reset only PowerState back to the embedded default so subsequent
+		// power actions behave normally again, without discarding other
+		// fields a test may have PATCHed into the override.
+		if override, ok := s.overrides[systemPath].(map[string]any); ok {
+			embedded, err := dataFS.ReadFile(systemPath)
+			if err != nil {
+				return fmt.Errorf("ForcePowerState: %w", err)
+			}
+			var base map[string]any
+			if err := json.Unmarshal(embedded, &base); err != nil {
+				return fmt.Errorf("ForcePowerState: %w", err)
+			}
+			override["PowerState"] = base["PowerState"]
+		}
+		s.log.Info("Cleared forced PowerState", "systemPath", systemPath)
+		return nil
+	}
+
+	base, err := s.loadResourceLocked(systemPath)
+	if err != nil {
+		return fmt.Errorf("ForcePowerState: %w", err)
+	}
+	base["PowerState"] = powerState
+	s.overrides[systemPath] = base
+	s.stuckPowerState[systemPath] = powerState
+	s.log.Info("Forced PowerState", "systemPath", systemPath, "PowerState", powerState)
+	return nil
 }
 
 func (s *MockServer) doBMCReset(bmcPath string) {

--- a/bmc/mock/server/server_test.go
+++ b/bmc/mock/server/server_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+const testSystemPath = "data/Systems/437XR1138R2/index.json"
+
+func embeddedPowerState(t *testing.T) string {
+	t.Helper()
+	s := NewMockServer(logr.Discard(), ":0")
+	base, err := s.loadResource(testSystemPath)
+	if err != nil {
+		t.Fatalf("failed to load embedded system resource: %v", err)
+	}
+	ps, _ := base["PowerState"].(string)
+	if ps == "" {
+		t.Fatalf("embedded system resource has no PowerState")
+	}
+	return ps
+}
+
+func TestForcePowerStatePinsAndBlocksPowerActions(t *testing.T) {
+	s := NewMockServer(logr.Discard(), ":0")
+
+	if err := s.ForcePowerState(testSystemPath, "Unknown"); err != nil {
+		t.Fatalf("ForcePowerState: %v", err)
+	}
+
+	base, err := s.loadResource(testSystemPath)
+	if err != nil {
+		t.Fatalf("loadResource: %v", err)
+	}
+	if got := base["PowerState"]; got != "Unknown" {
+		t.Fatalf("PowerState = %v, want Unknown", got)
+	}
+
+	// A PowerOff action must not change the pinned value.
+	s.doPowerOff(testSystemPath)
+	base, err = s.loadResource(testSystemPath)
+	if err != nil {
+		t.Fatalf("loadResource: %v", err)
+	}
+	if got := base["PowerState"]; got != "Unknown" {
+		t.Fatalf("after doPowerOff PowerState = %v, want Unknown (pinned)", got)
+	}
+}
+
+// TestForcePowerStateClearPreservesOtherOverrideFields guards the review
+// finding: clearing the pin must reset only PowerState to the embedded
+// default and must NOT discard other fields a caller PATCHed into the
+// override.
+func TestForcePowerStateClearPreservesOtherOverrideFields(t *testing.T) {
+	s := NewMockServer(logr.Discard(), ":0")
+	want := embeddedPowerState(t)
+
+	// Seed an override that carries a custom field plus a non-default
+	// PowerState, as a PATCH against the system resource would.
+	seeded, err := s.loadResource(testSystemPath)
+	if err != nil {
+		t.Fatalf("loadResource: %v", err)
+	}
+	seeded["PowerState"] = "On"
+	seeded["CustomPatchedField"] = "keep-me"
+	s.saveResource(testSystemPath, seeded)
+
+	// Pin, then release.
+	if err := s.ForcePowerState(testSystemPath, "Unknown"); err != nil {
+		t.Fatalf("ForcePowerState pin: %v", err)
+	}
+	if err := s.ForcePowerState(testSystemPath, ""); err != nil {
+		t.Fatalf("ForcePowerState clear: %v", err)
+	}
+
+	got, err := s.loadResource(testSystemPath)
+	if err != nil {
+		t.Fatalf("loadResource: %v", err)
+	}
+
+	if ps := got["PowerState"]; ps != want {
+		t.Errorf("PowerState after clear = %v, want embedded default %q", ps, want)
+	}
+	if v, ok := got["CustomPatchedField"]; !ok || v != "keep-me" {
+		t.Errorf("CustomPatchedField after clear = %v (present=%v), want \"keep-me\" preserved", v, ok)
+	}
+	if _, pinned := s.stuckPowerState[testSystemPath]; pinned {
+		t.Errorf("stuckPowerState still pinned after clear")
+	}
+
+	// After release a PowerOff action must once again drive PowerState to Off.
+	s.doPowerOff(testSystemPath)
+	got, err = s.loadResource(testSystemPath)
+	if err != nil {
+		t.Fatalf("loadResource: %v", err)
+	}
+	if ps := got["PowerState"]; ps != PowerOffState {
+		t.Errorf("after clear+doPowerOff PowerState = %v, want %q", ps, PowerOffState)
+	}
+}

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -31,6 +31,12 @@ const (
 	ConditionReady = "Ready"
 	// ConditionRetryOfFailedResourceIssued indicates a retry of a failed resource has been issued.
 	ConditionRetryOfFailedResourceIssued = "RetryOfFailedResourceIssued"
+	// ConditionWaitingForPowerOff indicates that the ServerReconciler has
+	// asked the BMC to power the host off but has not yet observed
+	// Status.PowerState=Off. While this condition is present with
+	// Status=True the Server cannot safely be released from its current
+	// ServerClaim.
+	ConditionWaitingForPowerOff = "WaitingForPowerOff"
 )
 
 // Shared reason strings used across multiple controllers.
@@ -79,4 +85,14 @@ const (
 	ReasonMaintenanceApproved = "ServerMaintenanceApproval"
 	// ReasonRetryOfFailedResourceIssued indicates a retry of a failed resource has been issued.
 	ReasonRetryOfFailedResourceIssued = "RetryOfFailedResourceIssued"
+	// ReasonWaitingForPowerOff indicates the Server is waiting for the BMC
+	// to confirm the target Status.PowerState=Off after a PowerOff command
+	// was issued. Emitted when WaitForServerPowerState (or a subsequent
+	// observation) has not yet seen the transition to Off, for example
+	// when the BMC reports "Unknown" indefinitely.
+	ReasonWaitingForPowerOff = "WaitingForPowerOff"
+	// ReasonPowerOffConfirmed marks the terminal state of the
+	// WaitingForPowerOff condition once the BMC has confirmed
+	// Status.PowerState=Off.
+	ReasonPowerOffConfirmed = "PowerOffConfirmed"
 )

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -492,6 +492,16 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bm
 			return modified, err
 		}
 
+		// Do not release the Server until the BMC has confirmed PowerState=Off.
+		// Releasing before confirmation would hand an unproven-off host to the
+		// next tenant (Recycle) or expose it for manual reclaim (Retain).
+		if server.Status.PowerState != metalv1alpha1.ServerOffPowerState {
+			return false, fmt.Errorf(
+				"cannot reclaim ServerClaim %s: BMC has not confirmed PowerState=Off (current: %q)",
+				claimKey, server.Status.PowerState,
+			)
+		}
+
 		switch server.Spec.ReclaimPolicy {
 		case metalv1alpha1.ServerReclaimPolicyRetain:
 			log.V(1).Info("Transitioning server to released state")
@@ -534,7 +544,12 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bm
 }
 
 func (r *ServerReconciler) ensureServerPoweredOffWithoutBootConfig(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (modified bool, err error) {
-	if server.Spec.Power == metalv1alpha1.PowerOff && server.Spec.BootConfigurationRef == nil {
+	// Short-circuit only once the spec is settled AND the BMC has confirmed
+	// PowerState=Off. Trusting Spec.Power alone can release a Server whose
+	// host never actually powered down (e.g. BMC stuck at Unknown).
+	if server.Spec.Power == metalv1alpha1.PowerOff &&
+		server.Spec.BootConfigurationRef == nil &&
+		server.Status.PowerState == metalv1alpha1.ServerOffPowerState {
 		return false, nil
 	}
 

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -433,9 +433,21 @@ func (r *ServerReconciler) handleAvailableState(ctx context.Context, bmcClient b
 		log.V(1).Info("Updated Server power state", "PowerState", metalv1alpha1.PowerOff)
 
 		if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
+			// PowerOff was issued but the BMC has not confirmed
+			// PowerState=Off within the polling timeout. Record the wait as
+			// a condition so it is visible via kubectl describe server, then
+			// return the error to requeue with backoff.
+			if condErr := r.setWaitingForPowerOffCondition(ctx, server, err); condErr != nil {
+				log.V(1).Info("Failed to set WaitingForPowerOff condition", "error", condErr)
+			}
 			return false, fmt.Errorf("failed to ensure server power state: %w", err)
 		}
 		log.V(1).Info("Server state set to power off")
+	}
+	// PowerOff confirmed (or already confirmed on entry): clear any prior
+	// WaitingForPowerOff condition.
+	if err := r.clearWaitingForPowerOffCondition(ctx, server); err != nil {
+		log.V(1).Info("Failed to clear WaitingForPowerOff condition", "error", err)
 	}
 
 	if err := r.ensureInitialBootConfigurationIsDeleted(ctx, server); err != nil {
@@ -488,18 +500,20 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bm
 			return false, fmt.Errorf("getting server claim %s: %w", claimKey, err)
 		}
 
-		if modified, err := r.ensureServerPoweredOffWithoutBootConfig(ctx, bmcClient, server); err != nil || modified {
-			return modified, err
+		// Safety: do not release the Server (Recycle) or move it to
+		// Released (Retain) until the BMC has confirmed PowerState=Off.
+		// ensureServerPoweredOffObserved issues an idempotent PowerOff and
+		// reports whether the BMC has confirmed the target state; it never
+		// blocks waiting for confirmation.
+		readyForRelease, err := r.ensureServerPoweredOffObserved(ctx, bmcClient, server)
+		if err != nil {
+			return false, err
 		}
-
-		// Do not release the Server until the BMC has confirmed PowerState=Off.
-		// Releasing before confirmation would hand an unproven-off host to the
-		// next tenant (Recycle) or expose it for manual reclaim (Retain).
-		if server.Status.PowerState != metalv1alpha1.ServerOffPowerState {
-			return false, fmt.Errorf(
-				"cannot reclaim ServerClaim %s: BMC has not confirmed PowerState=Off (current: %q)",
-				claimKey, server.Status.PowerState,
-			)
+		if !readyForRelease {
+			// The WaitingForPowerOff condition is set by the helper. Return
+			// without an error so controller-runtime requeues on the normal
+			// ResyncInterval cadence rather than hot-looping on backoff.
+			return true, nil
 		}
 
 		switch server.Spec.ReclaimPolicy {
@@ -512,6 +526,9 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bm
 			server.Spec.ServerClaimRef = nil
 			if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
 				return false, fmt.Errorf("failed to remove ServerClaimRef: %w", err)
+			}
+			if err := r.clearWaitingForPowerOffCondition(ctx, server); err != nil {
+				log.V(1).Info("Failed to clear WaitingForPowerOff condition", "error", err)
 			}
 			return false, nil
 		default:
@@ -543,35 +560,61 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bm
 	return true, nil
 }
 
-func (r *ServerReconciler) ensureServerPoweredOffWithoutBootConfig(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (modified bool, err error) {
-	// Short-circuit only once the spec is settled AND the BMC has confirmed
-	// PowerState=Off. Trusting Spec.Power alone can release a Server whose
-	// host never actually powered down (e.g. BMC stuck at Unknown).
-	if server.Spec.Power == metalv1alpha1.PowerOff &&
-		server.Spec.BootConfigurationRef == nil &&
-		server.Status.PowerState == metalv1alpha1.ServerOffPowerState {
-		return false, nil
+// ensureServerPoweredOffObserved ensures Spec.Power=PowerOff and
+// Spec.BootConfigurationRef=nil, then reports whether the BMC has confirmed
+// Status.PowerState=Off.
+//
+// It never blocks in WaitForServerPowerState: the observed power state is
+// re-read from the BMC by updateServerStatus at the top of every reconcile,
+// so this only issues an idempotent PowerOff command and returns. When the
+// observed state is not yet Off the WaitingForPowerOff condition is set and
+// the caller must not release the ServerClaim; the next resync re-evaluates.
+func (r *ServerReconciler) ensureServerPoweredOffObserved(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (readyForRelease bool, err error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	if server.Spec.Power != metalv1alpha1.PowerOff || server.Spec.BootConfigurationRef != nil {
+		base := server.DeepCopy()
+		server.Spec.Power = metalv1alpha1.PowerOff
+		server.Spec.BootConfigurationRef = nil
+		if err := r.Patch(ctx, server, client.MergeFrom(base)); err != nil {
+			return false, fmt.Errorf("failed to patch spec.power / spec.bootConfigurationRef: %w", err)
+		}
+		log.V(1).Info("Requested PowerOff and cleared BootConfigurationRef")
 	}
 
-	log := ctrl.LoggerFrom(ctx)
-	log.V(1).Info("Server claim is gone, powering off server and removing boot configuration")
-	base := server.DeepCopy()
-	server.Spec.Power = metalv1alpha1.PowerOff
-	server.Spec.BootConfigurationRef = nil
-	if err := r.Patch(ctx, server, client.MergeFrom(base)); err != nil {
-		return false, fmt.Errorf("failed to update server power state: %w", err)
+	if server.Status.PowerState == metalv1alpha1.ServerOffPowerState {
+		if err := r.clearWaitingForPowerOffCondition(ctx, server); err != nil {
+			log.V(1).Info("Failed to clear WaitingForPowerOff condition", "error", err)
+		}
+		return true, nil
 	}
-	if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
-		return true, fmt.Errorf("failed to power off server after claim deletion: %w", err)
+
+	// Issue an idempotent PowerOff but do NOT block waiting for confirmation;
+	// blocking would hold a controller worker for up to PowerPollingTimeout on
+	// an unhealthy BMC. The next reconcile refreshes Status.PowerState via
+	// updateServerStatus and we re-evaluate.
+	if err := bmcClient.PowerOff(ctx, server.Spec.SystemURI); err != nil {
+		return false, fmt.Errorf("failed to issue PowerOff to BMC: %w", err)
 	}
-	return true, nil
+	waitErr := fmt.Errorf(
+		"BMC has not confirmed PowerState=Off; current PowerState=%q",
+		server.Status.PowerState,
+	)
+	if condErr := r.setWaitingForPowerOffCondition(ctx, server, waitErr); condErr != nil {
+		log.V(1).Info("Failed to set WaitingForPowerOff condition", "error", condErr)
+	}
+	return false, nil
 }
 
 func (r *ServerReconciler) handleReleasedState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if modified, err := r.ensureServerPoweredOffWithoutBootConfig(ctx, bmcClient, server); err != nil || modified {
-		return modified, err
+	readyForRelease, err := r.ensureServerPoweredOffObserved(ctx, bmcClient, server)
+	if err != nil {
+		return false, err
+	}
+	if !readyForRelease {
+		return true, nil
 	}
 
 	if serverClaimRef := server.Spec.ServerClaimRef; serverClaimRef != nil {
@@ -1204,6 +1247,61 @@ func (r *ServerReconciler) updatePowerOnCondition(ctx context.Context, server *m
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update powering on condition: %w", err)
+	}
+	return r.Status().Patch(ctx, server, client.MergeFrom(original))
+}
+
+// setWaitingForPowerOffCondition records on the Server that the reconciler
+// has asked the BMC to power the host off but has not yet observed
+// Status.PowerState=Off. Presence with Status=True means "waiting"; absence
+// or Status=False means "not waiting". This makes the wait visible via
+// kubectl describe server so an operator can distinguish an unhealthy BMC
+// from a wedged controller.
+func (r *ServerReconciler) setWaitingForPowerOffCondition(ctx context.Context, server *metalv1alpha1.Server, cause error) error {
+	original := server.DeepCopy()
+	msg := fmt.Sprintf(
+		"Waiting for BMC to confirm PowerState=Off; current PowerState=%q: %v",
+		server.Status.PowerState, cause,
+	)
+	if err := r.Conditions.UpdateSlice(
+		&server.Status.Conditions,
+		ConditionWaitingForPowerOff,
+		conditionutils.UpdateStatus(metav1.ConditionTrue),
+		conditionutils.UpdateReason(ReasonWaitingForPowerOff),
+		conditionutils.UpdateMessage(msg),
+		conditionutils.UpdateObserved(server),
+	); err != nil {
+		return fmt.Errorf("failed to update WaitingForPowerOff condition: %w", err)
+	}
+	return r.Status().Patch(ctx, server, client.MergeFrom(original))
+}
+
+// clearWaitingForPowerOffCondition flips the WaitingForPowerOff condition to
+// Status=False with reason=PowerOffConfirmed once the BMC has confirmed
+// PowerState=Off. It is a no-op when no such condition was previously set
+// on this Server, so this helper does not stamp the condition onto Servers
+// that never experienced a wait.
+func (r *ServerReconciler) clearWaitingForPowerOffCondition(ctx context.Context, server *metalv1alpha1.Server) error {
+	found := false
+	for _, c := range server.Status.Conditions {
+		if c.Type == ConditionWaitingForPowerOff {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+	original := server.DeepCopy()
+	if err := r.Conditions.UpdateSlice(
+		&server.Status.Conditions,
+		ConditionWaitingForPowerOff,
+		conditionutils.UpdateStatus(metav1.ConditionFalse),
+		conditionutils.UpdateReason(ReasonPowerOffConfirmed),
+		conditionutils.UpdateMessage("BMC confirmed PowerState=Off"),
+		conditionutils.UpdateObserved(server),
+	); err != nil {
+		return fmt.Errorf("failed to clear WaitingForPowerOff condition: %w", err)
 	}
 	return r.Status().Patch(ctx, server, client.MergeFrom(original))
 }

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -880,12 +880,17 @@ var _ = Describe("Server Controller", func() {
 			server.Status.PowerState = metalv1alpha1.ServerOffPowerState
 		})).Should(Succeed())
 
+		// Snapshot A: what the maintenance controller would see right
+		// before calling updateServerRef. It carries the stale claim ref
+		// that will shortly be cleared by the ServerReconciler.
 		maintenanceView := &metalv1alpha1.Server{}
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(server), maintenanceView)).To(Succeed())
 		Expect(maintenanceView.Spec.ServerClaimRef).NotTo(BeNil(),
 			"pre-condition: the maintenance controller observes the stale ref before it's cleared")
 
 		By("ServerReconciler.handleReservedState clears the stale serverClaimRef (Recycle branch)")
+		// server_controller.go:501-505 does exactly this on Recycle when
+		// the referenced ServerClaim is NotFound.
 		Eventually(Update(server, func() {
 			server.Spec.ServerClaimRef = nil
 		})).Should(Succeed())
@@ -895,6 +900,9 @@ var _ = Describe("Server Controller", func() {
 		Expect(fresh.Spec.ServerClaimRef).To(BeNil())
 
 		By("ServerMaintenanceReconciler.updateServerRef fires with its stale in-memory snapshot")
+		// servermaintenance_controller.go:338-345: mutate the in-memory
+		// Server (set ServerMaintenanceRef) and call r.Update. The
+		// snapshot still carries the stale ServerClaimRef from Snapshot A.
 		maintenanceView.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{
 			Namespace: ns.Name,
 			Name:      "some-maintenance",
@@ -903,7 +911,7 @@ var _ = Describe("Server Controller", func() {
 
 		By("The stale Update must be rejected by optimistic concurrency")
 		Expect(err).To(HaveOccurred(),
-			"BUG: full-object Update on stale snapshot silently succeeded; the stale ServerClaimRef has now been restored on the API server")
+			"BUG: full-object Update on stale snapshot silently succeeded; the stale ServerClaimRef has now been restored on the API server, reproducing the production stuck state")
 		Expect(apierrors.IsConflict(err)).To(BeTrue(),
 			"expected a Conflict error, got: %v", err)
 
@@ -916,12 +924,16 @@ var _ = Describe("Server Controller", func() {
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 	})
 
-	// Before this fix, ensureServerPoweredOffWithoutBootConfig short-circuited
-	// on Spec.Power=Off alone without checking the observed Status.PowerState.
-	// A Server could therefore be released even if the BMC never confirmed the
-	// host was off. These specs assert the corrected behaviour: the ServerClaim
-	// sticks until Status.PowerState=Off is observed.
-	It("should not release a Recycle Server while the BMC has not confirmed PowerState=Off", func(ctx SpecContext) {
+	// When the BMC cannot confirm PowerState=Off (e.g. it reports "Unknown"
+	// indefinitely), a claimed Server stays bound to a host we cannot prove is
+	// powered down. This test asserts the two invariants the fix upholds:
+	//   1. While the BMC has not confirmed PowerState=Off, the Server carries a
+	//      WaitingForPowerOff condition and its serverClaimRef stays set.
+	//   2. Once the BMC confirms Off, the Server self-heals: serverClaimRef is
+	//      cleared, state returns to Available, and a fresh ServerClaim binds.
+	// The wedge is reproduced by pinning the mock Redfish PowerState via
+	// MockServer.ForcePowerState.
+	It("should surface a WaitingForPowerOff condition when the BMC cannot confirm PowerState=Off, and self-heal once it can", func(ctx SpecContext) {
 		By("Creating a BMCSecret and Server (default Recycle policy)")
 		bmcSecret := &metalv1alpha1.BMCSecret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -976,26 +988,45 @@ var _ = Describe("Server Controller", func() {
 			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
 		))
 
-		By("Pinning the BMC at PowerState=Unknown and deleting claim A")
+		By("Simulating a post-maintenance BMC stuck at PowerState=Unknown")
+		// The mock's data path for the default system:
 		const systemPath = "data/Systems/437XR1138R2/index.json"
+		// Pin the served PowerState so that neither a real PowerOff nor any
+		// subsequent read can flip the value to Off. Any subsequent doPowerOff
+		// becomes a no-op — modelling the unhealthy iLO seen on node002/005-bb088.
 		Expect(mockServers[0].ForcePowerState(systemPath, "Unknown")).To(Succeed())
-		DeferCleanup(func() { _ = mockServers[0].ForcePowerState(systemPath, "") })
+		DeferCleanup(func() {
+			// Belt-and-braces: make sure the pin is released even if the test
+			// fails partway through, so other specs get a healthy mock again.
+			_ = mockServers[0].ForcePowerState(systemPath, "")
+		})
+
+		By("Deleting claim A while the BMC is stuck")
 		Expect(k8sClient.Delete(ctx, claimA)).To(Succeed())
 		Eventually(Get(claimA)).Should(Satisfy(apierrors.IsNotFound))
 
-		By("The serverClaimRef must stick while the BMC cannot confirm PowerState=Off")
-		Consistently(Object(srv)).Should(HaveField("Spec.ServerClaimRef", Not(BeNil())))
+		By("The Server must surface a WaitingForPowerOff condition")
+		Eventually(Object(srv)).Should(HaveField("Status.Conditions",
+			ContainElement(SatisfyAll(
+				HaveField("Type", ConditionWaitingForPowerOff),
+				HaveField("Status", metav1.ConditionTrue),
+				HaveField("Reason", ReasonWaitingForPowerOff),
+			))))
 
-		By("Releasing the stuck BMC")
+		By("The stale serverClaimRef must stick while the BMC cannot confirm PowerState=Off")
+		Consistently(Object(srv)).Should(
+			HaveField("Spec.ServerClaimRef", Not(BeNil())))
+
+		By("Releasing the stuck BMC — it now behaves normally")
 		Expect(mockServers[0].ForcePowerState(systemPath, "")).To(Succeed())
 
-		By("The Server self-heals: serverClaimRef cleared and state returns to Available")
+		By("The Server self-heals: serverClaimRef is cleared and state returns to Available")
 		Eventually(Object(srv)).Should(SatisfyAll(
 			HaveField("Spec.ServerClaimRef", BeNil()),
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 		))
 
-		By("A fresh ServerClaim binds the Server")
+		By("A fresh ServerClaim binds the Server without human intervention")
 		claimB := &metalv1alpha1.ServerClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    ns.Name,
@@ -1078,10 +1109,15 @@ var _ = Describe("Server Controller", func() {
 		Eventually(Get(claim)).Should(Satisfy(apierrors.IsNotFound))
 
 		By("The Server must not reach Released while power-off is unconfirmed")
+		Eventually(Object(srv)).Should(HaveField("Status.Conditions",
+			ContainElement(SatisfyAll(
+				HaveField("Type", ConditionWaitingForPowerOff),
+				HaveField("Status", metav1.ConditionTrue),
+			))))
 		Consistently(Object(srv)).Should(
 			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateReleased))))
 
-		By("Once the BMC confirms Off, the Server moves to Released")
+		By("Once the BMC confirms Off, the Server moves to Released (Retain keeps the ref)")
 		Expect(mockServers[0].ForcePowerState(systemPath, "")).To(Succeed())
 		Eventually(Object(srv)).Should(HaveField("Status.State", metalv1alpha1.ServerStateReleased))
 

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -828,6 +828,268 @@ var _ = Describe("Server Controller", func() {
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 	})
 
+	// Regression guard: ServerMaintenanceReconciler.updateServerRef issues a
+	// full-object Update on a possibly-stale Server snapshot. Kubernetes
+	// optimistic concurrency (ResourceVersion) must reject such an Update so a
+	// stale serverClaimRef cannot be restored after the ServerReconciler has
+	// cleared it. This test fails if updateServerRef is ever changed to bypass
+	// optimistic concurrency.
+	It("must not let ServerMaintenance restore a stale serverClaimRef via a full-object Update", func(ctx SpecContext) {
+		By("Creating a BMCSecret and a Server (ignore-reconciliation keeps the manager out)")
+		bmcSecret := &metalv1alpha1.BMCSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-server-",
+			},
+			Data: map[string][]byte{
+				"username": []byte("foo"),
+				"password": []byte("bar"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "server-",
+				Annotations: map[string]string{
+					metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationIgnore,
+				},
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "38947555-7742-3448-3784-823347823834",
+				BMC: &metalv1alpha1.BMCAccess{
+					Protocol: metalv1alpha1.Protocol{
+						Name: metalv1alpha1.ProtocolRedfishLocal,
+						Port: MockServerPort,
+					},
+					Address: MockServerIP,
+					BMCSecretRef: v1.LocalObjectReference{
+						Name: bmcSecret.Name,
+					},
+				},
+				ServerClaimRef: &metalv1alpha1.ImmutableObjectReference{
+					Namespace: ns.Name,
+					Name:      "hana-claim",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+
+		By("Bringing the Server to Reserved with the stale claim ref (post-maintenance shape)")
+		Eventually(UpdateStatus(server, func() {
+			server.Status.State = metalv1alpha1.ServerStateReserved
+			server.Status.PowerState = metalv1alpha1.ServerOffPowerState
+		})).Should(Succeed())
+
+		maintenanceView := &metalv1alpha1.Server{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(server), maintenanceView)).To(Succeed())
+		Expect(maintenanceView.Spec.ServerClaimRef).NotTo(BeNil(),
+			"pre-condition: the maintenance controller observes the stale ref before it's cleared")
+
+		By("ServerReconciler.handleReservedState clears the stale serverClaimRef (Recycle branch)")
+		Eventually(Update(server, func() {
+			server.Spec.ServerClaimRef = nil
+		})).Should(Succeed())
+
+		fresh := &metalv1alpha1.Server{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(server), fresh)).To(Succeed())
+		Expect(fresh.Spec.ServerClaimRef).To(BeNil())
+
+		By("ServerMaintenanceReconciler.updateServerRef fires with its stale in-memory snapshot")
+		maintenanceView.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{
+			Namespace: ns.Name,
+			Name:      "some-maintenance",
+		}
+		err := k8sClient.Update(ctx, maintenanceView)
+
+		By("The stale Update must be rejected by optimistic concurrency")
+		Expect(err).To(HaveOccurred(),
+			"BUG: full-object Update on stale snapshot silently succeeded; the stale ServerClaimRef has now been restored on the API server")
+		Expect(apierrors.IsConflict(err)).To(BeTrue(),
+			"expected a Conflict error, got: %v", err)
+
+		By("The API server still shows serverClaimRef=nil")
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(server), fresh)).To(Succeed())
+		Expect(fresh.Spec.ServerClaimRef).To(BeNil())
+
+		// cleanup
+		Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+	})
+
+	// Before this fix, ensureServerPoweredOffWithoutBootConfig short-circuited
+	// on Spec.Power=Off alone without checking the observed Status.PowerState.
+	// A Server could therefore be released even if the BMC never confirmed the
+	// host was off. These specs assert the corrected behaviour: the ServerClaim
+	// sticks until Status.PowerState=Off is observed.
+	It("should not release a Recycle Server while the BMC has not confirmed PowerState=Off", func(ctx SpecContext) {
+		By("Creating a BMCSecret and Server (default Recycle policy)")
+		bmcSecret := &metalv1alpha1.BMCSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-server-",
+			},
+			Data: map[string][]byte{
+				"username": []byte("foo"),
+				"password": []byte("bar"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+		srv := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "server-",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "38947555-7742-3448-3784-823347823834",
+				BMC: &metalv1alpha1.BMCAccess{
+					Protocol: metalv1alpha1.Protocol{
+						Name: metalv1alpha1.ProtocolRedfishLocal,
+						Port: MockServerPort,
+					},
+					Address: MockServerIP,
+					BMCSecretRef: v1.LocalObjectReference{
+						Name: bmcSecret.Name,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, srv)).To(Succeed())
+
+		By("Driving the Server to Available and binding claim A")
+		Eventually(UpdateStatus(srv, func() {
+			srv.Status.State = metalv1alpha1.ServerStateAvailable
+		})).Should(Succeed())
+		claimA := &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "claim-a-",
+			},
+			Spec: metalv1alpha1.ServerClaimSpec{
+				ServerRef: &v1.LocalObjectReference{Name: srv.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, claimA)).To(Succeed())
+		Eventually(Object(srv)).Should(SatisfyAll(
+			HaveField("Spec.ServerClaimRef", Equal(&metalv1alpha1.ImmutableObjectReference{
+				Namespace: claimA.Namespace,
+				Name:      claimA.Name,
+			})),
+			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
+		))
+
+		By("Pinning the BMC at PowerState=Unknown and deleting claim A")
+		const systemPath = "data/Systems/437XR1138R2/index.json"
+		Expect(mockServers[0].ForcePowerState(systemPath, "Unknown")).To(Succeed())
+		DeferCleanup(func() { _ = mockServers[0].ForcePowerState(systemPath, "") })
+		Expect(k8sClient.Delete(ctx, claimA)).To(Succeed())
+		Eventually(Get(claimA)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("The serverClaimRef must stick while the BMC cannot confirm PowerState=Off")
+		Consistently(Object(srv)).Should(HaveField("Spec.ServerClaimRef", Not(BeNil())))
+
+		By("Releasing the stuck BMC")
+		Expect(mockServers[0].ForcePowerState(systemPath, "")).To(Succeed())
+
+		By("The Server self-heals: serverClaimRef cleared and state returns to Available")
+		Eventually(Object(srv)).Should(SatisfyAll(
+			HaveField("Spec.ServerClaimRef", BeNil()),
+			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
+		))
+
+		By("A fresh ServerClaim binds the Server")
+		claimB := &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "claim-b-",
+			},
+			Spec: metalv1alpha1.ServerClaimSpec{
+				ServerRef: &v1.LocalObjectReference{Name: srv.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, claimB)).To(Succeed())
+		Eventually(Object(srv)).Should(SatisfyAll(
+			HaveField("Spec.ServerClaimRef", Equal(&metalv1alpha1.ImmutableObjectReference{
+				Namespace: claimB.Namespace,
+				Name:      claimB.Name,
+			})),
+			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
+		))
+
+		// cleanup
+		Expect(k8sClient.Delete(ctx, claimB)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, srv)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+	})
+
+	It("should not move a Retain Server to Released until the BMC confirms PowerState=Off", func(ctx SpecContext) {
+		By("Creating a BMCSecret and a Retain-policy Server")
+		bmcSecret := &metalv1alpha1.BMCSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-server-",
+			},
+			Data: map[string][]byte{
+				"username": []byte("foo"),
+				"password": []byte("bar"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+		srv := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "server-",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID:    "38947555-7742-3448-3784-823347823834",
+				ReclaimPolicy: metalv1alpha1.ServerReclaimPolicyRetain,
+				BMC: &metalv1alpha1.BMCAccess{
+					Protocol: metalv1alpha1.Protocol{
+						Name: metalv1alpha1.ProtocolRedfishLocal,
+						Port: MockServerPort,
+					},
+					Address: MockServerIP,
+					BMCSecretRef: v1.LocalObjectReference{
+						Name: bmcSecret.Name,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, srv)).To(Succeed())
+
+		By("Driving the Server to Available and binding a claim")
+		Eventually(UpdateStatus(srv, func() {
+			srv.Status.State = metalv1alpha1.ServerStateAvailable
+		})).Should(Succeed())
+		claim := &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "retain-claim-",
+			},
+			Spec: metalv1alpha1.ServerClaimSpec{
+				ServerRef: &v1.LocalObjectReference{Name: srv.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, claim)).To(Succeed())
+		Eventually(Object(srv)).Should(HaveField("Status.State", metalv1alpha1.ServerStateReserved))
+
+		By("Pinning the BMC at PowerState=Unknown and deleting the claim")
+		const systemPath = "data/Systems/437XR1138R2/index.json"
+		Expect(mockServers[0].ForcePowerState(systemPath, "Unknown")).To(Succeed())
+		DeferCleanup(func() { _ = mockServers[0].ForcePowerState(systemPath, "") })
+		Expect(k8sClient.Delete(ctx, claim)).To(Succeed())
+		Eventually(Get(claim)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("The Server must not reach Released while power-off is unconfirmed")
+		Consistently(Object(srv)).Should(
+			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateReleased))))
+
+		By("Once the BMC confirms Off, the Server moves to Released")
+		Expect(mockServers[0].ForcePowerState(systemPath, "")).To(Succeed())
+		Eventually(Object(srv)).Should(HaveField("Status.State", metalv1alpha1.ServerStateReleased))
+
+		// cleanup
+		Expect(k8sClient.Delete(ctx, srv)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+	})
+
 	It("should update the BootStateReceived condition when the bootstate endpoint is called", func(ctx SpecContext) {
 		By("Creating a BMCSecret")
 		bmcSecret := &metalv1alpha1.BMCSecret{


### PR DESCRIPTION
## Summary

Split into two independently-green commits:

**Commit 1 — `54612f9` Safety: require BMC-confirmed `PowerState=Off` before release**

When a claim was deleted, `ensureServerPoweredOffWithoutBootConfig` set
`Spec.Power=Off` and cleared `Spec.BootConfigurationRef`, then on the next
reconcile short-circuited on those spec fields alone and released the
ServerClaim — even if the BMC still reported `PowerState=Unknown`. The
Server could be handed to the next tenant without confirming the host was
powered down.

Gates the reclaim/release paths on the observed `Status.PowerState=Off`.
Adds `MockServer.ForcePowerState` to simulate a stuck BMC in tests.

**Commit 2 — `4bc3808` Observability: report the wait, stop blocking a worker**

When the BMC cannot confirm `PowerState=Off`, a claimed Server correctly
stays bound, but nothing showed why — the stuck claim looked like an
operator bug and had to be diagnosed from controller logs.

Adds a dedicated `WaitingForPowerOff` condition (visible via
`kubectl describe server`, `Ready` left untouched). Issues `PowerOff`
without blocking in `WaitForServerPowerState` on the reclaim/release
paths so an unhealthy BMC no longer holds a controller worker for the
full polling timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer status reporting while a server is waiting for the BMC to confirm power-off.
  * Servers now remain in their current lifecycle state until power-off is confirmed, preventing premature release or reassignment.
  * Once confirmation is received, normal cleanup, release, and future claims proceed automatically.

* **Bug Fixes**
  * Improved recovery from BMCs that accept power commands but do not immediately update their reported power state.
  * Prevented stale server claim information from being restored during maintenance updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->