### PR TITLE
Fix BIOSSettings rejecting integer attributes provided as strings

### DIFF
--- a/bmc/mock/server/data/Registries/BiosAttributeRegistry.v1_0_0.json
+++ b/bmc/mock/server/data/Registries/BiosAttributeRegistry.v1_0_0.json
@@ -27,6 +27,23 @@
         "WriteOnly": false
       },
       {
+        "AttributeName": "MaxCores",
+        "CurrentValue": null,
+        "DisplayName": "Maximum Number of Cores",
+        "DisplayOrder": 250,
+        "HelpText": "Indicates the maximum number of enabled processor cores.",
+        "Hidden": false,
+        "Immutable": false,
+        "MenuPath": "./ProcSettingsRef",
+        "LowerBound": 0,
+        "UpperBound": 256,
+        "ReadOnly": false,
+        "ResetRequired": false,
+        "Type": "Integer",
+        "ValueExpression": null,
+        "WriteOnly": false
+      },
+      {
         "AttributeName": "BootMode",
         "CurrentValue": null,
         "DisplayName": "Boot Mode",

--- a/bmc/mock/server/data/Systems/437XR1138R2/Bios/index.json
+++ b/bmc/mock/server/data/Systems/437XR1138R2/Bios/index.json
@@ -7,6 +7,7 @@
         "AdminPhone": "",
         "BootMode": "Uefi",
         "EmbeddedSata": "Raid",
+        "MaxCores": 64,
         "NicBoot1": "Enabled",
         "NicBoot2": "Disabled",
         "PowerProfile": "MaxPerf",

--- a/bmc/redfish.go
+++ b/bmc/redfish.go
@@ -463,13 +463,30 @@ func (r *RedfishBaseBMC) GetBiosAttributeValues(ctx context.Context, systemURI s
 	}
 	result := make(schemas.SettingsAttributes, len(attributes))
 	for _, name := range attributes {
-		if _, ok := filteredAttr[name]; ok {
-			result[name] = bios.Attributes[name]
-		} else if _, ok := readOnlyAttr[name]; ok {
-			result[name] = bios.Attributes[name]
+		entry, ok := filteredAttr[name]
+		if !ok {
+			entry, ok = readOnlyAttr[name]
 		}
+		if !ok {
+			continue
+		}
+		result[name] = coerceRegistryValue(entry.Type, bios.Attributes[name])
 	}
 	return result, err
+}
+
+// coerceRegistryValue converts a raw JSON-decoded BIOS attribute value to the Go
+// type expected by checkAttributes, based on the registry attribute Type.
+// JSON numbers decode into any as float64, but integer attributes must be a Go
+// int for the type assertion in checkAttributes to succeed.
+func coerceRegistryValue(attrType string, raw any) any {
+	switch strings.ToLower(attrType) {
+	case "integer":
+		if f, ok := raw.(float64); ok {
+			return int(f)
+		}
+	}
+	return raw
 }
 
 func (r *RedfishBaseBMC) GetBMCAttributeValues(_ context.Context, req GetBMCAttributeValuesRequest) (schemas.SettingsAttributes, error) {

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -1173,9 +1174,16 @@ func (r *BIOSSettingsReconciler) getSettingsDiff(ctx context.Context, bmcClient 
 				floatValue, err := strconv.ParseFloat(value, 64)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to check type for name %s; value %s; error: %w", key, value, err))
+					continue
 				}
 				if data != floatValue {
-					diff[key] = floatValue
+					// JSON numbers decode as float64, but integer attributes must be
+					// applied as a Go int so BMC validation (checkAttributes) passes.
+					if floatValue == math.Trunc(floatValue) {
+						diff[key] = int(floatValue)
+					} else {
+						diff[key] = floatValue
+					}
 				}
 			}
 		} else {

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -309,6 +309,65 @@ var _ = Describe("BIOSSettings Controller", func() {
 		)
 	})
 
+	It("should apply an integer-typed bios setting provided as a string", func(ctx SpecContext) {
+		// MaxCores is mocked as an Integer-typed attribute (ResetRequired false) at
+		// metal-operator/bmc/mock/server/data/Registries/BiosAttributeRegistry.v1_0_0.json
+		// with a current value of 64 at
+		// metal-operator/bmc/mock/server/data/Systems/437XR1138R2/Bios/index.json.
+		// The CRD stores settings as strings, so "128" must be coerced to an int
+		// before being sent to the BMC, otherwise validation rejects it.
+		biosSetting := make(map[string]string)
+		biosSetting["MaxCores"] = "128"
+
+		By("Creating a BIOSSetting")
+		biosSettings := &metalv1alpha1.BIOSSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-integer-setting",
+			},
+			Spec: metalv1alpha1.BIOSSettingsSpec{
+				BIOSSettingsTemplate: metalv1alpha1.BIOSSettingsTemplate{
+					Version: mockUpServerBiosVersion,
+					SettingsFlow: []metalv1alpha1.SettingsFlowItem{{
+						Settings: biosSetting,
+						Priority: 1,
+						Name:     "one",
+					}},
+					ServerMaintenancePolicy: metalv1alpha1.ServerMaintenancePolicyEnforced,
+				},
+				ServerRef: &v1.LocalObjectReference{Name: server.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, biosSettings)).To(Succeed())
+
+		By("Ensuring that the Server has the bios setting ref")
+		Eventually(Object(server)).Should(
+			HaveField("Spec.BIOSSettingsRef.Name", biosSettings.Name),
+		)
+
+		By("Ensuring the integer setting is applied and not rejected as invalid")
+		Eventually(Object(biosSettings)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.BIOSSettingsStateApplied),
+			HaveField("Status.LastAppliedTime.IsZero()", false),
+		))
+
+		Consistently(Object(biosSettings)).Should(
+			HaveField("Status.Conditions", Not(ContainElement(
+				HaveField("Reason", ReasonSettingsValidationFailed),
+			))),
+		)
+
+		By("Deleting the BIOSSettings")
+		Expect(k8sClient.Delete(ctx, biosSettings)).To(Succeed())
+
+		By("Ensuring that the bios ref is empty")
+		Eventually(Object(server)).Should(
+			HaveField("Spec.BIOSSettingsRef", BeNil()),
+		)
+		Eventually(Object(server)).Should(
+			HaveField("Status.State", Not(Equal(metalv1alpha1.ServerStateMaintenance))),
+		)
+	})
+
 	It("should request maintenance when changing power status of server, even if bios settings update does not need it", func(ctx SpecContext) {
 		biosSetting := make(map[string]string)
 		// settings mocked at


### PR DESCRIPTION
Coerce integer-typed BIOS attributes (stored as strings in the CRD) to Go int using the BIOS attribute registry type so they pass BMC validation instead of failing with "Settings provided is invalid".

Error:
```
Settings provided is invalid. error: Settings Name: Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot2PhysicalPort2LogicalPort1_MaximumNumberofPFMSI_XVectors
        Settings Value: 128
        Error: attribute value has wrong type. needed 'Integer'
        Settings Name: Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot1PhysicalPort2LogicalPort1_MaximumNumberofPFMSI_XVectors
        Settings Value: 128

```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the BIOS `MaxCores` setting, including a maximum value of 256.
  * Added `MaxCores` with a default value of 64 to the sample system configuration.

* **Bug Fixes**
  * Improved BIOS attribute value conversion for integer and numeric settings.
  * BIOS settings supplied as numeric strings are now correctly validated and applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->