### PR TITLE
Wire metaldata DaemonSet image through values

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -85,6 +85,8 @@ jobs:
           IMAGE_TAG=sha-$(echo ${{ github.sha }} | cut -c1-7)
           yq -i '.manager.image.repository = "ghcr.io/ironcore-dev/metal-operator-controller-manager"' dist/chart/values.yaml
           yq -i '.manager.image.tag = "'$IMAGE_TAG'"' dist/chart/values.yaml
+          yq -i '.metaldata.image.repository = "ghcr.io/ironcore-dev/metaldata"' dist/chart/values.yaml
+          yq -i '.metaldata.image.tag = "'$IMAGE_TAG'"' dist/chart/values.yaml
 
       - name: Package Helm chart with crds folder in template
         run: |

--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,18 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 .PHONY: helm
 helm: manifests kubebuilder
 	"$(KUBEBUILDER)" edit --plugins=helm/v2-alpha
+	@sed -i '/^        imagePullPolicy: /d' \
+	  dist/chart/templates/extras/metaldata.yaml
+	@grep -qF '        image: metaldata:latest' \
+	  dist/chart/templates/extras/metaldata.yaml || { \
+	  echo "unexpected metaldata template; image patch not applied" >&2; exit 1; }
+	@sed -i \
+	  's|image: metaldata:latest|image: "{{ .Values.metaldata.image.repository }}:{{ .Values.metaldata.image.tag \| default .Chart.AppVersion }}"\n        {{- with .Values.metaldata.image.pullPolicy }}\n        imagePullPolicy: {{ . }}\n        {{- end }}|' \
+	  dist/chart/templates/extras/metaldata.yaml
+	@awk '/^metaldata:/{f=1} f && /^[ \t]+image:/{found=1; exit} END{exit !found}' \
+	  dist/chart/values.yaml || \
+	  printf '\n## Configure the metaldata DaemonSet\n##\nmetaldata:\n  image:\n    repository: ghcr.io/ironcore-dev/metaldata\n    # tag: ""\n    pullPolicy: IfNotPresent\n' \
+	  >> dist/chart/values.yaml
 
 ##@ Dependencies
 

--- a/dist/chart/templates/extras/metaldata.yaml
+++ b/dist/chart/templates/extras/metaldata.yaml
@@ -26,7 +26,10 @@ spec:
       containers:
       - command:
         - /metaldata
-        image: metaldata:latest
+        image: "{{ .Values.metaldata.image.repository }}:{{ .Values.metaldata.image.tag | default .Chart.AppVersion }}"
+        {{- with .Values.metaldata.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -200,3 +200,11 @@ image: metalprobe:latest
 flags: ""
 sshPublicKey: ""
 passwordHash: ""
+
+## Configure the metaldata DaemonSet
+##
+metaldata:
+  image:
+    repository: ghcr.io/ironcore-dev/metaldata
+    # tag: ""
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
# Proposed Changes

- Add post-generation `sed`/`printf` patches to `make helm` that wire the `metaldata`
  DaemonSet image through `values.yaml` after every `kubebuilder` run (including `--force`)
- Add `metaldata.image.repository` and `metaldata.image.tag` to `publish-chart.yml`
  so published charts deploy the correct image

Fixes #1057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm charts now support configurable Metaldata image repository, tag (defaulting to the chart app version), and pull policy.
  * Published charts automatically carry the release-specific Metaldata image settings.

* **Bug Fixes**
  * Improved Helm chart packaging to remove the hardcoded Metaldata image reference and image pull policy, ensuring generated values are applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->