### PR TITLE
Add `manager.env` and `metaldata.additionalLabels` to Helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: helm
-helm: manifests kubebuilder
+helm: manifests kubebuilder yq
 	"$(KUBEBUILDER)" edit --plugins=helm/v2-alpha
 	@sed -i '/^        imagePullPolicy: /d' \
 	  dist/chart/templates/extras/metaldata.yaml
@@ -274,6 +274,14 @@ helm: manifests kubebuilder
 	  dist/chart/values.yaml || \
 	  printf '\n## Configure the metaldata DaemonSet\n##\nmetaldata:\n  image:\n    repository: ghcr.io/ironcore-dev/metaldata\n    # tag: ""\n    pullPolicy: IfNotPresent\n' \
 	  >> dist/chart/values.yaml
+	@# Patch metaldata pod template to support additional labels via values
+	@grep -qF '        app.kubernetes.io/managed-by: {{ .Release.Service }}' \
+	  dist/chart/templates/extras/metaldata.yaml || { \
+	  echo "unexpected metaldata template; additionalLabels patch not applied" >&2; exit 1; }
+	@sed -i \
+	  's|        app.kubernetes.io/managed-by: {{ .Release.Service }}$$|        app.kubernetes.io/managed-by: {{ .Release.Service }}\n        {{- with .Values.metaldata.additionalLabels }}\n        {{- toYaml . \| nindent 8 }}\n        {{- end }}|' \
+	  dist/chart/templates/extras/metaldata.yaml
+	@"$(YQ)" -i '.metaldata.additionalLabels = (.metaldata.additionalLabels // {})' dist/chart/values.yaml
 
 ##@ Dependencies
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,6 +64,9 @@ spec:
         - /manager
         args:
         - --leader-elect
+        env:
+        - name: ENABLE_WEBHOOKS
+          value: "true"
         image: controller:latest
         name: manager
         ports:

--- a/dist/chart/templates/extras/metaldata.yaml
+++ b/dist/chart/templates/extras/metaldata.yaml
@@ -22,6 +22,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+        {{- with .Values.metaldata.additionalLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - command:

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -94,6 +94,20 @@ spec:
         {{- end }}
         command:
         - /manager
+        env:
+{{- if or .Values.manager.env (and (kindIs "map" .Values.manager.envOverrides) (not (empty .Values.manager.envOverrides))) }}
+          {{- if .Values.manager.env }}
+          {{- toYaml .Values.manager.env | nindent 10 }}
+          {{- end }}
+          {{- if kindIs "map" .Values.manager.envOverrides }}
+          {{- range $k, $v := .Values.manager.envOverrides }}
+          - name: {{ $k }}
+            value: {{ $v | quote }}
+          {{ end }}
+          {{- end }}
+          {{- else }}
+          []
+          {{- end }}
         image: "{{ .Values.manager.image.repository }}{{- if not (contains "@" .Values.manager.image.repository) }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}{{- end }}"
         {{- with .Values.manager.image.pullPolicy }}
         imagePullPolicy: {{ . }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -12,21 +12,20 @@ manager:
   ## Set to false to skip manager installation
   ##
   enabled: true
-
+  env:
+    - name: ENABLE_WEBHOOKS
+      value: "true"
   replicas: 1
-
   image:
     repository: controller
     ## Image tag (defaults to Chart.appVersion if not set)
     ##
     # tag: ""
     pullPolicy: IfNotPresent
-
   ## Arguments
   ##
   args:
     - --leader-elect
-
   ## Image pull secrets
   ##
   # imagePullSecrets:
@@ -38,15 +37,13 @@ manager:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
-
   ## Container-level security settings
   ##
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
-
+        - ALL
   ## Resource limits and requests
   ##
   resources:
@@ -56,19 +53,15 @@ manager:
     requests:
       cpu: 10m
       memory: 64Mi
-
   ## Manager pod's affinity
   ##
   affinity: {}
-
   ## Manager pod's node selector
   ##
   nodeSelector: {}
-
   ## Manager pod's tolerations
   ##
   tolerations: []
-
   ## Deployment strategy
   ##
   # strategy:
@@ -88,20 +81,18 @@ manager:
   ## Termination grace period seconds
   ##
   terminationGracePeriodSeconds: 10
-
   ## Custom Deployment labels
   ##
   # labels: {}
+## Custom Deployment annotations
+##
+# annotations: {}
 
-  ## Custom Deployment annotations
-  ##
-  # annotations: {}
-
-  ## Custom Pod labels and annotations
-  ##
-  # pod:
-  #   labels: {}
-  #   annotations: {}
+## Custom Pod labels and annotations
+##
+# pod:
+#   labels: {}
+#   annotations: {}
 
 ## RBAC configuration
 ##
@@ -111,32 +102,28 @@ rbac:
   ## - true: Role/RoleBinding (release namespace only)
   ##
   namespaced: false
-
   ## Helper roles for CRD management (admin/editor/viewer)
   ##
   helpers:
     ## Install convenience admin/editor/viewer roles for CRDs
     ##
     enable: false
-
 ## ServiceAccount configuration
 ##
 serviceAccount:
   # Install default ServiceAccount provided
   enable: true
-
   ## Existing ServiceAccount name (only when enable=false)
   ## Note: When enable=true, respects nameOverride/fullnameOverride
   ##
   # name: ""
+## Custom ServiceAccount annotations
+##
+# annotations: {}
 
-  ## Custom ServiceAccount annotations
-  ##
-  # annotations: {}
-
-  ## Custom ServiceAccount labels
-  ##
-  # labels: {}
+## Custom ServiceAccount labels
+##
+# labels: {}
 
 ## Custom Resource Definitions
 ##
@@ -145,7 +132,6 @@ crd:
   enable: true
   # Keep CRDs when uninstalling
   keep: true
-
 ## Controller metrics endpoint.
 ## Enable to expose /metrics endpoint
 ##
@@ -156,26 +142,22 @@ metrics:
   # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
   # Note: Metrics authn/authz needs ClusterRole access.
   secure: true
-
 ## Cert-manager integration for TLS certificates.
 ## Required for webhook certificates and metrics endpoint certificates.
 ##
 certManager:
   enable: true
-
 ## Webhook server configuration
 ##
 webhook:
   enable: true
   # Webhook server port
   port: 9443
-
 ## Prometheus ServiceMonitor for metrics scraping.
 ## Requires prometheus-operator to be installed in the cluster.
 ##
 prometheus:
   enable: false
-
 # [IGNITION]: Ignition template configuration
 # By default, the operator uses a template file baked into the container at /etc/metal-operator/ignition-template.yaml
 # Enable this to override the template by mounting a ConfigMap at that location
@@ -185,22 +167,18 @@ ignition:
   # Template content that can be customized - this will be created as a ConfigMap
   # and mounted to override the default template
   # template: |
-
 ## The registry service exposed by the metal-controller-manager to receive metalprobe request call-backs.
 registry:
   enabled: false
   port: 30000
-
   # {{.Image}} - The Docker image to run for metalprobe
   # {{.Flags}} - The flags to pass to the metalprobe container, this includes --registry-url and --server-uuid
   # {{.SSHPublicKey}} - The SSH public key for the 'metal' user
   # {{.PasswordHash}} - The password hash for the 'metal' user
-
 image: metalprobe:latest
 flags: ""
 sshPublicKey: ""
 passwordHash: ""
-
 ## Configure the metaldata DaemonSet
 ##
 metaldata:
@@ -208,3 +186,4 @@ metaldata:
     repository: ghcr.io/ironcore-dev/metaldata
     # tag: ""
     pullPolicy: IfNotPresent
+  additionalLabels: {}

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -5952,6 +5952,9 @@ spec:
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
         command:
         - /manager
+        env:
+        - name: ENABLE_WEBHOOKS
+          value: "true"
         image: controller:latest
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Proposed Changes

- Add `manager.env` and `manager.envOverrides` values to allow configuring
  environment variables on the controller manager container
- Add `metaldata.additionalLabels` values to allow injecting extra labels
  into the metaldata DaemonSet pod template

Fixes #1065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm chart values now support defining `metaldata.additionalLabels` to add custom labels to the MetalData pod template.
  * Webhook functionality is enabled by default for the controller manager deployment.

* **Chores**
  * Helm chart generation now applies the required MetalData label configuration updates automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->