### PR TITLE
Use resourceName helper for metaldata ServiceAccount name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,13 @@ helm: manifests kubebuilder yq
 	  's|        app.kubernetes.io/managed-by: {{ .Release.Service }}$$|        app.kubernetes.io/managed-by: {{ .Release.Service }}\n        {{- with .Values.metaldata.additionalLabels }}\n        {{- toYaml . \| nindent 8 }}\n        {{- end }}|' \
 	  dist/chart/templates/extras/metaldata.yaml
 	@"$(YQ)" -i '.metaldata.additionalLabels = (.metaldata.additionalLabels // {})' dist/chart/values.yaml
+	@# Fix metaldata ServiceAccount name
+	@grep -qF '  name: metal-operator-metaldata' \
+	  dist/chart/templates/rbac/metaldata.yaml || { \
+	  echo "unexpected metaldata SA template; name patch not applied" >&2; exit 1; }
+	@sed -i \
+	  's|  name: metal-operator-metaldata$$|  name: {{ include "metal-operator.resourceName" (dict "suffix" "metaldata" "context" $$) }}|' \
+	  dist/chart/templates/rbac/metaldata.yaml
 
 ##@ Dependencies
 

--- a/dist/chart/templates/rbac/metaldata.yaml
+++ b/dist/chart/templates/rbac/metaldata.yaml
@@ -17,6 +17,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: metal-operator-metaldata
+  name: {{ include "metal-operator.resourceName" (dict "suffix" "metaldata" "context" $) }}
   namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
## Proposed Changes

- Add post-generation sed patch in `make helm` to replace the hardcoded
  `metal-operator-metaldata` ServiceAccount name with the release-name-aware
  helper `{{ include "metal-operator.resourceName" (dict "suffix" "metaldata" "context" $) }}`
- Regenerate `dist/chart/templates/rbac/metaldata.yaml` with the corrected name

Fixes #1069


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm-generated configuration to ensure the metaldata service account consistently uses the expected resource name.
  * Added validation to detect unexpected default naming before applying the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->