### PR TITLE
IEP-23: Add Server Parked state for out-of-band day-2 operations

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -78,9 +78,6 @@ const (
 	// ParkedAnnotation is the durable, controller-set marker recording that a Server is parked.
 	ParkedAnnotation = "metal.ironcore.dev/parked"
 
-	// ParkedAnnotationTrue is the value set on ParkedAnnotation while a server is parked.
-	ParkedAnnotationTrue = "true"
-
 	// MetadataKeyPrefix is the shared prefix for labels and annotations on a Server
 	// whose suffix is exposed via the metaldata service to the booted server.
 	MetadataKeyPrefix = "metadata.metal.ironcore.dev/"

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -75,6 +75,10 @@ const (
 	// hardware rework).
 	OperationAnnotationPark = "park"
 
+	// OperationAnnotationUnpark requests that a parked Server be resumed into the normal
+	// ServerClaim lifecycle.
+	OperationAnnotationUnpark = "unpark"
+
 	// ParkedAnnotation is the durable, controller-set marker recording that a Server is parked.
 	ParkedAnnotation = "metal.ironcore.dev/parked"
 

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -70,6 +70,17 @@ const (
 	// when set on it.
 	OperationAnnotationRotateCredentials = "rotate-credentials"
 
+	// OperationAnnotationPark requests that a Server be parked out of the ServerClaim lifecycle so an
+	// external component can run out-of-band day-2 operations (firmware/BIOS/BMC updates, diagnostics,
+	// hardware rework).
+	OperationAnnotationPark = "park"
+
+	// ParkedAnnotation is the durable, controller-set marker recording that a Server is parked.
+	ParkedAnnotation = "metal.ironcore.dev/parked"
+
+	// ParkedAnnotationTrue is the value set on ParkedAnnotation while a server is parked.
+	ParkedAnnotationTrue = "true"
+
 	// MetadataKeyPrefix is the shared prefix for labels and annotations on a Server
 	// whose suffix is exposed via the metaldata service to the booted server.
 	MetadataKeyPrefix = "metadata.metal.ironcore.dev/"

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -199,6 +199,11 @@ const (
 
 	// ServerStateMaintenance indicates that the server is in maintenance.
 	ServerStateMaintenance ServerState = "Maintenance"
+
+	// ServerStateParked indicates that the server is parked out of the ServerClaim lifecycle so an
+	// external component can run out-of-band day-2 operations. Parked is an overlay state: while
+	// active, normal state-machine progression, boot, and power healing are suspended.
+	ServerStateParked ServerState = "Parked"
 )
 
 // IndicatorLED represents LED indicator states

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -451,6 +451,7 @@ func main() { // nolint: gocyclo
 		Client:                  mgr.GetClient(),
 		APIReader:               mgr.GetAPIReader(),
 		Scheme:                  mgr.GetScheme(),
+		Recorder:                mgr.GetEventRecorder("server-controller"),
 		DefaultProtocol:         effectiveProtocol,
 		SkipCertValidation:      effectiveSkipCert,
 		ManagerNamespace:        managerNamespace,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,15 +46,6 @@ rules:
 - apiGroups:
   - metal.ironcore.dev
   resources:
-  - BMC
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - metal.ironcore.dev
-  resources:
   - biossettings
   - biossettingssets
   - biosversions

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -37,6 +37,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - metal.ironcore.dev
   resources:
   - BMC

--- a/dist/chart/templates/rbac/manager-role.yaml
+++ b/dist/chart/templates/rbac/manager-role.yaml
@@ -43,6 +43,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - metal.ironcore.dev
   resources:
   - BMC

--- a/dist/chart/templates/rbac/manager-role.yaml
+++ b/dist/chart/templates/rbac/manager-role.yaml
@@ -52,15 +52,6 @@ rules:
 - apiGroups:
   - metal.ironcore.dev
   resources:
-  - BMC
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - metal.ironcore.dev
-  resources:
   - biossettings
   - biossettingssets
   - biosversions

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -5286,15 +5286,6 @@ rules:
 - apiGroups:
   - metal.ironcore.dev
   resources:
-  - BMC
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - metal.ironcore.dev
-  resources:
   - biossettings
   - biossettingssets
   - biosversions

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -5277,6 +5277,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - metal.ironcore.dev
   resources:
   - BMC

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1841,6 +1841,7 @@ _Appears in:_
 | `Released` | ServerStateReleased indicates that the server is released after use.<br /> |
 | `Error` | ServerStateError indicates that there is an error with the server.<br /> |
 | `Maintenance` | ServerStateMaintenance indicates that the server is in maintenance.<br /> |
+| `Parked` | ServerStateParked indicates that the server is parked out of the ServerClaim lifecycle so an<br />external component can run out-of-band day-2 operations. Parked is an overlay state: while<br />active, normal state-machine progression, boot, and power healing are suspended.<br /> |
 
 
 #### ServerStatus

--- a/docs/concepts/servers.md
+++ b/docs/concepts/servers.md
@@ -211,8 +211,8 @@ Parking is driven by annotations with distinct roles:
 - `metal.ironcore.dev/operation: park`: a **transient request** set by the external actor. The
   `Server` reconciler removes it again as soon as the server has reached the `Parked` state.
 - `metal.ironcore.dev/operation: unpark`: a **transient request** set by the external actor to end
-  parking. The `Server` reconciler consumes it by releasing the parked marker and resuming the
-  server.
+  parking. The `Server` reconciler removes it once the server has left the `Parked` state; while
+  the annotation is present, the unpark is still in progress.
 - `metal.ironcore.dev/parked: "true"`: a **durable, controller-set marker** the operator writes
   when it parks the server and removes again when an unpark request comes in. Do not set or remove
   it directly; it is controller-owned state, not user-facing input.
@@ -256,9 +256,9 @@ and the parked marker stay the same regardless of how the request arrives.
        metal.ironcore.dev/operation: unpark
    ```
 
-   The `Server` reconciler consumes the request: it removes the internal
-   `metal.ironcore.dev/parked` annotation and both operation annotations, then the next
-   reconciliation re-enters the normal flow:
+   The `Server` reconciler processes the request step by step: it removes the internal
+   `metal.ironcore.dev/parked` annotation, resumes the server, and only then removes the
+   `operation: unpark` request annotation. The next reconciliation re-enters the normal flow:
    - the `Server` reconciler refreshes system info (hardware or firmware state may have changed
      during the procedure),
    - transitions back to the pre-parking state: `Reserved` if the server has a `ServerClaimRef`,

--- a/docs/concepts/servers.md
+++ b/docs/concepts/servers.md
@@ -67,7 +67,19 @@ A server undergoes the following phases:
     - Servers in the `Available` state can transition to `Maintenance`.
     - Maintenance tasks such as BIOS updates or hardware repairs are performed.
 
-7. **Error**:
+7. **Parked**:
+    - An overlay state a server enters when it is **parked** out of the `ServerClaim` lifecycle so an
+      external component can run an out-of-band **day-2 operation** (a firmware or BIOS/BMC update,
+      hardware rework, diagnostics, or low-level storage reconfiguration) that must not be fought by
+      the reconcilers.
+    - While parked, both the `Server` and `ServerClaim` reconcilers stand down: the server is powered
+      off, no boot is performed, and no power state is healed, so an intermediate restart during the
+      procedure cannot boot the claim's image.
+    - Only servers in the `Available` or `Reserved` state can be parked. A park request on a server in
+      any other state is deferred until it reaches a parkable state.
+    - See [Parking](#parking) below.
+
+8. **Error**:
     - The server has encountered an error.
     - Requires intervention to resolve issues before it can return to `Available`.
 
@@ -86,6 +98,10 @@ stateDiagram-v2
     Released --> Available : serverClaimRef cleared manually
     Available --> Maintenance : Maintenance initiated
     Maintenance --> Initial : Maintenance complete
+    Available --> Parked : Park requested
+    Reserved --> Parked : Park requested
+    Parked --> Available : Parked annotation removed (no ServerClaimRef)
+    Parked --> Reserved : Parked annotation removed (ServerClaimRef present)
     Available --> Error : Error detected
     Reserved --> Error : Error detected
     Discovery --> Error : Error detected
@@ -175,6 +191,96 @@ kubectl patch server my-server --type=merge -p '{"spec":{"unclaimable":false}}'
 ```
 
 Any subject with `update` permission on the `Server` resource can toggle `spec.unclaimable`, typically operators/admins for manual maintenance and automated maintenance controllers.
+
+## Parking
+
+Parking takes a `Server` out of the `ServerClaim` lifecycle so an external component can run an
+out-of-band **day-2 operation**, a firmware or BIOS/BMC update, hardware rework, diagnostics, or
+low-level storage reconfiguration, without the reconcilers interfering. Parking is what powers the
+server down: as part of reaching the `Parked` state the operator powers the server **off** itself,
+then stands down so an external component can perform the procedure. While a server is parked, both
+the `Server` and `ServerClaim` reconcilers stand down: no boot is performed and no power state is
+healed, so an intermediate restart during the procedure cannot boot the claim's image. The bound
+`ServerClaim` stays in place (bound), so on recovery the claim controller can take over again
+without re-scheduling.
+
+Parking uses two annotations with distinct roles:
+
+- `metal.ironcore.dev/operation: park`: a **transient request** set by the external actor. The
+  `Server` reconciler removes it again as soon as the server has reached the `Parked` state.
+- `metal.ironcore.dev/parked: "true"`: a **durable, controller-set marker** the operator writes
+  when it parks the server and removes when it un-parks it. It is the source of truth for the parked
+  state: if `status.state` is ever lost or reset, the reconcilers reconstruct the parked status from
+  this annotation and keep standing down across operator restarts.
+
+### Lifecycle
+
+1. **Request.** The external actor sets the `operation` annotation to `park`:
+
+   ```yaml
+   metadata:
+     annotations:
+       metal.ironcore.dev/operation: park
+   ```
+
+   This is a one-shot request; it does **not** itself persist the parked state.
+2. **Park.** The `Server` reconciler observes the request and, if the server is in a parkable state
+   (`Available` or `Reserved`):
+   - powers the server **off** (idempotent; only if not already off),
+   - records the parked state by setting the internal `metal.ironcore.dev/parked: "true"` annotation,
+   - sets `status.state = Parked`,
+   - **removes** the `metal.ironcore.dev/operation: park` request annotation again.
+3. **Stand down.** While the `metal.ironcore.dev/parked` annotation is present:
+   - the `Server` reconciler returns early, before any power healing, boot, or state-machine
+     progression,
+   - the `ServerClaim` reconciler returns early, so the claim does not re-apply the boot
+     configuration or revert power. The `ServerClaim` stays bound; its phase is unchanged.
+   - If `status.state` is ever lost or reset, the reconcilers reconstruct the parked status from the
+     annotation and keep standing down.
+4. **Resume.** The external actor brings the server back by removing the internal
+   `metal.ironcore.dev/parked` annotation (or clearing its value). The next reconciliation re-enters
+   the normal flow:
+   - the `Server` reconciler refreshes system info (hardware or firmware state may have changed
+     during the procedure),
+   - transitions back to the pre-parking state: `Reserved` if the server has a `ServerClaimRef`,
+     otherwise `Available`,
+   - the `ServerClaim` reconciler takes over again and re-applies the boot configuration and power
+     state as before.
+
+   Removing the `metal.ironcore.dev/operation` annotation is **not** the resume signal: that
+   annotation was already consumed during parking. Resume is driven by the requestor removing the
+   internal `parked` annotation.
+
+### Admission control
+
+Parking is admitted only from the `Available` and `Reserved` states, the in-use states. A `park`
+request on a server in any other state (`Initial`, `Discovery`, `Released`, `Maintenance`, `Error`)
+is **deferred**: the request annotation is left in place and retried on the next resync, so a server
+that is still discovering (or otherwise not yet parkable) is parked automatically once it reaches a
+parkable state, without the requestor having to re-issue the request.
+
+### Interaction with deletion
+
+The `parked` annotation does **not** gate the deletion path. A `Server` that is deleted while parked
+is still cleaned up normally: the finalizer is removed and the boot configuration deleted. Parking and
+deletion are independent.
+
+### Example
+
+Park a reserved server to run a firmware update out of band:
+
+```bash
+kubectl annotate server my-server metal.ironcore.dev/operation=park
+```
+
+Once the server has reached `Parked` (and the request annotation is consumed), perform the procedure.
+When done, bring the server back by removing the parked marker:
+
+```bash
+kubectl annotate server my-server metal.ironcore.dev/parked-
+```
+
+The server powers back on and the bound `ServerClaim` resumes ownership without re-scheduling.
 
 ## Interaction with BMC
 

--- a/docs/concepts/servers.md
+++ b/docs/concepts/servers.md
@@ -72,9 +72,11 @@ A server undergoes the following phases:
       external component can run an out-of-band **day-2 operation** (a firmware or BIOS/BMC update,
       hardware rework, diagnostics, or low-level storage reconfiguration) that must not be fought by
       the reconcilers.
-    - While parked, both the `Server` and `ServerClaim` reconcilers stand down: the server is powered
-      off, no boot is performed, and no power state is healed, so an intermediate restart during the
-      procedure cannot boot the claim's image.
+    - Entering the state powers the server **off**. While parked, both the `Server` and `ServerClaim`
+      reconcilers stand down: no boot is performed and no power state is healed, so the external actor
+      owns power control (e.g. the power cycles a firmware update needs). Boot behavior during the
+      procedure is the external actor's responsibility: it must ensure a correct boot order so the box
+      does not boot the claim's image.
     - Only servers in the `Available` or `Reserved` state can be parked. A park request on a server in
       any other state is deferred until it reaches a parkable state.
     - See [Parking](#parking) below.
@@ -209,7 +211,8 @@ Parking uses two annotations with distinct roles:
 - `metal.ironcore.dev/operation: park`: a **transient request** set by the external actor. The
   `Server` reconciler removes it again as soon as the server has reached the `Parked` state.
 - `metal.ironcore.dev/parked: "true"`: a **durable, controller-set marker** the operator writes
-  when it parks the server and removes when it un-parks it. It is the source of truth for the parked
+  when it parks the server. The external actor removes it again to end parking. It is the source of
+  truth for the parked
   state: if `status.state` is ever lost or reset, the reconcilers reconstruct the parked status from
   this annotation and keep standing down across operator restarts.
 
@@ -226,7 +229,8 @@ Parking uses two annotations with distinct roles:
    This is a one-shot request; it does **not** itself persist the parked state.
 2. **Park.** The `Server` reconciler observes the request and, if the server is in a parkable state
    (`Available` or `Reserved`):
-   - powers the server **off** (idempotent; only if not already off),
+   - powers the server **off** via the BMC (idempotent; only if not already off; `spec.power` is
+     left untouched),
    - records the parked state by setting the internal `metal.ironcore.dev/parked: "true"` annotation,
    - sets `status.state = Parked`,
    - **removes** the `metal.ironcore.dev/operation: park` request annotation again.
@@ -280,7 +284,7 @@ When done, bring the server back by removing the parked marker:
 kubectl annotate server my-server metal.ironcore.dev/parked-
 ```
 
-The server powers back on and the bound `ServerClaim` resumes ownership without re-scheduling.
+The bound `ServerClaim` resumes ownership without re-scheduling, and its reconciler reapplies the claim's requested power state, including `Off` when the claim requests it.
 
 ## Interaction with BMC
 

--- a/docs/concepts/servers.md
+++ b/docs/concepts/servers.md
@@ -102,8 +102,8 @@ stateDiagram-v2
     Maintenance --> Initial : Maintenance complete
     Available --> Parked : Park requested
     Reserved --> Parked : Park requested
-    Parked --> Available : Parked annotation removed (no ServerClaimRef)
-    Parked --> Reserved : Parked annotation removed (ServerClaimRef present)
+    Parked --> Available : Unpark requested (no ServerClaimRef)
+    Parked --> Reserved : Unpark requested (ServerClaimRef present)
     Available --> Error : Error detected
     Reserved --> Error : Error detected
     Discovery --> Error : Error detected
@@ -210,11 +210,12 @@ Parking uses two annotations with distinct roles:
 
 - `metal.ironcore.dev/operation: park`: a **transient request** set by the external actor. The
   `Server` reconciler removes it again as soon as the server has reached the `Parked` state.
+- `metal.ironcore.dev/operation: unpark`: a **transient request** set by the external actor to end
+  parking. The `Server` reconciler consumes it by releasing the parked marker and resuming the
+  server.
 - `metal.ironcore.dev/parked: "true"`: a **durable, controller-set marker** the operator writes
-  when it parks the server. The external actor removes it again to end parking. It is the source of
-  truth for the parked
-  state: if `status.state` is ever lost or reset, the reconcilers reconstruct the parked status from
-  this annotation and keep standing down across operator restarts.
+  when it parks the server and removes again when an unpark request comes in. Do not set or remove
+  it directly; it is controller-owned state, not user-facing input. 
 
 ### Lifecycle
 
@@ -241,9 +242,18 @@ Parking uses two annotations with distinct roles:
      configuration or revert power. The `ServerClaim` stays bound; its phase is unchanged.
    - If `status.state` is ever lost or reset, the reconcilers reconstruct the parked status from the
      annotation and keep standing down.
-4. **Resume.** The external actor brings the server back by removing the internal
-   `metal.ironcore.dev/parked` annotation (or clearing its value). The next reconciliation re-enters
-   the normal flow:
+4. **Resume.** The external actor brings the server back by setting the `operation` annotation to
+   `unpark`:
+
+   ```yaml
+   metadata:
+     annotations:
+       metal.ironcore.dev/operation: unpark
+   ```
+
+   The `Server` reconciler consumes the request: it removes the internal
+   `metal.ironcore.dev/parked` annotation and both operation annotations, then the next
+   reconciliation re-enters the normal flow:
    - the `Server` reconciler refreshes system info (hardware or firmware state may have changed
      during the procedure),
    - transitions back to the pre-parking state: `Reserved` if the server has a `ServerClaimRef`,
@@ -251,9 +261,8 @@ Parking uses two annotations with distinct roles:
    - the `ServerClaim` reconciler takes over again and re-applies the boot configuration and power
      state as before.
 
-   Removing the `metal.ironcore.dev/operation` annotation is **not** the resume signal: that
-   annotation was already consumed during parking. Resume is driven by the requestor removing the
-   internal `parked` annotation.
+   An unpark request on a server that is not parked is a no-op: the request annotation is consumed
+   and nothing else happens.
 
 ### Admission control
 
@@ -278,10 +287,10 @@ kubectl annotate server my-server metal.ironcore.dev/operation=park
 ```
 
 Once the server has reached `Parked` (and the request annotation is consumed), perform the procedure.
-When done, bring the server back by removing the parked marker:
+When done, bring the server back with an unpark request:
 
 ```bash
-kubectl annotate server my-server metal.ironcore.dev/parked-
+kubectl annotate server my-server metal.ironcore.dev/operation=unpark
 ```
 
 The bound `ServerClaim` resumes ownership without re-scheduling, and its reconciler reapplies the claim's requested power state, including `Off` when the claim requests it.

--- a/docs/concepts/servers.md
+++ b/docs/concepts/servers.md
@@ -206,7 +206,7 @@ healed, so an intermediate restart during the procedure cannot boot the claim's 
 `ServerClaim` stays in place (bound), so on recovery the claim controller can take over again
 without re-scheduling.
 
-Parking uses two annotations with distinct roles:
+Parking is driven by annotations with distinct roles:
 
 - `metal.ironcore.dev/operation: park`: a **transient request** set by the external actor. The
   `Server` reconciler removes it again as soon as the server has reached the `Parked` state.
@@ -215,7 +215,12 @@ Parking uses two annotations with distinct roles:
   server.
 - `metal.ironcore.dev/parked: "true"`: a **durable, controller-set marker** the operator writes
   when it parks the server and removes again when an unpark request comes in. Do not set or remove
-  it directly; it is controller-owned state, not user-facing input. 
+  it directly; it is controller-owned state, not user-facing input.
+
+The `operation: park`/`unpark` request annotations are the interface of the current `Server`
+reconciler implementation only. Eventually, the parking request is expected to originate from an
+external entity rather than being issued by hand; the stand-down semantics of the `Parked` state
+and the parked marker stay the same regardless of how the request arrives.
 
 ### Lifecycle
 

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -83,7 +83,7 @@ type BIOSSettingsReconciler struct {
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biossettings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biossettings/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servers,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups=metal.ironcore.dev,resources=BMC,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcs,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servermaintenances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servermaintenances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -150,6 +150,19 @@ func isServerParkingOrParked(server *metalv1alpha1.Server) bool {
 	return server.GetAnnotations()[metalv1alpha1.OperationAnnotation] == metalv1alpha1.OperationAnnotationPark
 }
 
+func isResetAnnotation(operation string) bool {
+	_, ok := metalv1alpha1.AnnotationToRedfishMapping[operation]
+	return ok
+}
+
+func isParkableState(state metalv1alpha1.ServerState) bool {
+	switch state {
+	case metalv1alpha1.ServerStateAvailable, metalv1alpha1.ServerStateReserved:
+		return true
+	}
+	return false
+}
+
 // shouldChildIgnoreReconciliation checks if the object Child should ignore reconciliation.
 // if Parent has OperationAnnotation set to ignore-child, Child should also ignore reconciliation.
 func shouldChildIgnoreReconciliation(parentObj client.Object) bool {

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -138,13 +138,11 @@ func shouldIgnoreReconciliation(obj client.Object) bool {
 	}, val)
 }
 
-// isServerParked reports whether the Server carries the durable parked annotation, i.e. the operator
-// (not the requestor) has recorded the server as parked.
 func isServerParked(server *metalv1alpha1.Server) bool {
-	return server.GetAnnotations()[metalv1alpha1.ParkedAnnotation] == metalv1alpha1.ParkedAnnotationTrue
+	_, ok := server.GetAnnotations()[metalv1alpha1.ParkedAnnotation]
+	return ok
 }
 
-// isServerParkingOrParked reports whether a Server is being parked or already parked.
 func isServerParkingOrParked(server *metalv1alpha1.Server) bool {
 	if isServerParked(server) {
 		return true

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -138,6 +138,20 @@ func shouldIgnoreReconciliation(obj client.Object) bool {
 	}, val)
 }
 
+// isServerParked reports whether the Server carries the durable parked annotation, i.e. the operator
+// (not the requestor) has recorded the server as parked.
+func isServerParked(server *metalv1alpha1.Server) bool {
+	return server.GetAnnotations()[metalv1alpha1.ParkedAnnotation] == metalv1alpha1.ParkedAnnotationTrue
+}
+
+// isServerParkingOrParked reports whether a Server is being parked or already parked.
+func isServerParkingOrParked(server *metalv1alpha1.Server) bool {
+	if isServerParked(server) {
+		return true
+	}
+	return server.GetAnnotations()[metalv1alpha1.OperationAnnotation] == metalv1alpha1.OperationAnnotationPark
+}
+
 // shouldChildIgnoreReconciliation checks if the object Child should ignore reconciliation.
 // if Parent has OperationAnnotation set to ignore-child, Child should also ignore reconciliation.
 func shouldChildIgnoreReconciliation(parentObj client.Object) bool {

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	"github.com/ironcore-dev/controller-utils/conditionutils"
+	"github.com/ironcore-dev/controller-utils/metautils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/ironcore-dev/metal-operator/bmc"
 	"github.com/ironcore-dev/metal-operator/internal/api/registry"
@@ -240,6 +241,10 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 	defer bmcClient.Logout()
 
 	if modified, err := r.patchServerURI(ctx, bmcClient, server); err != nil || modified {
+		return ctrl.Result{}, err
+	}
+
+	if modified, err := r.handleParkedState(ctx, bmcClient, server); err != nil || modified {
 		return ctrl.Result{}, err
 	}
 
@@ -724,6 +729,128 @@ func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient
 
 	log.V(1).Info("Reconciled maintenance state")
 	return false, nil
+}
+
+func (r *ServerReconciler) handleParkedState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	parked := isServerParked(server)
+	hasParkRequest := server.GetAnnotations()[metalv1alpha1.OperationAnnotation] == metalv1alpha1.OperationAnnotationPark
+
+	// 1. Resume: the parked annotation is gone but state still records Parked.
+	if !parked && server.Status.State == metalv1alpha1.ServerStateParked {
+		prePark := r.resolvePreParkState(server)
+		log.Info("Resuming Server from Parked state", "preParkState", prePark)
+		if err := r.updateServerStatusFromSystemInfo(ctx, bmcClient, server); err != nil {
+			return false, fmt.Errorf("failed to refresh server system info on resume: %w", err)
+		}
+		if modified, err := r.patchServerState(ctx, server, prePark); err != nil || modified {
+			return modified, err
+		}
+		return false, nil
+	}
+
+	// 2. Stay parked: the annotation is the source of truth.
+	if parked {
+		if server.Status.State != metalv1alpha1.ServerStateParked {
+			log.Info("Reconciling Parked state from parked annotation", "currentState", server.Status.State)
+			if modified, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateParked); err != nil || modified {
+				return modified, err
+			}
+		}
+		if server.Status.PowerState != metalv1alpha1.ServerOffPowerState &&
+			server.Status.PowerState != metalv1alpha1.ServerPoweringOffPowerState {
+			log.V(1).Info("Server is parked but not off, powering off")
+			if err := r.ensureParkedServerPoweredOff(ctx, bmcClient, server); err != nil {
+				return false, err
+			}
+		}
+		return false, nil
+	}
+
+	// 3. Park request: not parked yet.
+	if hasParkRequest {
+		if !isParkableState(server.Status.State) {
+			log.V(1).Info("Server is not in a parkable state, deferring park request", "currentState", server.Status.State)
+			return false, nil
+		}
+		log.V(1).Info("Park requested, parking server")
+		return r.parkServer(ctx, bmcClient, server)
+	}
+
+	return false, nil
+}
+
+func isParkableState(state metalv1alpha1.ServerState) bool {
+	switch state {
+	case metalv1alpha1.ServerStateAvailable, metalv1alpha1.ServerStateReserved:
+		return true
+	}
+	return false
+}
+
+// parkServer powers the server off (idempotent), records the parked annotation,
+// sets status.state = Parked, and removes the transient operation: park request annotation.
+func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	if err := r.ensureParkedServerPoweredOff(ctx, bmcClient, server); err != nil {
+		return false, err
+	}
+
+	if server.Status.PowerState != metalv1alpha1.ServerOffPowerState {
+		return true, nil
+	}
+
+	serverBase := server.DeepCopy()
+	metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)
+	metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
+	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+		return false, fmt.Errorf("failed to patch parked annotations: %w", err)
+	}
+
+	if _, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateParked); err != nil {
+		return false, err
+	}
+	log.Info("Parked Server")
+	return true, nil
+}
+
+// ensureParkedServerPoweredOff sets spec.Power = PowerOff and powers the server.
+func (r *ServerReconciler) ensureParkedServerPoweredOff(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	if server.Spec.Power != metalv1alpha1.PowerOff {
+		serverBase := server.DeepCopy()
+		// TODO: drop the spec.power write — it's deprecated (#1042) and only kept here to carry
+		// the desired state until the field is removed.
+		server.Spec.Power = metalv1alpha1.PowerOff
+		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+			return fmt.Errorf("failed to patch spec.power: %w", err)
+		}
+		log.V(1).Info("Requested power off for parked server")
+	}
+
+	if err := r.updateServerStatus(ctx, bmcClient, server); err != nil {
+		return fmt.Errorf("failed to update server status: %w", err)
+	}
+
+	if server.Status.PowerState == metalv1alpha1.ServerOffPowerState ||
+		server.Status.PowerState == metalv1alpha1.ServerPoweringOffPowerState {
+		return nil
+	}
+
+	if err := bmcClient.PowerOff(ctx, server.Spec.SystemURI); err != nil {
+		return fmt.Errorf("failed to power off parked server: %w", err)
+	}
+	return nil
+}
+
+func (r *ServerReconciler) resolvePreParkState(server *metalv1alpha1.Server) metalv1alpha1.ServerState {
+	if server.Spec.ServerClaimRef != nil {
+		return metalv1alpha1.ServerStateReserved
+	}
+	return metalv1alpha1.ServerStateAvailable
 }
 
 func (r *ServerReconciler) ensureServerBootConfigRef(ctx context.Context, server *metalv1alpha1.Server, config *metalv1alpha1.ServerBootConfiguration) error {

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -85,6 +86,7 @@ type ServerReconciler struct {
 	client.Client
 	APIReader               client.Reader
 	Scheme                  *runtime.Scheme
+	Recorder                events.EventRecorder
 	DefaultProtocol         metalv1alpha1.ProtocolScheme
 	SkipCertValidation      bool
 	ManagerNamespace        string
@@ -113,6 +115,7 @@ type ServerReconciler struct {
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=serverconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="batch",resources=jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -732,22 +735,64 @@ func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient
 func (r *ServerReconciler) handleAnnotationOperations(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
 	operation := server.GetAnnotations()[metalv1alpha1.OperationAnnotation]
 
-	if isServerParked(server) && operation != metalv1alpha1.OperationAnnotationUnpark {
-		return ctrl.Result{}, true, r.stayParked(ctx, server)
-	}
-
-	switch operation {
-	case metalv1alpha1.OperationAnnotationUnpark:
+	switch {
+	case operation == metalv1alpha1.OperationAnnotationUnpark:
 		modified, err := r.unparkServer(ctx, server)
 		return ctrl.Result{}, modified, err
-	case metalv1alpha1.OperationAnnotationPark:
+	case operation == metalv1alpha1.OperationAnnotationPark:
+		if isServerParked(server) {
+			return r.standDownParked(ctx, server, operation)
+		}
 		return r.parkServer(ctx, bmcClient, server)
-	case "":
-		return ctrl.Result{}, false, nil
-	default:
+	case isResetAnnotation(operation):
+		if isServerParked(server) {
+			return r.standDownParked(ctx, server, operation)
+		}
 		modified, err := r.resetServer(ctx, bmcClient, server, operation)
 		return ctrl.Result{}, modified, err
+	default:
+		if operation != "" {
+			return r.rejectUnsupportedOperation(ctx, server, operation)
+		}
+		if isServerParked(server) {
+			return r.standDownParked(ctx, server, operation)
+		}
+		return ctrl.Result{}, false, nil
 	}
+}
+
+func (r *ServerReconciler) standDownParked(ctx context.Context, server *metalv1alpha1.Server, operation string) (ctrl.Result, bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	if operation != "" {
+		log.V(1).Info("Server is parked, dropping operation annotation", "Operation", operation)
+		if err := r.removeOperationAnnotation(ctx, server); err != nil {
+			return ctrl.Result{}, false, err
+		}
+
+		if operation != metalv1alpha1.OperationAnnotationPark {
+			r.Recorder.Eventf(server, nil, v1.EventTypeWarning, "ParkedOperationDropped", "ClearOperationAnnotation", "Operation %q dropped because server is parked", operation)
+		}
+	}
+	return ctrl.Result{}, true, r.stayParked(ctx, server)
+}
+
+func (r *ServerReconciler) removeOperationAnnotation(ctx context.Context, server *metalv1alpha1.Server) error {
+	serverBase := server.DeepCopy()
+	metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
+	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+		return fmt.Errorf("failed to consume operation annotation: %w", err)
+	}
+	return nil
+}
+
+func (r *ServerReconciler) rejectUnsupportedOperation(ctx context.Context, server *metalv1alpha1.Server, operation string) (ctrl.Result, bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.V(1).Info("Unsupported operation annotation", "Operation", operation, "SupportedOperations", metalv1alpha1.AnnotationToRedfishMapping)
+	r.Recorder.Eventf(server, nil, v1.EventTypeWarning, "UnsupportedOperation", "ClearOperationAnnotation", "Unsupported operation annotation %q", operation)
+	if err := r.removeOperationAnnotation(ctx, server); err != nil {
+		return ctrl.Result{}, false, err
+	}
+	return ctrl.Result{}, true, nil
 }
 
 func (r *ServerReconciler) unparkServer(ctx context.Context, server *metalv1alpha1.Server) (bool, error) {
@@ -757,20 +802,16 @@ func (r *ServerReconciler) unparkServer(ctx context.Context, server *metalv1alph
 		log.V(1).Info("Unpark requested, releasing server")
 		serverBase := server.DeepCopy()
 		metautils.DeleteAnnotation(server, metalv1alpha1.ParkedAnnotation)
+		metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
 		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
 			return false, fmt.Errorf("failed to release parked annotation: %w", err)
 		}
+		r.Recorder.Eventf(server, nil, v1.EventTypeNormal, "Unparking", "Unpark", "Unpark requested, releasing server")
 		return true, nil
 	}
 
-	if server.Status.State == metalv1alpha1.ServerStateParked {
-		return false, nil
-	}
-
-	serverBase := server.DeepCopy()
-	metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
-	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-		return false, fmt.Errorf("failed to consume unpark request: %w", err)
+	if err := r.removeOperationAnnotation(ctx, server); err != nil {
+		return false, err
 	}
 	return true, nil
 }
@@ -778,11 +819,17 @@ func (r *ServerReconciler) unparkServer(ctx context.Context, server *metalv1alph
 func (r *ServerReconciler) resumeParkedServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 	prePark := r.resolvePreParkState(server)
+
 	log.Info("Resuming Server from Parked state", "preParkState", prePark)
 	if err := r.updateServerStatusFromSystemInfo(ctx, bmcClient, server); err != nil {
 		return false, fmt.Errorf("failed to refresh server system info on resume: %w", err)
 	}
-	return r.patchServerState(ctx, server, prePark)
+
+	modified, err := r.patchServerState(ctx, server, prePark)
+	if err == nil && modified {
+		r.Recorder.Eventf(server, nil, v1.EventTypeNormal, "Resumed", "Resume", "Resumed Server from Parked state to %s", prePark)
+	}
+	return modified, err
 }
 
 func (r *ServerReconciler) stayParked(ctx context.Context, server *metalv1alpha1.Server) error {
@@ -795,11 +842,7 @@ func (r *ServerReconciler) stayParked(ctx context.Context, server *metalv1alpha1
 
 func (r *ServerReconciler) resetServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server, operation string) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	resetType, ok := metalv1alpha1.AnnotationToRedfishMapping[operation]
-	if !ok {
-		log.V(1).Info("Unsupported operation annotation", "Operation", operation, "SupportedOperations", metalv1alpha1.AnnotationToRedfishMapping)
-		return false, nil
-	}
+	resetType := metalv1alpha1.AnnotationToRedfishMapping[operation]
 
 	log.V(1).Info("Handling operation", "Operation", operation, "RedfishResetType", resetType)
 	if err := bmcClient.Reset(ctx, server.Spec.SystemURI, resetType); err != nil {
@@ -807,10 +850,8 @@ func (r *ServerReconciler) resetServer(ctx context.Context, bmcClient bmc.BMC, s
 	}
 	log.V(1).Info("Operation completed", "Operation", operation, "RedfishResetType", resetType)
 
-	serverBase := server.DeepCopy()
-	metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
-	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-		return false, fmt.Errorf("failed to consume operation annotation: %w", err)
+	if err := r.removeOperationAnnotation(ctx, server); err != nil {
+		return false, err
 	}
 	return true, nil
 }
@@ -823,11 +864,17 @@ func isParkableState(state metalv1alpha1.ServerState) bool {
 	return false
 }
 
+func isResetAnnotation(operation string) bool {
+	_, ok := metalv1alpha1.AnnotationToRedfishMapping[operation]
+	return ok
+}
+
 func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if !isParkableState(server.Status.State) {
 		log.V(1).Info("Server is not in a parkable state, deferring park request", "currentState", server.Status.State)
+		r.Recorder.Eventf(server, nil, v1.EventTypeWarning, "ParkDeferred", "DeferPark", "Park request deferred because server is in state %q", server.Status.State)
 		return ctrl.Result{}, false, nil
 	}
 
@@ -856,10 +903,8 @@ func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, se
 		return ctrl.Result{}, false, fmt.Errorf("failed to patch parked annotations: %w", err)
 	}
 
-	if _, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateParked); err != nil {
-		return ctrl.Result{}, false, err
-	}
 	log.Info("Parked Server")
+	r.Recorder.Eventf(server, nil, v1.EventTypeNormal, "Parked", "PowerOff", "Parked Server, powered off")
 	return ctrl.Result{}, true, nil
 }
 

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -244,12 +244,8 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 		return ctrl.Result{}, err
 	}
 
-	if result, handled, err := r.handleParking(ctx, bmcClient, server); err != nil || handled {
+	if result, modified, err := r.handleAnnotationOperations(ctx, bmcClient, server); err != nil || modified {
 		return result, err
-	}
-
-	if modified, err := r.handleAnnotationOperations(ctx, bmcClient, server); err != nil || modified {
-		return ctrl.Result{}, err
 	}
 	log.V(1).Info("Handled annotation operations")
 
@@ -328,6 +324,8 @@ func (r *ServerReconciler) ensureServerStateTransition(ctx context.Context, bmcC
 		return r.handleReleasedState(ctx, bmcClient, server)
 	case metalv1alpha1.ServerStateMaintenance:
 		return r.handleMaintenanceState(ctx, bmcClient, server)
+	case metalv1alpha1.ServerStateParked:
+		return r.resumeParkedServer(ctx, bmcClient, server)
 	default:
 		return false, nil
 	}
@@ -731,63 +729,90 @@ func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient
 	return false, nil
 }
 
-func (r *ServerReconciler) handleParking(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
+func (r *ServerReconciler) handleAnnotationOperations(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
+	operation := server.GetAnnotations()[metalv1alpha1.OperationAnnotation]
+
+	if isServerParked(server) && operation != metalv1alpha1.OperationAnnotationUnpark {
+		return ctrl.Result{}, true, r.stayParked(ctx, server)
+	}
+
+	switch operation {
+	case metalv1alpha1.OperationAnnotationUnpark:
+		modified, err := r.unparkServer(ctx, server)
+		return ctrl.Result{}, modified, err
+	case metalv1alpha1.OperationAnnotationPark:
+		return r.parkServer(ctx, bmcClient, server)
+	case "":
+		return ctrl.Result{}, false, nil
+	default:
+		modified, err := r.resetServer(ctx, bmcClient, server, operation)
+		return ctrl.Result{}, modified, err
+	}
+}
+
+func (r *ServerReconciler) unparkServer(ctx context.Context, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	parked := isServerParked(server)
-	operation := server.GetAnnotations()[metalv1alpha1.OperationAnnotation]
-	hasParkRequest := operation == metalv1alpha1.OperationAnnotationPark
-	hasUnparkRequest := operation == metalv1alpha1.OperationAnnotationUnpark
-
-	// 0. Unpark
-	if hasUnparkRequest {
+	if isServerParked(server) {
+		log.V(1).Info("Unpark requested, releasing server")
 		serverBase := server.DeepCopy()
-		metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
-		if parked {
-			log.V(1).Info("Unpark requested, releasing server")
-			metautils.DeleteAnnotation(server, metalv1alpha1.ParkedAnnotation)
-		}
+		metautils.DeleteAnnotation(server, metalv1alpha1.ParkedAnnotation)
 		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-			return ctrl.Result{}, false, fmt.Errorf("failed to consume unpark request: %w", err)
+			return false, fmt.Errorf("failed to release parked annotation: %w", err)
 		}
-		return ctrl.Result{}, true, nil
+		return true, nil
 	}
 
-	// 1. Resume: the parked annotation is gone but state still records Parked.
-	if !parked && server.Status.State == metalv1alpha1.ServerStateParked {
-		prePark := r.resolvePreParkState(server)
-		log.Info("Resuming Server from Parked state", "preParkState", prePark)
-		if err := r.updateServerStatusFromSystemInfo(ctx, bmcClient, server); err != nil {
-			return ctrl.Result{}, false, fmt.Errorf("failed to refresh server system info on resume: %w", err)
-		}
-		if modified, err := r.patchServerState(ctx, server, prePark); err != nil || modified {
-			return ctrl.Result{}, modified, err
-		}
-		return ctrl.Result{}, false, nil
+	if server.Status.State == metalv1alpha1.ServerStateParked {
+		return false, nil
 	}
 
-	// 2. Stay parked
-	if parked {
-		if server.Status.State != metalv1alpha1.ServerStateParked {
-			log.Info("Reconciling Parked state from parked annotation", "currentState", server.Status.State)
-			if modified, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateParked); err != nil || modified {
-				return ctrl.Result{}, modified, err
-			}
-		}
-		return ctrl.Result{}, true, nil
+	serverBase := server.DeepCopy()
+	metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
+	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+		return false, fmt.Errorf("failed to consume unpark request: %w", err)
+	}
+	return true, nil
+}
+
+func (r *ServerReconciler) resumeParkedServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	prePark := r.resolvePreParkState(server)
+	log.Info("Resuming Server from Parked state", "preParkState", prePark)
+	if err := r.updateServerStatusFromSystemInfo(ctx, bmcClient, server); err != nil {
+		return false, fmt.Errorf("failed to refresh server system info on resume: %w", err)
+	}
+	return r.patchServerState(ctx, server, prePark)
+}
+
+func (r *ServerReconciler) stayParked(ctx context.Context, server *metalv1alpha1.Server) error {
+	if server.Status.State == metalv1alpha1.ServerStateParked {
+		return nil
+	}
+	_, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateParked)
+	return err
+}
+
+func (r *ServerReconciler) resetServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server, operation string) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	resetType, ok := metalv1alpha1.AnnotationToRedfishMapping[operation]
+	if !ok {
+		log.V(1).Info("Unsupported operation annotation", "Operation", operation, "SupportedOperations", metalv1alpha1.AnnotationToRedfishMapping)
+		return false, nil
 	}
 
-	// 3. Park request: not parked yet.
-	if hasParkRequest {
-		if !isParkableState(server.Status.State) {
-			log.V(1).Info("Server is not in a parkable state, deferring park request", "currentState", server.Status.State)
-			return ctrl.Result{}, false, nil
-		}
-		log.V(1).Info("Park requested, parking server")
-		return r.parkServer(ctx, bmcClient, server)
+	log.V(1).Info("Handling operation", "Operation", operation, "RedfishResetType", resetType)
+	if err := bmcClient.Reset(ctx, server.Spec.SystemURI, resetType); err != nil {
+		return false, fmt.Errorf("failed to reset server: %w", err)
 	}
+	log.V(1).Info("Operation completed", "Operation", operation, "RedfishResetType", resetType)
 
-	return ctrl.Result{}, false, nil
+	serverBase := server.DeepCopy()
+	metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
+	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+		return false, fmt.Errorf("failed to consume operation annotation: %w", err)
+	}
+	return true, nil
 }
 
 func isParkableState(state metalv1alpha1.ServerState) bool {
@@ -800,6 +825,11 @@ func isParkableState(state metalv1alpha1.ServerState) bool {
 
 func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
+
+	if !isParkableState(server.Status.State) {
+		log.V(1).Info("Server is not in a parkable state, deferring park request", "currentState", server.Status.State)
+		return ctrl.Result{}, false, nil
+	}
 
 	if err := r.updateServerStatus(ctx, bmcClient, server); err != nil {
 		return ctrl.Result{}, false, fmt.Errorf("failed to update server status: %w", err)
@@ -1500,33 +1530,6 @@ func (r *ServerReconciler) applyBootOrder(ctx context.Context, bmcClient bmc.BMC
 		return bmcClient.SetBootOrder(ctx, server.Spec.SystemURI, newOrder)
 	}
 	return nil
-}
-
-func (r *ServerReconciler) handleAnnotationOperations(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
-	annotations := server.GetAnnotations()
-	operation, ok := annotations[metalv1alpha1.OperationAnnotation]
-	if !ok {
-		return false, nil
-	}
-
-	if value, ok := metalv1alpha1.AnnotationToRedfishMapping[operation]; !ok {
-		log.V(1).Info("Unsupported operation annotation", "Operation", operation, "SupportedOperations", metalv1alpha1.AnnotationToRedfishMapping)
-		return false, nil
-	} else {
-		log.V(1).Info("Handling operation", "Operation", operation, "RedfishResetType", value)
-		if err := bmcClient.Reset(ctx, server.Spec.SystemURI, value); err != nil {
-			return false, fmt.Errorf("failed to reset server: %w", err)
-		}
-		log.V(1).Info("Operation completed", "Operation", operation, "RedfishResetType", value)
-		serverBase := server.DeepCopy()
-		delete(annotations, metalv1alpha1.OperationAnnotation)
-		server.SetAnnotations(annotations)
-		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-			return false, fmt.Errorf("failed to patch server annotations: %w", err)
-		}
-	}
-	return true, nil
 }
 
 func (r *ServerReconciler) checkLastStatusUpdateAfter(duration time.Duration, server *metalv1alpha1.Server) bool {

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -733,47 +733,54 @@ func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient
 }
 
 func (r *ServerReconciler) handleAnnotationOperations(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
+	log := ctrl.LoggerFrom(ctx)
 	operation := server.GetAnnotations()[metalv1alpha1.OperationAnnotation]
+
+	var (
+		result ctrl.Result
+		done   bool
+		err    error
+	)
 
 	switch {
 	case operation == metalv1alpha1.OperationAnnotationUnpark:
-		modified, err := r.unparkServer(ctx, server)
-		return ctrl.Result{}, modified, err
+		done, err = true, r.unparkServer(ctx, server)
+	case isServerParked(server) && (operation == metalv1alpha1.OperationAnnotationPark || isResetAnnotation(operation) || operation == ""):
+		done, err = true, r.standDownParked(ctx, server, operation)
 	case operation == metalv1alpha1.OperationAnnotationPark:
-		if isServerParked(server) {
-			return r.standDownParked(ctx, server, operation)
-		}
-		return r.parkServer(ctx, bmcClient, server)
+		result, done, err = r.parkServer(ctx, bmcClient, server)
 	case isResetAnnotation(operation):
-		if isServerParked(server) {
-			return r.standDownParked(ctx, server, operation)
-		}
-		modified, err := r.resetServer(ctx, bmcClient, server, operation)
-		return ctrl.Result{}, modified, err
+		done, err = true, r.resetServer(ctx, bmcClient, server, operation)
+	case operation != "":
+		r.rejectUnsupportedOperation(ctx, server, operation)
+		done = true
 	default:
-		if operation != "" {
-			return r.rejectUnsupportedOperation(ctx, server, operation)
-		}
-		if isServerParked(server) {
-			return r.standDownParked(ctx, server, operation)
-		}
 		return ctrl.Result{}, false, nil
 	}
-}
 
-func (r *ServerReconciler) standDownParked(ctx context.Context, server *metalv1alpha1.Server, operation string) (ctrl.Result, bool, error) {
-	log := ctrl.LoggerFrom(ctx)
+	// not done yet
+	if err != nil || !done || !result.IsZero() {
+		return result, done, err
+	}
+
 	if operation != "" {
-		log.V(1).Info("Server is parked, dropping operation annotation", "Operation", operation)
 		if err := r.removeOperationAnnotation(ctx, server); err != nil {
 			return ctrl.Result{}, false, err
 		}
+		log.V(1).Info("Removed operation annotation", "Operation", operation)
+	}
+	return ctrl.Result{}, true, nil
+}
 
+func (r *ServerReconciler) standDownParked(ctx context.Context, server *metalv1alpha1.Server, operation string) error {
+	log := ctrl.LoggerFrom(ctx)
+	if operation != "" {
+		log.V(1).Info("Dropping Server operation annotation because Server is parked", "Operation", operation)
 		if operation != metalv1alpha1.OperationAnnotationPark {
 			r.Recorder.Eventf(server, nil, v1.EventTypeWarning, "ParkedOperationDropped", "ClearOperationAnnotation", "Operation %q dropped because server is parked", operation)
 		}
 	}
-	return ctrl.Result{}, true, r.stayParked(ctx, server)
+	return r.stayParked(ctx, server)
 }
 
 func (r *ServerReconciler) removeOperationAnnotation(ctx context.Context, server *metalv1alpha1.Server) error {
@@ -785,35 +792,27 @@ func (r *ServerReconciler) removeOperationAnnotation(ctx context.Context, server
 	return nil
 }
 
-func (r *ServerReconciler) rejectUnsupportedOperation(ctx context.Context, server *metalv1alpha1.Server, operation string) (ctrl.Result, bool, error) {
+func (r *ServerReconciler) rejectUnsupportedOperation(ctx context.Context, server *metalv1alpha1.Server, operation string) {
 	log := ctrl.LoggerFrom(ctx)
-	log.V(1).Info("Unsupported operation annotation", "Operation", operation, "SupportedOperations", metalv1alpha1.AnnotationToRedfishMapping)
+	log.V(1).Info("Unsupported Server operation annotation", "Operation", operation, "SupportedOperations", metalv1alpha1.AnnotationToRedfishMapping)
 	r.Recorder.Eventf(server, nil, v1.EventTypeWarning, "UnsupportedOperation", "ClearOperationAnnotation", "Unsupported operation annotation %q", operation)
-	if err := r.removeOperationAnnotation(ctx, server); err != nil {
-		return ctrl.Result{}, false, err
-	}
-	return ctrl.Result{}, true, nil
 }
 
-func (r *ServerReconciler) unparkServer(ctx context.Context, server *metalv1alpha1.Server) (bool, error) {
+func (r *ServerReconciler) unparkServer(ctx context.Context, server *metalv1alpha1.Server) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	if isServerParked(server) {
-		log.V(1).Info("Unpark requested, releasing server")
-		serverBase := server.DeepCopy()
-		metautils.DeleteAnnotation(server, metalv1alpha1.ParkedAnnotation)
-		metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
-		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-			return false, fmt.Errorf("failed to release parked annotation: %w", err)
-		}
-		r.Recorder.Eventf(server, nil, v1.EventTypeNormal, "Unparking", "Unpark", "Unpark requested, releasing server")
-		return true, nil
+	if !isServerParked(server) {
+		return nil
 	}
 
-	if err := r.removeOperationAnnotation(ctx, server); err != nil {
-		return false, err
+	log.V(1).Info("Unpark requested, releasing server")
+	serverBase := server.DeepCopy()
+	metautils.DeleteAnnotation(server, metalv1alpha1.ParkedAnnotation)
+	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+		return fmt.Errorf("failed to release parked annotation: %w", err)
 	}
-	return true, nil
+	r.Recorder.Eventf(server, nil, v1.EventTypeNormal, "Unparking", "Unpark", "Unpark requested, releasing server")
+	return nil
 }
 
 func (r *ServerReconciler) resumeParkedServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
@@ -840,33 +839,16 @@ func (r *ServerReconciler) stayParked(ctx context.Context, server *metalv1alpha1
 	return err
 }
 
-func (r *ServerReconciler) resetServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server, operation string) (bool, error) {
+func (r *ServerReconciler) resetServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server, operation string) error {
 	log := ctrl.LoggerFrom(ctx)
 	resetType := metalv1alpha1.AnnotationToRedfishMapping[operation]
 
 	log.V(1).Info("Handling operation", "Operation", operation, "RedfishResetType", resetType)
 	if err := bmcClient.Reset(ctx, server.Spec.SystemURI, resetType); err != nil {
-		return false, fmt.Errorf("failed to reset server: %w", err)
+		return fmt.Errorf("failed to reset server: %w", err)
 	}
 	log.V(1).Info("Operation completed", "Operation", operation, "RedfishResetType", resetType)
-
-	if err := r.removeOperationAnnotation(ctx, server); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func isParkableState(state metalv1alpha1.ServerState) bool {
-	switch state {
-	case metalv1alpha1.ServerStateAvailable, metalv1alpha1.ServerStateReserved:
-		return true
-	}
-	return false
-}
-
-func isResetAnnotation(operation string) bool {
-	_, ok := metalv1alpha1.AnnotationToRedfishMapping[operation]
-	return ok
+	return nil
 }
 
 func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
@@ -898,7 +880,6 @@ func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, se
 
 	serverBase := server.DeepCopy()
 	metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.ParkedAnnotation, "true")
-	metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
 	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
 		return ctrl.Result{}, false, fmt.Errorf("failed to patch parked annotations: %w", err)
 	}

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -244,8 +244,8 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 		return ctrl.Result{}, err
 	}
 
-	if modified, err := r.handleParkedState(ctx, bmcClient, server); err != nil || modified {
-		return ctrl.Result{}, err
+	if result, handled, err := r.handleParkedState(ctx, bmcClient, server); err != nil || handled {
+		return result, err
 	}
 
 	if modified, err := r.handleAnnotationOperations(ctx, bmcClient, server); err != nil || modified {
@@ -731,7 +731,7 @@ func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient
 	return false, nil
 }
 
-func (r *ServerReconciler) handleParkedState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
+func (r *ServerReconciler) handleParkedState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	parked := isServerParked(server)
@@ -742,43 +742,38 @@ func (r *ServerReconciler) handleParkedState(ctx context.Context, bmcClient bmc.
 		prePark := r.resolvePreParkState(server)
 		log.Info("Resuming Server from Parked state", "preParkState", prePark)
 		if err := r.updateServerStatusFromSystemInfo(ctx, bmcClient, server); err != nil {
-			return false, fmt.Errorf("failed to refresh server system info on resume: %w", err)
+			return ctrl.Result{}, false, fmt.Errorf("failed to refresh server system info on resume: %w", err)
 		}
 		if modified, err := r.patchServerState(ctx, server, prePark); err != nil || modified {
-			return modified, err
+			return ctrl.Result{}, modified, err
 		}
-		return false, nil
+		return ctrl.Result{}, false, nil
 	}
 
-	// 2. Stay parked: the annotation is the source of truth.
+	// 2. Stay parked: the annotation is the source of truth. Stand down entirely: no power
+	// healing, no boot order, no state-machine progression. The external actor owns the server
+	// (including power) until the parked annotation is removed, which re-triggers reconciliation.
 	if parked {
 		if server.Status.State != metalv1alpha1.ServerStateParked {
 			log.Info("Reconciling Parked state from parked annotation", "currentState", server.Status.State)
 			if modified, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateParked); err != nil || modified {
-				return modified, err
+				return ctrl.Result{}, modified, err
 			}
 		}
-		if server.Status.PowerState != metalv1alpha1.ServerOffPowerState &&
-			server.Status.PowerState != metalv1alpha1.ServerPoweringOffPowerState {
-			log.V(1).Info("Server is parked but not off, powering off")
-			if err := r.ensureParkedServerPoweredOff(ctx, bmcClient, server); err != nil {
-				return false, err
-			}
-		}
-		return false, nil
+		return ctrl.Result{}, true, nil
 	}
 
 	// 3. Park request: not parked yet.
 	if hasParkRequest {
 		if !isParkableState(server.Status.State) {
 			log.V(1).Info("Server is not in a parkable state, deferring park request", "currentState", server.Status.State)
-			return false, nil
+			return ctrl.Result{}, false, nil
 		}
 		log.V(1).Info("Park requested, parking server")
 		return r.parkServer(ctx, bmcClient, server)
 	}
 
-	return false, nil
+	return ctrl.Result{}, false, nil
 }
 
 func isParkableState(state metalv1alpha1.ServerState) bool {
@@ -789,61 +784,42 @@ func isParkableState(state metalv1alpha1.ServerState) bool {
 	return false
 }
 
-// parkServer powers the server off (idempotent), records the parked annotation,
-// sets status.state = Parked, and removes the transient operation: park request annotation.
-func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
+// parkServer powers the server off via the BMC (idempotent, spec.power is left untouched),
+// records the parked annotation, sets status.state = Parked, and removes the transient
+// operation: park request annotation.
+func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if err := r.ensureParkedServerPoweredOff(ctx, bmcClient, server); err != nil {
-		return false, err
+	if err := r.updateServerStatus(ctx, bmcClient, server); err != nil {
+		return ctrl.Result{}, false, fmt.Errorf("failed to update server status: %w", err)
+	}
+
+	if server.Status.PowerState != metalv1alpha1.ServerOffPowerState &&
+		server.Status.PowerState != metalv1alpha1.ServerPoweringOffPowerState {
+		if err := bmcClient.PowerOff(ctx, server.Spec.SystemURI); err != nil {
+			return ctrl.Result{}, false, fmt.Errorf("failed to power off server for parking: %w", err)
+		}
+		log.V(1).Info("Requested power off for parking")
 	}
 
 	if server.Status.PowerState != metalv1alpha1.ServerOffPowerState {
-		return true, nil
+		// Wait for the power off to take effect; requeue explicitly since a BMC-side power
+		// transition might not produce a watch event.
+		return ctrl.Result{RequeueAfter: r.ResyncInterval}, true, nil
 	}
 
 	serverBase := server.DeepCopy()
 	metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)
 	metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
 	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-		return false, fmt.Errorf("failed to patch parked annotations: %w", err)
+		return ctrl.Result{}, false, fmt.Errorf("failed to patch parked annotations: %w", err)
 	}
 
 	if _, err := r.patchServerState(ctx, server, metalv1alpha1.ServerStateParked); err != nil {
-		return false, err
+		return ctrl.Result{}, false, err
 	}
 	log.Info("Parked Server")
-	return true, nil
-}
-
-// ensureParkedServerPoweredOff sets spec.Power = PowerOff and powers the server.
-func (r *ServerReconciler) ensureParkedServerPoweredOff(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) error {
-	log := ctrl.LoggerFrom(ctx)
-
-	if server.Spec.Power != metalv1alpha1.PowerOff {
-		serverBase := server.DeepCopy()
-		// TODO: drop the spec.power write — it's deprecated (#1042) and only kept here to carry
-		// the desired state until the field is removed.
-		server.Spec.Power = metalv1alpha1.PowerOff
-		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-			return fmt.Errorf("failed to patch spec.power: %w", err)
-		}
-		log.V(1).Info("Requested power off for parked server")
-	}
-
-	if err := r.updateServerStatus(ctx, bmcClient, server); err != nil {
-		return fmt.Errorf("failed to update server status: %w", err)
-	}
-
-	if server.Status.PowerState == metalv1alpha1.ServerOffPowerState ||
-		server.Status.PowerState == metalv1alpha1.ServerPoweringOffPowerState {
-		return nil
-	}
-
-	if err := bmcClient.PowerOff(ctx, server.Spec.SystemURI); err != nil {
-		return fmt.Errorf("failed to power off parked server: %w", err)
-	}
-	return nil
+	return ctrl.Result{}, true, nil
 }
 
 func (r *ServerReconciler) resolvePreParkState(server *metalv1alpha1.Server) metalv1alpha1.ServerState {

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -735,7 +735,23 @@ func (r *ServerReconciler) handleParking(ctx context.Context, bmcClient bmc.BMC,
 	log := ctrl.LoggerFrom(ctx)
 
 	parked := isServerParked(server)
-	hasParkRequest := server.GetAnnotations()[metalv1alpha1.OperationAnnotation] == metalv1alpha1.OperationAnnotationPark
+	operation := server.GetAnnotations()[metalv1alpha1.OperationAnnotation]
+	hasParkRequest := operation == metalv1alpha1.OperationAnnotationPark
+	hasUnparkRequest := operation == metalv1alpha1.OperationAnnotationUnpark
+
+	// 0. Unpark
+	if hasUnparkRequest {
+		serverBase := server.DeepCopy()
+		metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
+		if parked {
+			log.V(1).Info("Unpark requested, releasing server")
+			metautils.DeleteAnnotation(server, metalv1alpha1.ParkedAnnotation)
+		}
+		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+			return ctrl.Result{}, false, fmt.Errorf("failed to consume unpark request: %w", err)
+		}
+		return ctrl.Result{}, true, nil
+	}
 
 	// 1. Resume: the parked annotation is gone but state still records Parked.
 	if !parked && server.Status.State == metalv1alpha1.ServerStateParked {
@@ -750,9 +766,7 @@ func (r *ServerReconciler) handleParking(ctx context.Context, bmcClient bmc.BMC,
 		return ctrl.Result{}, false, nil
 	}
 
-	// 2. Stay parked: the annotation is the source of truth. Stand down entirely: no power
-	// healing, no boot order, no state-machine progression. The external actor owns the server
-	// (including power) until the parked annotation is removed, which re-triggers reconciliation.
+	// 2. Stay parked
 	if parked {
 		if server.Status.State != metalv1alpha1.ServerStateParked {
 			log.Info("Reconciling Parked state from parked annotation", "currentState", server.Status.State)
@@ -784,9 +798,6 @@ func isParkableState(state metalv1alpha1.ServerState) bool {
 	return false
 }
 
-// parkServer powers the server off via the BMC (idempotent, spec.power is left untouched),
-// records the parked annotation, sets status.state = Parked, and removes the transient
-// operation: park request annotation.
 func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -244,7 +244,7 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 		return ctrl.Result{}, err
 	}
 
-	if result, handled, err := r.handleParkedState(ctx, bmcClient, server); err != nil || handled {
+	if result, handled, err := r.handleParking(ctx, bmcClient, server); err != nil || handled {
 		return result, err
 	}
 
@@ -731,7 +731,7 @@ func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient
 	return false, nil
 }
 
-func (r *ServerReconciler) handleParkedState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
+func (r *ServerReconciler) handleParking(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	parked := isServerParked(server)
@@ -804,12 +804,12 @@ func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, se
 
 	if server.Status.PowerState != metalv1alpha1.ServerOffPowerState {
 		// Wait for the power off to take effect; requeue explicitly since a BMC-side power
-		// transition might not produce a watch event.
+		// transition does not produce a watch event.
 		return ctrl.Result{RequeueAfter: r.ResyncInterval}, true, nil
 	}
 
 	serverBase := server.DeepCopy()
-	metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)
+	metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.ParkedAnnotation, "true")
 	metautils.DeleteAnnotation(server, metalv1alpha1.OperationAnnotation)
 	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
 		return ctrl.Result{}, false, fmt.Errorf("failed to patch parked annotations: %w", err)

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	eventsv1 "k8s.io/api/events/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1295,37 +1294,6 @@ passwd:
 	})
 
 	Describe("Parked state", func() {
-		createServerAndSecret := func(ctx SpecContext) (*metalv1alpha1.Server, *metalv1alpha1.BMCSecret) {
-			By("Creating a BMCSecret")
-			bmcSecret := &metalv1alpha1.BMCSecret{
-				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-server-"},
-				Data: map[string][]byte{
-					"username": []byte("foo"),
-					"password": []byte("bar"),
-				},
-			}
-			Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
-
-			By("Creating a Server with inline BMC configuration")
-			server := &metalv1alpha1.Server{
-				ObjectMeta: metav1.ObjectMeta{GenerateName: "server-"},
-				Spec: metalv1alpha1.ServerSpec{
-					SystemUUID: "38947555-7742-3448-3784-823347823834",
-					BMC: &metalv1alpha1.BMCAccess{
-						Protocol: metalv1alpha1.Protocol{
-							Name: metalv1alpha1.ProtocolRedfishLocal,
-							Port: MockServerPort,
-						},
-						Address: MockServerIP,
-						BMCSecretRef: v1.LocalObjectReference{
-							Name: bmcSecret.Name,
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, server)).To(Succeed())
-			return server, bmcSecret
-		}
 
 		park := func(server *metalv1alpha1.Server) {
 			By("Requesting the server to be parked")
@@ -1565,35 +1533,6 @@ passwd:
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		})
 
-		It("should stay parked when a ServerMaintenanceRef appears while parked", func(ctx SpecContext) {
-			server, bmcSecret := createServerAndSecret(ctx)
-
-			By("Driving the Server to available state and parking it")
-			Eventually(UpdateStatus(server, func() {
-				server.Status.State = metalv1alpha1.ServerStateAvailable
-			})).Should(Succeed())
-			park(server)
-			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
-
-			By("Attaching a ServerMaintenanceRef while parked")
-			Eventually(Update(server, func() {
-				server.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{Name: "parked-maintenance"}
-			})).Should(Succeed())
-
-			By("Ensuring the server stays parked and does not flap to Maintenance")
-			Consistently(Object(server), "2s", "100ms").Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
-
-			By("Resuming the server after clearing the maintenance ref")
-			Eventually(Update(server, func() {
-				server.Spec.ServerMaintenanceRef = nil
-				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
-			})).Should(Succeed())
-			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
-
-			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
-			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
-		})
-
 		It("should defer a park request on a non-parkable state and park once parkable", func(ctx SpecContext) {
 			server, bmcSecret := createServerAndSecret(ctx)
 
@@ -1656,20 +1595,6 @@ passwd:
 				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
 			))
 
-			By("Ensuring a warning event was emitted for the reset dropped while parked")
-			Eventually(func(g Gomega) {
-				events := &eventsv1.EventList{}
-				g.Expect(k8sClient.List(ctx, events)).To(Succeed())
-				found := false
-				for _, e := range events.Items {
-					if e.Regarding.Name == server.Name && e.Reason == "ParkedOperationDropped" {
-						found = true
-						break
-					}
-				}
-				g.Expect(found).To(BeTrue(), "expected a ParkedOperationDropped warning event for the server")
-			}).Should(Succeed())
-
 			By("Resuming the server via an unpark request")
 			Eventually(Update(server, func() {
 				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
@@ -1680,76 +1605,11 @@ passwd:
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		})
 
-		It("should consume a redundant park request while already parked", func(ctx SpecContext) {
-			server, bmcSecret := createServerAndSecret(ctx)
-
-			By("Driving the Server to available state and parking it")
-			Eventually(UpdateStatus(server, func() {
-				server.Status.State = metalv1alpha1.ServerStateAvailable
-			})).Should(Succeed())
-			park(server)
-			Eventually(Object(server)).Should(SatisfyAll(
-				HaveField("Status.State", metalv1alpha1.ServerStateParked),
-				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
-			))
-
-			By("Re-issuing a park request against the already-parked server")
-			Eventually(Update(server, func() {
-				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)
-			})).Should(Succeed())
-
-			By("Ensuring the redundant park request is consumed and the server stays parked")
-			Eventually(Object(server)).Should(SatisfyAll(
-				HaveField("Status.State", metalv1alpha1.ServerStateParked),
-				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
-				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
-			))
-
-			By("Resuming the server via an unpark request")
-			Eventually(Update(server, func() {
-				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
-			})).Should(Succeed())
-			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
-
-			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
-			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
-		})
 	})
 
 	Describe("Operation annotations", func() {
-		createServerAndSecret := func(ctx SpecContext) (*metalv1alpha1.Server, *metalv1alpha1.BMCSecret) {
-			By("Creating a BMCSecret")
-			bmcSecret := &metalv1alpha1.BMCSecret{
-				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-server-"},
-				Data: map[string][]byte{
-					"username": []byte("foo"),
-					"password": []byte("bar"),
-				},
-			}
-			Expect(k8sClient.Create(ctx, bmcSecret)).Should(Succeed())
 
-			By("Creating a Server with inline BMC configuration")
-			server := &metalv1alpha1.Server{
-				ObjectMeta: metav1.ObjectMeta{GenerateName: "server-"},
-				Spec: metalv1alpha1.ServerSpec{
-					SystemUUID: "38947555-7742-3448-3784-823347823834",
-					BMC: &metalv1alpha1.BMCAccess{
-						Protocol: metalv1alpha1.Protocol{
-							Name: metalv1alpha1.ProtocolRedfishLocal,
-							Port: MockServerPort,
-						},
-						Address: MockServerIP,
-						BMCSecretRef: v1.LocalObjectReference{
-							Name: bmcSecret.Name,
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, server)).Should(Succeed())
-			return server, bmcSecret
-		}
-
-		It("should clear an unsupported operation annotation and emit a warning event", func(ctx SpecContext) {
+		It("should clear an unsupported operation annotation", func(ctx SpecContext) {
 			server, bmcSecret := createServerAndSecret(ctx)
 
 			By("Driving the Server to available state")
@@ -1772,7 +1632,7 @@ passwd:
 			Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
 		})
 
-		It("should emit a warning event for an unsupported operation while parked", func(ctx SpecContext) {
+		It("should clear an unsupported operation annotation while parked", func(ctx SpecContext) {
 			server, bmcSecret := createServerAndSecret(ctx)
 
 			By("Driving the Server to available state and parking it")
@@ -1792,38 +1652,47 @@ passwd:
 			By("Ensuring the unsupported operation annotation is consumed and the server stays parked")
 			Eventually(Object(server)).Should(SatisfyAll(
 				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
 				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
 			))
-
-			By("Ensuring a warning event was emitted for the unsupported operation")
-			Eventually(func(g Gomega) {
-				events := &eventsv1.EventList{}
-				g.Expect(k8sClient.List(ctx, events)).To(Succeed())
-				found := false
-				for _, e := range events.Items {
-					if e.Regarding.Name == server.Name && e.Reason == "UnsupportedOperation" {
-						found = true
-						break
-					}
-				}
-				g.Expect(found).To(BeTrue(), "expected an UnsupportedOperation warning event for the server")
-			}).Should(Succeed())
-
-			By("Ensuring no ParkedOperationDropped event fires for an unsupported operation")
-			Consistently(func(g Gomega) {
-				events := &eventsv1.EventList{}
-				g.Expect(k8sClient.List(ctx, events)).To(Succeed())
-				for _, e := range events.Items {
-					g.Expect(e.Regarding.Name == server.Name && e.Reason == "ParkedOperationDropped").To(BeFalse(),
-						"unsupported operations must not emit ParkedOperationDropped")
-				}
-			}, "1s").Should(Succeed())
 
 			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
 		})
 	})
 })
+
+func createServerAndSecret(ctx SpecContext) (*metalv1alpha1.Server, *metalv1alpha1.BMCSecret) {
+	By("Creating a BMCSecret")
+	bmcSecret := &metalv1alpha1.BMCSecret{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "test-server-"},
+		Data: map[string][]byte{
+			"username": []byte("foo"),
+			"password": []byte("bar"),
+		},
+	}
+	Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+	By("Creating a Server with inline BMC configuration")
+	server := &metalv1alpha1.Server{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "server-"},
+		Spec: metalv1alpha1.ServerSpec{
+			SystemUUID: "38947555-7742-3448-3784-823347823834",
+			BMC: &metalv1alpha1.BMCAccess{
+				Protocol: metalv1alpha1.Protocol{
+					Name: metalv1alpha1.ProtocolRedfishLocal,
+					Port: MockServerPort,
+				},
+				Address: MockServerIP,
+				BMCSecretRef: v1.LocalObjectReference{
+					Name: bmcSecret.Name,
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, server)).To(Succeed())
+	return server, bmcSecret
+}
 
 func deleteRegistrySystemIfExists(systemUUID string) {
 	response, err := http.Get(registryURL + "/systems/" + systemUUID)

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -1351,9 +1351,9 @@ passwd:
 				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
 			))
 
-			By("Removing the parked annotation to resume")
+			By("Requesting unpark to resume")
 			Eventually(Update(server, func() {
-				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
 
 			By("Ensuring the server resumes to available")
@@ -1396,9 +1396,9 @@ passwd:
 			))
 			Eventually(Object(claim)).Should(HaveField("Status.Phase", metalv1alpha1.PhaseBound))
 
-			By("Removing the parked annotation to resume")
+			By("Requesting unpark to resume")
 			Eventually(Update(server, func() {
-				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
 
 			By("Ensuring the server resumes to reserved")
@@ -1431,9 +1431,9 @@ passwd:
 				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
 			))
 
-			By("Removing the parked annotation to resume")
+			By("Requesting unpark to resume")
 			Eventually(Update(server, func() {
-				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
 			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
 
@@ -1471,9 +1471,9 @@ passwd:
 				server.Spec.ServerClaimRef = nil
 			})).Should(Succeed())
 
-			By("Removing the parked annotation to resume")
+			By("Requesting unpark to resume")
 			Eventually(Update(server, func() {
-				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
 
 			By("Ensuring the server resumes to available (not reserved) since the claim ref is gone")
@@ -1620,9 +1620,9 @@ passwd:
 				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
 			))
 
-			By("Removing the parked annotation to resume")
+			By("Requesting unpark to resume")
 			Eventually(Update(server, func() {
-				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
 			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
 

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -1347,7 +1347,7 @@ passwd:
 			Eventually(Object(server)).Should(SatisfyAll(
 				HaveField("Status.State", metalv1alpha1.ServerStateParked),
 				HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
-				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
 				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
 			))
 
@@ -1392,7 +1392,7 @@ passwd:
 			Eventually(Object(server)).Should(SatisfyAll(
 				HaveField("Status.State", metalv1alpha1.ServerStateParked),
 				HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
-				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
 			))
 			Eventually(Object(claim)).Should(HaveField("Status.Phase", metalv1alpha1.PhaseBound))
 
@@ -1428,7 +1428,7 @@ passwd:
 			By("Ensuring the reconciler reconstructs the Parked state from the annotation")
 			Eventually(Object(server)).Should(SatisfyAll(
 				HaveField("Status.State", metalv1alpha1.ServerStateParked),
-				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
 			))
 
 			By("Removing the parked annotation to resume")
@@ -1616,7 +1616,7 @@ passwd:
 			By("Ensuring the deferred request is now honored and the server is parked")
 			Eventually(Object(server)).Should(SatisfyAll(
 				HaveField("Status.State", metalv1alpha1.ServerStateParked),
-				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
 				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
 			))
 

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -1503,6 +1503,93 @@ passwd:
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		})
 
+		It("should not power off a parked server that the external actor powered on", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state and parking it")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+			park(server)
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
+
+			mockPowerState := func() string {
+				req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d%s", MockServerIP, MockServerPort, server.Spec.SystemURI), nil)
+				Expect(err).NotTo(HaveOccurred())
+				req.SetBasicAuth("foo", "bar")
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					return ""
+				}
+				defer func() { _ = resp.Body.Close() }()
+				out := struct {
+					PowerState string `json:"PowerState"`
+				}{}
+				Expect(json.NewDecoder(resp.Body).Decode(&out)).To(Succeed())
+				return out.PowerState
+			}
+
+			By("Simulating the external actor powering the server on out of band")
+			resetReq, err := http.NewRequest(http.MethodPost,
+				fmt.Sprintf("http://%s:%d%s/Actions/ComputerSystem.Reset", MockServerIP, MockServerPort, server.Spec.SystemURI),
+				bytes.NewBufferString(`{"ResetType":"On"}`),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			resetReq.SetBasicAuth("foo", "bar")
+			resetReq.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(resetReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+			Expect(resp.Body.Close()).To(Succeed())
+			Eventually(mockPowerState).Should(Equal("On"))
+
+			By("Nudging a reconciliation while parked (dummy annotation)")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, "metal.ironcore.dev/parked-tickle", "true")
+			})).Should(Succeed())
+
+			By("Ensuring the operator does not power the parked server back off")
+			Consistently(mockPowerState, "2s", "100ms").Should(Equal("On"))
+
+			By("Resuming the server")
+			Eventually(Update(server, func() {
+				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+			})).Should(Succeed())
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should stay parked when a ServerMaintenanceRef appears while parked", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state and parking it")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+			park(server)
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
+
+			By("Attaching a ServerMaintenanceRef while parked")
+			Eventually(Update(server, func() {
+				server.Spec.ServerMaintenanceRef = &metalv1alpha1.ObjectReference{Name: "parked-maintenance"}
+			})).Should(Succeed())
+
+			By("Ensuring the server stays parked and does not flap to Maintenance")
+			Consistently(Object(server), "2s", "100ms").Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
+
+			By("Resuming the server after clearing the maintenance ref")
+			Eventually(Update(server, func() {
+				server.Spec.ServerMaintenanceRef = nil
+				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+			})).Should(Succeed())
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
 		It("should defer a park request on a non-parkable state and park once parkable", func(ctx SpecContext) {
 			server, bmcSecret := createServerAndSecret(ctx)
 

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -1356,8 +1356,11 @@ passwd:
 				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
 
-			By("Ensuring the server resumes to available")
-			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+			By("Ensuring the server resumes to available and the unpark request is consumed")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+			))
 
 			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
@@ -1551,9 +1554,9 @@ passwd:
 			By("Ensuring the operator does not power the parked server back off")
 			Consistently(mockPowerState, "2s", "100ms").Should(Equal("On"))
 
-			By("Resuming the server")
+			By("Resuming the server via an unpark request")
 			Eventually(Update(server, func() {
-				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
 			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
 
@@ -1582,7 +1585,7 @@ passwd:
 			By("Resuming the server after clearing the maintenance ref")
 			Eventually(Update(server, func() {
 				server.Spec.ServerMaintenanceRef = nil
-				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
 			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
 

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1631,6 +1632,195 @@ passwd:
 
 			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should consume a reset operation annotation while parked without leaving it linger", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state and parking it")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+			park(server)
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
+
+			By("Issuing a reset operation against the parked server")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.GracefulRestartServerPower)
+			})).Should(Succeed())
+
+			By("Ensuring the server stays parked and the reset request is consumed (not lingered)")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+			))
+
+			By("Ensuring a warning event was emitted for the reset dropped while parked")
+			Eventually(func(g Gomega) {
+				events := &eventsv1.EventList{}
+				g.Expect(k8sClient.List(ctx, events)).To(Succeed())
+				found := false
+				for _, e := range events.Items {
+					if e.Regarding.Name == server.Name && e.Reason == "ParkedOperationDropped" {
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "expected a ParkedOperationDropped warning event for the server")
+			}).Should(Succeed())
+
+			By("Resuming the server via an unpark request")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
+			})).Should(Succeed())
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should consume a redundant park request while already parked", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state and parking it")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+			park(server)
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+			))
+
+			By("Re-issuing a park request against the already-parked server")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)
+			})).Should(Succeed())
+
+			By("Ensuring the redundant park request is consumed and the server stays parked")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+			))
+
+			By("Resuming the server via an unpark request")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
+			})).Should(Succeed())
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+	})
+
+	Describe("Operation annotations", func() {
+		createServerAndSecret := func(ctx SpecContext) (*metalv1alpha1.Server, *metalv1alpha1.BMCSecret) {
+			By("Creating a BMCSecret")
+			bmcSecret := &metalv1alpha1.BMCSecret{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-server-"},
+				Data: map[string][]byte{
+					"username": []byte("foo"),
+					"password": []byte("bar"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, bmcSecret)).Should(Succeed())
+
+			By("Creating a Server with inline BMC configuration")
+			server := &metalv1alpha1.Server{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "server-"},
+				Spec: metalv1alpha1.ServerSpec{
+					SystemUUID: "38947555-7742-3448-3784-823347823834",
+					BMC: &metalv1alpha1.BMCAccess{
+						Protocol: metalv1alpha1.Protocol{
+							Name: metalv1alpha1.ProtocolRedfishLocal,
+							Port: MockServerPort,
+						},
+						Address: MockServerIP,
+						BMCSecretRef: v1.LocalObjectReference{
+							Name: bmcSecret.Name,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, server)).Should(Succeed())
+			return server, bmcSecret
+		}
+
+		It("should clear an unsupported operation annotation and emit a warning event", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+
+			By("Setting an unsupported operation annotation")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, "bogus-operation")
+			})).Should(Succeed())
+
+			By("Ensuring the unsupported operation annotation is consumed")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+			))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
+		})
+
+		It("should emit a warning event for an unsupported operation while parked", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state and parking it")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)
+			})).Should(Succeed())
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
+
+			By("Setting an unsupported operation annotation on the parked server")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, "bogus-operation")
+			})).Should(Succeed())
+
+			By("Ensuring the unsupported operation annotation is consumed and the server stays parked")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+			))
+
+			By("Ensuring a warning event was emitted for the unsupported operation")
+			Eventually(func(g Gomega) {
+				events := &eventsv1.EventList{}
+				g.Expect(k8sClient.List(ctx, events)).To(Succeed())
+				found := false
+				for _, e := range events.Items {
+					if e.Regarding.Name == server.Name && e.Reason == "UnsupportedOperation" {
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "expected an UnsupportedOperation warning event for the server")
+			}).Should(Succeed())
+
+			By("Ensuring no ParkedOperationDropped event fires for an unsupported operation")
+			Consistently(func(g Gomega) {
+				events := &eventsv1.EventList{}
+				g.Expect(k8sClient.List(ctx, events)).To(Succeed())
+				for _, e := range events.Items {
+					g.Expect(e.Regarding.Name == server.Name && e.Reason == "ParkedOperationDropped").To(BeFalse(),
+						"unsupported operations must not emit ParkedOperationDropped")
+				}
+			}, "1s").Should(Succeed())
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
 		})
 	})
 })

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -1294,7 +1294,6 @@ passwd:
 	})
 
 	Describe("Parked state", func() {
-
 		park := func(server *metalv1alpha1.Server) {
 			By("Requesting the server to be parked")
 			Eventually(Update(server, func() {
@@ -1604,11 +1603,9 @@ passwd:
 			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		})
-
 	})
 
 	Describe("Operation annotations", func() {
-
 		It("should clear an unsupported operation annotation", func(ctx SpecContext) {
 			server, bmcSecret := createServerAndSecret(ctx)
 

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -1292,6 +1292,257 @@ passwd:
 			Expect(ignitionStr).To(ContainSubstring("custom-probe:v1.0.0"), "Should include custom probe image")
 		})
 	})
+
+	Describe("Parked state", func() {
+		createServerAndSecret := func(ctx SpecContext) (*metalv1alpha1.Server, *metalv1alpha1.BMCSecret) {
+			By("Creating a BMCSecret")
+			bmcSecret := &metalv1alpha1.BMCSecret{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-server-"},
+				Data: map[string][]byte{
+					"username": []byte("foo"),
+					"password": []byte("bar"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+			By("Creating a Server with inline BMC configuration")
+			server := &metalv1alpha1.Server{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "server-"},
+				Spec: metalv1alpha1.ServerSpec{
+					SystemUUID: "38947555-7742-3448-3784-823347823834",
+					BMC: &metalv1alpha1.BMCAccess{
+						Protocol: metalv1alpha1.Protocol{
+							Name: metalv1alpha1.ProtocolRedfishLocal,
+							Port: MockServerPort,
+						},
+						Address: MockServerIP,
+						BMCSecretRef: v1.LocalObjectReference{
+							Name: bmcSecret.Name,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, server)).To(Succeed())
+			return server, bmcSecret
+		}
+
+		park := func(server *metalv1alpha1.Server) {
+			By("Requesting the server to be parked")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)
+			})).Should(Succeed())
+		}
+
+		It("should park a free server and resume to available", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+
+			park(server)
+
+			By("Ensuring the server reaches Parked, is off, and the request annotation is consumed")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+			))
+
+			By("Removing the parked annotation to resume")
+			Eventually(Update(server, func() {
+				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+			})).Should(Succeed())
+
+			By("Ensuring the server resumes to available")
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should park a claimed server, keep the claim bound, and resume to reserved", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+
+			By("Creating a ServerClaim for the server")
+			claim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "parked-claim",
+					Namespace: ns.Name,
+				},
+				Spec: metalv1alpha1.ServerClaimSpec{
+					ServerRef: &v1.LocalObjectReference{Name: server.Name},
+				},
+			}
+			Expect(k8sClient.Create(ctx, claim)).To(Succeed())
+
+			By("Ensuring that the Server is set to reserved")
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateReserved))
+
+			park(server)
+
+			By("Ensuring the server is parked and the claim stays bound")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)),
+			))
+			Eventually(Object(claim)).Should(HaveField("Status.Phase", metalv1alpha1.PhaseBound))
+
+			By("Removing the parked annotation to resume")
+			Eventually(Update(server, func() {
+				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+			})).Should(Succeed())
+
+			By("Ensuring the server resumes to reserved")
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateReserved))
+
+			Expect(k8sClient.Delete(ctx, claim)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should reconstruct the parked state from the annotation if status.state is lost", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+
+			park(server)
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
+
+			By("Clearing status.state while the parked annotation remains")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = ""
+			})).Should(Succeed())
+
+			By("Ensuring the reconciler reconstructs the Parked state from the annotation")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)),
+			))
+
+			By("Removing the parked annotation to resume")
+			Eventually(Update(server, func() {
+				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+			})).Should(Succeed())
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should fall back to available on resume if the ServerClaimRef is gone while parked", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state and claiming it")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+
+			claim := &metalv1alpha1.ServerClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "parked-fallback-claim",
+					Namespace: ns.Name,
+				},
+				Spec: metalv1alpha1.ServerClaimSpec{
+					ServerRef: &v1.LocalObjectReference{Name: server.Name},
+				},
+			}
+			Expect(k8sClient.Create(ctx, claim)).To(Succeed())
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateReserved))
+
+			park(server)
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
+
+			By("Deleting the claim while parked and clearing the ServerClaimRef (claim removed during the procedure)")
+			Expect(k8sClient.Delete(ctx, claim)).Should(Succeed())
+			Eventually(Get(claim)).Should(Satisfy(apierrors.IsNotFound))
+			Eventually(Update(server, func() {
+				server.Spec.ServerClaimRef = nil
+			})).Should(Succeed())
+
+			By("Removing the parked annotation to resume")
+			Eventually(Update(server, func() {
+				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+			})).Should(Succeed())
+
+			By("Ensuring the server resumes to available (not reserved) since the claim ref is gone")
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should not deadlock on deletion while parked", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+
+			park(server)
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
+
+			By("Deleting the parked server")
+			Expect(k8sClient.Delete(ctx, server)).To(Succeed())
+
+			By("Ensuring the server is gone (finalizer removed despite being parked)")
+			Eventually(Get(server)).Should(Satisfy(apierrors.IsNotFound))
+
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should defer a park request on a non-parkable state and park once parkable", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Ensuring the server reaches Discovery (a non-parkable state)")
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateDiscovery))
+
+			By("Requesting the server to be parked while still in Discovery")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)
+			})).Should(Succeed())
+
+			By("Ensuring the server is not parked and the request is left in place")
+			Consistently(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateDiscovery),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.ParkedAnnotation))),
+			))
+
+			By("Driving the Server to available state (now parkable)")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+
+			By("Ensuring the deferred request is now honored and the server is parked")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, metalv1alpha1.ParkedAnnotationTrue)),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+			))
+
+			By("Removing the parked annotation to resume")
+			Eventually(Update(server, func() {
+				delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+			})).Should(Succeed())
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+	})
 })
 
 func deleteRegistrySystemIfExists(systemUUID string) {

--- a/internal/controller/serverclaim_controller.go
+++ b/internal/controller/serverclaim_controller.go
@@ -135,6 +135,18 @@ func (r *ServerClaimReconciler) reconcile(ctx context.Context, claim *metalv1alp
 		}
 	}
 
+	if claim.Spec.ServerRef != nil {
+		server := &metalv1alpha1.Server{}
+		if err := r.Get(ctx, client.ObjectKey{Name: claim.Spec.ServerRef.Name}, server); err == nil {
+			if isServerParkingOrParked(server) {
+				log.V(1).Info("Bound server is parked, standing down", "Server", server.Name)
+				return ctrl.Result{}, nil
+			}
+		} else if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to get server for parked check: %w", err)
+		}
+	}
+
 	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, claim, serverClaimFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -710,6 +710,65 @@ var _ = Describe("ServerClaim Controller", func() {
 		Expect(k8sClient.Delete(ctx, claim)).To(Succeed())
 		Eventually(Get(claim)).Should(Satisfy(apierrors.IsNotFound))
 	})
+
+	It("should stand down and not revert power while the bound server is parked", func(ctx SpecContext) {
+		By("Creating a ServerClaim with PowerOn")
+		claim := &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      "parked-stand-down-claim",
+			},
+			Spec: metalv1alpha1.ServerClaimSpec{
+				Power:     metalv1alpha1.PowerOn,
+				ServerRef: &v1.LocalObjectReference{Name: server.Name},
+				Image:     "foo:bar",
+			},
+		}
+		Expect(k8sClient.Create(ctx, claim)).To(Succeed())
+
+		By("Ensuring the server is reserved and the claim is bound")
+		Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateReserved))
+
+		By("Patching the boot configuration to a Ready state so the claim binds and powers on")
+		config := &metalv1alpha1.ServerBootConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      claim.Name,
+			},
+		}
+		Eventually(UpdateStatus(config, func() {
+			config.Status.State = metalv1alpha1.ServerBootConfigurationStateReady
+		})).Should(Succeed())
+		Eventually(Object(claim)).Should(HaveField("Status.Phase", metalv1alpha1.PhaseBound))
+		Eventually(Object(server)).Should(HaveField("Spec.Power", metalv1alpha1.PowerOn))
+
+		By("Parking the server")
+		Eventually(Update(server, func() {
+			metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)
+		})).Should(Succeed())
+		Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
+
+		By("Ensuring the server is powered off while parked")
+		Eventually(Object(server)).Should(HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState))
+
+		By("Asserting the claim reconciler does not revert spec.power to On while parked")
+		Consistently(Object(server)).Should(HaveField("Spec.Power", metalv1alpha1.PowerOff))
+
+		By("Resuming the server")
+		Eventually(Update(server, func() {
+			delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+		})).Should(Succeed())
+
+		By("Ensuring the server resumes to reserved and the claim reconciler re-applies power")
+		Eventually(Object(server)).Should(SatisfyAll(
+			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
+			HaveField("Spec.Power", metalv1alpha1.PowerOn),
+		))
+
+		By("Removing the ServerClaim")
+		Expect(k8sClient.Delete(ctx, claim)).To(Succeed())
+		Eventually(Get(claim)).To(Satisfy(apierrors.IsNotFound))
+	})
 })
 
 var _ = Describe("ServerClaim Validation", func() {

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -751,8 +751,8 @@ var _ = Describe("ServerClaim Controller", func() {
 		By("Ensuring the server is powered off while parked")
 		Eventually(Object(server)).Should(HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState))
 
-		By("Asserting the claim reconciler does not revert spec.power to On while parked")
-		Consistently(Object(server)).Should(HaveField("Spec.Power", metalv1alpha1.PowerOff))
+		By("Asserting spec.power is left untouched while parked")
+		Consistently(Object(server)).Should(HaveField("Spec.Power", metalv1alpha1.PowerOn))
 
 		By("Resuming the server")
 		Eventually(Update(server, func() {

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -754,9 +754,9 @@ var _ = Describe("ServerClaim Controller", func() {
 		By("Asserting spec.power is left untouched while parked")
 		Consistently(Object(server)).Should(HaveField("Spec.Power", metalv1alpha1.PowerOn))
 
-		By("Resuming the server")
+		By("Resuming the server via an unpark request")
 		Eventually(Update(server, func() {
-			delete(server.Annotations, metalv1alpha1.ParkedAnnotation)
+			metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 		})).Should(Succeed())
 
 		By("Ensuring the server resumes to reserved and the claim reconciler re-applies power")

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -211,6 +211,7 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			Client:                  k8sManager.GetClient(),
 			APIReader:               k8sManager.GetAPIReader(),
 			Scheme:                  k8sManager.GetScheme(),
+			Recorder:                k8sManager.GetEventRecorder("server-controller"),
 			DefaultProtocol:         metalv1alpha1.HTTPProtocolScheme,
 			SkipCertValidation:      true,
 			ManagerNamespace:        ns.Name,


### PR DESCRIPTION
# Proposed Changes

Implement IEP-23 and add Server Parked state for out-of-band day-2 operations.

Fixes #1068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `Parked` server lifecycle state.
  * Servers can be parked by powering them off while preserving claims and configuration.
  * Parking pauses normal lifecycle actions while allowing external operations.
  * Added park and unpark requests with automatic state restoration.
  * Added events for parking, resuming, and unsupported operations.

* **Bug Fixes**
  * Prevented claim processing during parking or while parked.
  * Improved handling of deletion, maintenance references, and external power changes.
  * Corrected BIOS settings resource permissions.

* **Documentation**
  * Added guidance covering parking behavior, state transitions, admission rules, and CLI examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->