### PR TITLE
Add clusterctl discovery label to ServerClaim CRD

### DIFF
--- a/api/v1alpha1/serverclaim_types.go
+++ b/api/v1alpha1/serverclaim_types.go
@@ -69,6 +69,7 @@ type ServerClaimStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=scl
+// +kubebuilder:metadata:labels="clusterctl.cluster.x-k8s.io="
 // +kubebuilder:printcolumn:name="Server",type="string",JSONPath=".spec.serverRef.name"
 // +kubebuilder:printcolumn:name="Ignition",type="string",JSONPath=".spec.ignitionSecretRef.name"
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.image"

--- a/config/crd/bases/metal.ironcore.dev_serverclaims.yaml
+++ b/config/crd/bases/metal.ironcore.dev_serverclaims.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
   name: serverclaims.metal.ironcore.dev
 spec:
   group: metal.ironcore.dev


### PR DESCRIPTION
# Proposed Changes

- Add the `clusterctl.cluster.x-k8s.io` discovery label to the `ServerClaim` CRD (via a `+kubebuilder:metadata:labels` marker on the type, so it survives `make manifests`).

## Why

`clusterctl move` (pivot) only considers objects whose CRD carries the `clusterctl.cluster.x-k8s.io` label. `ServerClaim` is the **direct owner** of the per-machine `IPAddressClaim` (set by the `IroncoreMetalMachine` controller in `cluster-api-provider-ironcore-metal`), so it is the link that gives the IPAM resources their path to the `Cluster`:

```
IPAddressClaim -> ServerClaim -> IroncoreMetalMachine -> Machine -> Cluster
```

`IPAddressClaim` / `IPAddress` (CAPI core) and `IroncoreMetalMachine` (CAPI infra provider, labeled by `clusterctl init`) are already discovered. `ServerClaim` is the only unlabeled link in the chain.

## Impact without this label — data loss, not just stranding

Validated locally with CAPD + kind against the real CRDs:

- `IroncoreMetalMachine` is discovered and `Cluster`-linked, so `clusterctl move` moves it to the target **and deletes it from the source**.
- `ServerClaim` is **not** discovered, so it is never added to the move set — but it is owned by that `IroncoreMetalMachine`. When clusterctl deletes the source `IroncoreMetalMachine`, Kubernetes garbage collection **cascade-deletes the `ServerClaim` and, with it, the owned `IPAddressClaim` and `IPAddress`**.
- Net result: the target receives a childless `IroncoreMetalMachine`; the IPAM allocations exist nowhere.

With the label present, the entire chain moves cleanly (no controller/ownerRef changes needed — the ownerRefs are already wired correctly).

This mirrors the established CAPI precedent, e.g. `cluster-api-ipam-provider-in-cluster` labels its pool CRDs for the same reason.

## Note for maintainers

The `+kubebuilder:metadata:labels` marker correctly labels `config/crd/bases/*` and the kustomize install (`dist/install.yaml`). However, the kubebuilder `helm/v1-alpha` plugin currently **replaces** per-CRD static labels with the shared `chart.labels` helper when generating `dist/chart`, so this label does **not** propagate into the packaged Helm chart. Consumers who install via the Helm chart (rather than kustomize) will not get the label until that plugin limitation is addressed. Happy to follow up on the chart path if you'd like — flagging it so the source change here isn't mistaken for a complete fix for chart-based installs.

Fixes: (IPAM resources not moving during `clusterctl move` pivot)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added clusterctl metadata to the ServerClaim custom resource definition.
  * No changes to the resource schema, validation, or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->