### PR TITLE
Update publish-chart.yml to use v2-alpha values key

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Set container image repository and tag
         run: |
           IMAGE_TAG=sha-$(echo ${{ github.sha }} | cut -c1-7)
-          yq -i '.controllerManager.manager.image.repository = "ghcr.io/ironcore-dev/metal-operator-controller-manager"' dist/chart/values.yaml
-          yq -i '.controllerManager.manager.image.tag = "'$IMAGE_TAG'"' dist/chart/values.yaml
+          yq -i '.manager.image.repository = "ghcr.io/ironcore-dev/metal-operator-controller-manager"' dist/chart/values.yaml
+          yq -i '.manager.image.tag = "'$IMAGE_TAG'"' dist/chart/values.yaml
 
       - name: Package Helm chart with crds folder in template
         run: |


### PR DESCRIPTION
# Proposed Changes

- Update `publish-chart.yml` to use the `manager.image.*` values key introduced in `helm/v2-alpha`
- Remove stale `controllerManager.manager.image.*` key references which are silently ignored by the chart since PR #1045

Fixes #1053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Helm chart image overrides so repository and tag values are applied to the expected chart configuration fields.
  * Ensured published charts use the intended manager image settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->