### PR TITLE
Improve misleading message in biossettings controller

### DIFF
--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -624,7 +624,7 @@ func (r *BIOSSettingsReconciler) applySettingUpdate(ctx context.Context, bmcClie
 				turnOnServer,
 				conditionutils.UpdateStatus(corev1.ConditionTrue),
 				conditionutils.UpdateReason(ReasonSettingsServerPoweredOn),
-				conditionutils.UpdateMessage("Server is powered On to start the biosUpdate process"),
+				conditionutils.UpdateMessage("Server is powered On to start the bios settings update process"),
 			); err != nil {
 				return false, fmt.Errorf("failed to update power on server condition: %w", err)
 			}


### PR DESCRIPTION
The current message gives you the impression that a bios version update is triggered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the status message shown when BIOS settings are updated while the server is powered on, providing more accurate wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->