### PR TITLE
Fix latent nil-deref, dead branches and fragile finalizer logic in server/BMC/serverclaim controllers

### DIFF
--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -124,8 +124,7 @@ func (r *BMCReconciler) reconcile(ctx context.Context, bmcObj *metalv1alpha1.BMC
 	}
 	if r.waitForBMCReset(bmcObj, r.BMCResetWaitTime) {
 		log.V(1).Info("Skipped BMC reconciliation while waiting for BMC reset to complete")
-		err := r.updateBMCState(ctx, bmcObj, metalv1alpha1.BMCStatePending)
-		if err != nil {
+		if err := r.patchBMCStatePending(ctx, bmcObj); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{
@@ -144,10 +143,7 @@ func (r *BMCReconciler) reconcile(ctx context.Context, bmcObj *metalv1alpha1.BMC
 				RequeueAfter: r.BMCClientRetryInterval,
 			}, nil
 		}
-		err = r.updateReadyConditionOnBMCFailure(ctx, bmcObj, err)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+		return ctrl.Result{RequeueAfter: r.BMCClientRetryInterval}, r.updateReadyConditionOnBMCFailure(ctx, bmcObj, err)
 	}
 	defer bmcClient.Logout()
 
@@ -227,6 +223,7 @@ func (r *BMCReconciler) updateBMCStatusDetails(ctx context.Context, bmcClient bm
 	if err != nil {
 		return fmt.Errorf("failed to get manager details for BMC %s: %w", bmcObj.Name, err)
 	}
+	// GetManager returns (nil, err) on failure, so manager is non-nil here.
 	// parse time to metav1.Time: ISO 8601 format
 	lastResetTime := &metav1.Time{}
 	if manager.LastResetTime != "" {
@@ -235,27 +232,23 @@ func (r *BMCReconciler) updateBMCStatusDetails(ctx context.Context, bmcClient bm
 			lastResetTime = &metav1.Time{Time: t}
 		}
 	}
-	if manager != nil {
-		bmcBase := bmcObj.DeepCopy()
-		bmcObj.Status.Manufacturer = manager.Manufacturer
-		bmcObj.Status.State = metalv1alpha1.BMCState(string(manager.Status.State))
-		// Set power state, or unknown if not available from BMC
-		if manager.PowerState != "" {
-			bmcObj.Status.PowerState = metalv1alpha1.BMCPowerState(string(manager.PowerState))
-		} else {
-			bmcObj.Status.PowerState = metalv1alpha1.UnknownPowerState
-			log.V(1).Info("Power state not reported by BMC, setting to unknown", "BMC", bmcObj.Name)
-		}
-		bmcObj.Status.FirmwareVersion = manager.FirmwareVersion
-		bmcObj.Status.SerialNumber = manager.SerialNumber
-		bmcObj.Status.SKU = manager.PartNumber
-		bmcObj.Status.Model = manager.Model
-		bmcObj.Status.LastResetTime = lastResetTime
-		if err := r.Status().Patch(ctx, bmcObj, client.MergeFrom(bmcBase)); err != nil {
-			return fmt.Errorf("failed to patch manager details for BMC %s: %w", bmcObj.Name, err)
-		}
+	bmcBase = bmcObj.DeepCopy()
+	bmcObj.Status.Manufacturer = manager.Manufacturer
+	bmcObj.Status.State = metalv1alpha1.BMCState(manager.Status.State)
+	// Set power state, or unknown if not available from BMC
+	if manager.PowerState != "" {
+		bmcObj.Status.PowerState = metalv1alpha1.BMCPowerState(manager.PowerState)
 	} else {
-		log.V(1).Info("Manager details not available for BMC", "BMC", bmcObj.Name)
+		bmcObj.Status.PowerState = metalv1alpha1.UnknownPowerState
+		log.V(1).Info("Power state not reported by BMC, setting to unknown", "BMC", bmcObj.Name)
+	}
+	bmcObj.Status.FirmwareVersion = manager.FirmwareVersion
+	bmcObj.Status.SerialNumber = manager.SerialNumber
+	bmcObj.Status.SKU = manager.PartNumber
+	bmcObj.Status.Model = manager.Model
+	bmcObj.Status.LastResetTime = lastResetTime
+	if err := r.Status().Patch(ctx, bmcObj, client.MergeFrom(bmcBase)); err != nil {
+		return fmt.Errorf("failed to patch manager details for BMC %s: %w", bmcObj.Name, err)
 	}
 	return nil
 }
@@ -291,7 +284,7 @@ func (r *BMCReconciler) discoverServers(ctx context.Context, bmcClient bmc.BMC, 
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("errors occurred during server discovery: %v", errs)
+		return fmt.Errorf("errors occurred during server discovery: %w", errors.Join(errs...))
 	}
 	return nil
 }
@@ -478,12 +471,12 @@ func (r *BMCReconciler) shouldResetBMC(bmcObj *metalv1alpha1.BMC) bool {
 	return false
 }
 
-func (r *BMCReconciler) updateBMCState(ctx context.Context, bmcObj *metalv1alpha1.BMC, state metalv1alpha1.BMCState) error {
-	if bmcObj.Status.State == state {
+func (r *BMCReconciler) patchBMCStatePending(ctx context.Context, bmcObj *metalv1alpha1.BMC) error {
+	if bmcObj.Status.State == metalv1alpha1.BMCStatePending {
 		return nil
 	}
 	bmcBase := bmcObj.DeepCopy()
-	bmcObj.Status.State = state
+	bmcObj.Status.State = metalv1alpha1.BMCStatePending
 	if err := r.Status().Patch(ctx, bmcObj, client.MergeFrom(bmcBase)); err != nil {
 		return fmt.Errorf("failed to patch BMC state to Pending: %w", err)
 	}
@@ -495,23 +488,29 @@ func (r *BMCReconciler) resetBMC(ctx context.Context, bmcObj *metalv1alpha1.BMC,
 	if err := r.updateConditions(ctx, bmcObj, true, ConditionReset, corev1.ConditionTrue, reason, message); err != nil {
 		return fmt.Errorf("failed to set BMC resetting condition: %w", err)
 	}
-	var err error
-	if bmcClient != nil {
-		if err = bmcClient.ResetManager(ctx, bmcObj.Spec.BMCUUID, schemas.GracefulRestartResetType); err == nil {
-			log.Info("Successfully reset BMC via Redfish", "BMC", bmcObj.Name)
-			return r.updateBMCState(ctx, bmcObj, metalv1alpha1.BMCStatePending)
-		}
+	if bmcClient == nil {
+		// No client connection at all (e.g. auto-reset reached with a nil
+		// client from GetBMCClientFromBMC). No Redfish call possible — surface
+		// it instead of logging a nil error.
+		return errors.Join(
+			r.patchBMCStatePending(ctx, bmcObj),
+			fmt.Errorf("could not reset BMC %s: no client connection", bmcObj.Name),
+		)
 	}
-	// BMC Unavailable, currently can not perform reset. try to reset with ssh when available
-	log.Error(err, "Failed to reset BMC via Redfish, falling back to reset via SSH", "BMC", bmcObj.Name)
-	if httpErr, ok := err.(*schemas.Error); ok {
-		// only handle 5xx errors
-		if httpErr.HTTPReturnedStatusCode < 500 || httpErr.HTTPReturnedStatusCode >= 600 {
-			return errors.Join(r.updateBMCState(ctx, bmcObj, metalv1alpha1.BMCStatePending), fmt.Errorf("could not reset BMC: %w", err))
-		}
+	if err := bmcClient.ResetManager(ctx, bmcObj.Spec.BMCUUID, schemas.GracefulRestartResetType); err == nil {
+		log.Info("Successfully reset BMC via Redfish", "BMC", bmcObj.Name)
+		return r.patchBMCStatePending(ctx, bmcObj)
 	} else {
-		return fmt.Errorf("could not reset BMC, unknown error: %w", err)
+		if httpErr, ok := errors.AsType[*schemas.Error](err); ok {
+			// only retryable on 5xx; anything else is a permanent failure for this attempt
+			if httpErr.HTTPReturnedStatusCode < 500 || httpErr.HTTPReturnedStatusCode >= 600 {
+				return errors.Join(r.patchBMCStatePending(ctx, bmcObj), fmt.Errorf("could not reset BMC: %w", err))
+			}
+		} else {
+			return fmt.Errorf("could not reset BMC, unknown error: %w", err)
+		}
 	}
+	log.V(1).Info("BMC reset returned a retryable 5xx, leaving reset condition set", "BMC", bmcObj.Name)
 	return nil
 }
 

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -476,6 +476,7 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bm
 		if modified, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateAvailable); err != nil || modified {
 			return true, err
 		}
+		return true, nil
 	}
 
 	log = log.WithValues("ServerClaimRef", serverClaimRef)
@@ -1390,6 +1391,9 @@ func (r *ServerReconciler) handleAnnotationOperations(ctx context.Context, bmcCl
 }
 
 func (r *ServerReconciler) checkLastStatusUpdateAfter(duration time.Duration, server *metalv1alpha1.Server) bool {
+	if len(server.ManagedFields) == 0 {
+		return false
+	}
 	length := len(server.ManagedFields) - 1
 	if server.ManagedFields[length].Operation == "Update" {
 		if server.ManagedFields[length].Subresource == "status" {

--- a/internal/controller/serverclaim_controller.go
+++ b/internal/controller/serverclaim_controller.go
@@ -74,7 +74,7 @@ func (r *ServerClaimReconciler) delete(ctx context.Context, claim *metalv1alpha1
 	if err := r.cleanupAndShutdownServer(ctx, claim); err != nil {
 		return ctrl.Result{}, err
 	}
-	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, claim, serverClaimFinalizer); !apierrors.IsNotFound(err) || modified {
+	if _, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, claim, serverClaimFinalizer); err != nil {
 		return ctrl.Result{}, err
 	}
 	log.V(1).Info("Ensured that the finalizer has been removed")
@@ -296,35 +296,28 @@ func (r *ServerClaimReconciler) claimServer(ctx context.Context, claim *metalv1a
 	}
 
 	var selectedServer *metalv1alpha1.Server
+	selector, err := metav1.LabelSelectorAsSelector(claim.Spec.ServerSelector)
+	if err != nil {
+		return nil, err
+	}
 	for _, server := range serverList.Items {
-		selector, err := metav1.LabelSelectorAsSelector(claim.Spec.ServerSelector)
-		if err != nil {
-			return nil, err
-		}
 		switch {
 		case claim.Spec.ServerRef != nil:
-			// server reference is provided, we should only consider this server
 			if server.Name != claim.Spec.ServerRef.Name {
-				// server reference not matching
 				continue
 			}
-			// server reference matches, now check for selector if provided
 			if claim.Spec.ServerSelector != nil && !selector.Matches(labels.Set(server.Labels)) {
-				log.V(1).Info("Specified server matches ServerRef But does not match label selector", "Server", server.Name, "Claim", claim.Name)
+				log.V(1).Info("Specified server matches ServerRef but does not match label selector", "Server", server.Name, "Claim", claim.Name)
 				continue
 			}
 		case claim.Spec.ServerSelector != nil:
-			// server selector is provided, we should only consider servers matching the selector
 			if !selector.Matches(labels.Set(server.Labels)) {
 				log.V(1).Info("Specified server does not match label selector", "Server", server.Name, "Claim", claim.Name)
 				continue
 			}
 		}
 
-		// server has to passed all the checks for free server
-		// always select the first matching server
-		// we continue through the loop to find if previously claimed server is also present
-		if selectedServer == nil && r.isServerClaimable(ctx, &server, claim) {
+		if r.isServerClaimable(ctx, &server, claim) {
 			selectedServer = &server
 			break
 		}
@@ -347,8 +340,7 @@ func (r *ServerClaimReconciler) claimServer(ctx context.Context, claim *metalv1a
 
 	// ensureObjectRefForServer uses optimistic locking on the patch, so it will
 	// not overwrite a claim that was set between our re-fetch and the write.
-	err := r.ensureObjectRefForServer(ctx, claim, selectedServer)
-	if err != nil {
+	if err = r.ensureObjectRefForServer(ctx, claim, selectedServer); err != nil {
 		return nil, err
 	}
 	// If another reconciler won the optimistic-lock race, the ref will point to
@@ -366,7 +358,7 @@ func (r *ServerClaimReconciler) isUnderMaintenanceQueue(ctx context.Context, ser
 		log.V(1).Info("Server in or entering Maintenance, Hence can not be claimed")
 		return true, nil
 	}
-	// check if the current available state is a temerary state between multiple Maintenances states.
+	// check if the current available state is a temporary state between multiple Maintenances states.
 	// We do not want to claim server while it is undergoing series of Maintenance in sequence.
 	serverMaintenancesList := &metalv1alpha1.ServerMaintenanceList{}
 	if err := clientutils.ListAndFilter(ctx, r.Client, serverMaintenancesList, func(object client.Object) (bool, error) {


### PR DESCRIPTION
# Proposed Changes

Fix latent nil-deref, dead branches and fragile finalizer logic in server/BMC/serverclaim controllers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of BMC connection failures, including more reliable Ready condition updates.
  * Safer BMC reset behavior when no BMC connection is available (avoids fallback reset paths).
  * BMC status now more consistently reports hardware, firmware, power, and last reset details.
  * Improved error reporting when server discovery encounters multiple failures.
  * Prevented reserved servers and servers lacking status history from entering invalid reconciliation flows.
  * Improved server claim cleanup reliability and more consistent server selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->