### PR TITLE
Clean up operation annotation constants

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -9,51 +9,65 @@ import (
 	"github.com/stmcginnis/gofish/schemas"
 )
 
-// establishing general rule for constants naming for Annotations
-// "Key" for Annotation constants should be named OperationAnnotation.
-// we do not want to handle multiple annotation keys for outside the spec flow operations.
-// "Value" for Annotation constants should be named as OperationAnnotation<ActionType>
+// Establishing the general rule for constants naming for Annotations:
+//   - "Key" for Annotation constants should be named OperationAnnotation.
+//     We do not want to handle multiple annotation keys for operations performed
+//     outside the spec-defined flow.
+//   - "Value" for Annotation constants should be named as OperationAnnotation<ActionType>.
+//
+// Values follow the grammar: <verb>[-child]
+// where <verb> is one of: ignore | retry
 // e.g.
-// OperationAnnotationIgnore
-// OperationAnnotationIgnoreChild
-// OperationAnnotationIgnoreChildAndSelf
-// OperationAnnotationRetry
+//
+//	OperationAnnotationIgnore  -> "ignore"
+//	OperationAnnotationRetry   -> "retry"
 
 const (
-	// OperationAnnotation indicates operation should be performed outside the current spec definition flow.
-	// This annotation performs Operation on the Server.
+	// OperationAnnotation is the annotation key selecting an out-of-band operation to perform on
+	// a resource, i.e. an action driven by the annotation value rather than by spec reconciliation.
+	// Its value must be one of the OperationAnnotation* constants below.
 	OperationAnnotation = "metal.ironcore.dev/operation"
 
-	// OperationAnnotationIgnore skips the reconciliation of a resource if OperationAnnotation is set to this.
-	OperationAnnotationIgnore = "ignore-reconciliation"
+	// OperationAnnotationIgnore makes the reconciler skip a resource entirely when set on it.
+	OperationAnnotationIgnore = "ignore"
 
-	// OperationAnnotationIgnorePropagated skips the reconciliation of a resource's Child if OperationAnnotation is set to this.
-	OperationAnnotationIgnorePropagated = "ignore-reconciliation-propagated"
+	// OperationAnnotationIgnorePropagated is set by the controller on a child resource to make the
+	// child's reconciler skip it, after the parent requested ignoring its children via ignore-child
+	// or ignore-child-and-self. It is controller-set state, not user-facing input.
+	OperationAnnotationIgnorePropagated = "ignore-propagated"
 
-	// OperationAnnotationIgnoreChild skips the reconciliation of a resource's Child if OperationAnnotation is set to this.
-	OperationAnnotationIgnoreChild = "ignore-child-reconciliation"
-	// OperationAnnotationIgnoreChildAndSelf skips the reconciliation of a resource's Child ans self if OperationAnnotation is set to this.
-	OperationAnnotationIgnoreChildAndSelf = "ignore-child-and-self-reconciliation"
-	// OperationAnnotationRetryChild restarts the reconciliation of a resource's Child if OperationAnnotation is set to this, from failed state -> initial state.
-	OperationAnnotationRetryChild = "retry-child-reconciliation"
-	// OperationAnnotationRetryChildAndSelf restarts the reconciliation of a resource's Child ans self if OperationAnnotation is set to this, from failed state -> initial state..
-	OperationAnnotationRetryChildAndSelf = "retry-child-and-self-reconciliation"
+	// OperationAnnotationIgnoreChild makes the controller skip reconciling a parent resource's
+	// children while still reconciling the parent itself.
+	OperationAnnotationIgnoreChild = "ignore-child"
+	// OperationAnnotationIgnoreChildAndSelf makes the controller skip reconciling both a parent
+	// resource's children and the parent itself.
+	OperationAnnotationIgnoreChildAndSelf = "ignore-child-and-self"
+	// OperationAnnotationRetryChild restarts the reconciliation of a parent resource's children
+	// from failed state back to initial state.
+	OperationAnnotationRetryChild = "retry-child"
+	// OperationAnnotationRetryChildAndSelf restarts the reconciliation of both a parent resource's
+	// children and the parent itself from failed state back to initial state.
+	OperationAnnotationRetryChildAndSelf = "retry-child-and-self"
 
-	// AnnotationInstanceType is used to specify the type of Server.
-	AnnotationInstanceType = "metal.ironcore.dev/instance-type"
-
-	// OperationAnnotationForceUpdateOrDeleteInProgress allows update/Delete of a resource even if it is in progress.
+	// OperationAnnotationForceUpdateOrDeleteInProgress allows a resource to be deleted even while an
+	// operation is still in progress.
 	OperationAnnotationForceUpdateOrDeleteInProgress = "allow-in-progress-delete"
-	// OperationAnnotationForceUpdateInProgress allows update of a resource even if it is in progress.
+	// OperationAnnotationForceUpdateInProgress allows a resource to be updated even while an operation
+	// is still in progress.
 	OperationAnnotationForceUpdateInProgress = "allow-in-progress-update"
 
-	// OperationAnnotationRetryFailed restarts the reconciliation of a resource from failed state -> initial state.
-	OperationAnnotationRetryFailed = "retry-failed-state-resource"
+	// OperationAnnotationRetry restarts a resource's reconciliation from failed state back to
+	// initial state when set on it.
+	OperationAnnotationRetry = "retry"
 
-	// OperationAnnotationRetryFailedPropagated restarts the reconciliation of a resource's child from failed state -> initial state.
-	OperationAnnotationRetryFailedPropagated = "retry-failed-state-resource-propagated"
+	// OperationAnnotationRetryPropagated is set by the controller on a child resource to restart
+	// the child's reconciliation from failed state back to initial state, after the parent requested
+	// retrying its children via retry-child or retry-child-and-self. It is controller-set state, not
+	// user-facing input.
+	OperationAnnotationRetryPropagated = "retry-propagated"
 
-	// OperationAnnotationRotateCredentials is used to indicate that credentials should be rotated.
+	// OperationAnnotationRotateCredentials indicates that a resource's credentials should be rotated
+	// when set on it.
 	OperationAnnotationRotateCredentials = "rotate-credentials"
 
 	// MetadataKeyPrefix is the shared prefix for labels and annotations on a Server
@@ -73,18 +87,17 @@ const (
 const SecretTypeUserData v1.SecretType = "metal.ironcore.dev/user-data"
 
 const (
-	// GracefulShutdownServerPower indicates to gracefully restart the baremetal server power.
+	// GracefulRestartServerPower indicates to gracefully restart the baremetal server power.
 	GracefulRestartServerPower = "graceful-restart-server"
 	// HardRestartServerPower indicates to hard restart the baremetal server power.
 	HardRestartServerPower = "hard-restart-server"
-	// PowerOffServerPower indicates to power cycle the baremetal server.
+	// PowerCycleServerPower indicates to power cycle the baremetal server.
 	PowerCycleServerPower = "power-cycle-server"
 	// ForceOffServerPower indicates to force powerOff the baremetal server power.
 	ForceOffServerPower = "force-off-server"
 	// ForceOnServerPower indicates to force powerOn the baremetal server power.
 	ForceOnServerPower = "force-on-server"
-
-	// GracefulShutdownBMC indicates to gracefully restart the baremetal server's BMC's power.
+	// GracefulRestartBMC indicates to gracefully restart the baremetal server's BMC's power.
 	GracefulRestartBMC = "graceful-restart-bmc"
 )
 

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -879,7 +879,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-from-server-avail",
 				Annotations: map[string]string{
-					metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetryFailed,
+					metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetry,
 				},
 			},
 			Spec: metalv1alpha1.BIOSSettingsSpec{

--- a/internal/controller/biosversion_controller_test.go
+++ b/internal/controller/biosversion_controller_test.go
@@ -356,7 +356,7 @@ var _ = Describe("BIOSVersion Controller", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-",
 				Annotations: map[string]string{
-					metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetryFailed,
+					metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetry,
 				},
 			},
 			Spec: metalv1alpha1.BIOSVersionSpec{

--- a/internal/controller/bmcsettings_controller_test.go
+++ b/internal/controller/bmcsettings_controller_test.go
@@ -474,7 +474,7 @@ var _ = Describe("BMCSettings Controller", func() {
 
 		Eventually(Update(settings, func() {
 			settings.Annotations = map[string]string{
-				metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetryFailed,
+				metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetry,
 			}
 		})).Should(Succeed())
 
@@ -626,7 +626,7 @@ var _ = Describe("BMCSettings Controller", func() {
 				Namespace:    ns.Name,
 				GenerateName: "test-bmc-upgrade",
 				Annotations: map[string]string{
-					metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetryFailed,
+					metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetry,
 				},
 			},
 			Spec: metalv1alpha1.BMCSettingsSpec{

--- a/internal/controller/bmcversion_controller_test.go
+++ b/internal/controller/bmcversion_controller_test.go
@@ -368,7 +368,7 @@ var _ = Describe("BMCVersion Controller", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-",
 				Annotations: map[string]string{
-					metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetryFailed,
+					metalv1alpha1.OperationAnnotation: metalv1alpha1.OperationAnnotationRetry,
 				},
 			},
 			Spec: metalv1alpha1.BMCVersionSpec{

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -164,7 +164,7 @@ func shouldRetryReconciliation(obj client.Object) bool {
 	if !found {
 		return false
 	}
-	return val == metalv1alpha1.OperationAnnotationRetryFailed || val == metalv1alpha1.OperationAnnotationRetryFailedPropagated
+	return val == metalv1alpha1.OperationAnnotationRetry || val == metalv1alpha1.OperationAnnotationRetryPropagated
 }
 
 // shouldChildRetryReconciliation checks if the object Child should retry reconciliation.
@@ -184,7 +184,7 @@ func isChildRetryThroughSets(childObj client.Object) bool {
 	if !found {
 		return false
 	}
-	return valChildRetry == metalv1alpha1.OperationAnnotationRetryFailedPropagated
+	return valChildRetry == metalv1alpha1.OperationAnnotationRetryPropagated
 }
 
 // GenerateRandomPassword generates a random password of the given length.
@@ -372,7 +372,7 @@ func handleRetryAnnotationPropagation(ctx context.Context, c client.Client, pare
 
 						if err == nil && retriedCondition != nil &&
 							retriedCondition.Status == metav1.ConditionTrue &&
-							retriedCondition.Message == metalv1alpha1.OperationAnnotationRetryFailedPropagated {
+							retriedCondition.Message == metalv1alpha1.OperationAnnotationRetryPropagated {
 							// retry was already propagated to child, we can skip re-propagation to avoid infinite loop
 							return nil
 						}
@@ -386,7 +386,7 @@ func handleRetryAnnotationPropagation(ctx context.Context, c client.Client, pare
 				if annotations == nil {
 					annotations = make(map[string]string)
 				}
-				annotations[metalv1alpha1.OperationAnnotation] = metalv1alpha1.OperationAnnotationRetryFailedPropagated
+				annotations[metalv1alpha1.OperationAnnotation] = metalv1alpha1.OperationAnnotationRetryPropagated
 				childObj.SetAnnotations(annotations)
 			}
 			return nil

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -831,7 +831,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 			HaveField("Finalizers", ContainElement(serverMaintenanceFinalizer)),
 		)
 
-		By("Setting ignore-reconciliation annotation to prevent the reconciler from re-adding the finalizer")
+		By("Setting ignore operation annotation to prevent the reconciler from re-adding the finalizer")
 		Eventually(Update(serverMaintenance, func() {
 			metav1.SetMetaDataAnnotation(&serverMaintenance.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationIgnore)
 		})).Should(Succeed())


### PR DESCRIPTION
# Proposed Changes

Rename the OperationAnnotation value strings and tidy up their doc comments.

Values previously carried redundant suffixes (ignore-reconciliation, retry-failed-state-resource, ...) that repeated the verb and the "resource" the key already implies. They now follow a consistent <verb>[-child][-and-self] grammar:

```
ignore                            (was ignore-reconciliation)
ignore-child                      (was ignore-child-reconciliation)
ignore-child-and-self             (was ignore-child-and-self-reconciliation)
ignore-propagated                 (was ignore-reconciliation-propagated)
retry                             (was retry-failed-state-resource)
retry-child                       (was retry-child-reconciliation)
retry-child-and-self              (was retry-child-and-self-reconciliation)
retry-propagated                  (was retry-failed-state-resource-propagated)
```

🚧 BREAKING CHANGE: the annotation value strings are user-facing. Existing annotations on live resources must be migrated to the new values; the unchanged allow-in-progress-* and rotate-credentials values are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated operation annotation names to use simplified values, including `ignore`, `retry`, and their child or propagated variants.
  * Removed the `AnnotationInstanceType` annotation constant.

* **Documentation**
  * Clarified documentation for operation annotations and bare-metal power operations.
  * Updated test descriptions to reflect the revised annotation terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->