### PR TITLE
Fix helm serviceAccountName helper ignoring serviceAccount.enable=false

### DIFF
--- a/dist/chart/templates/_helpers.tpl
+++ b/dist/chart/templates/_helpers.tpl
@@ -55,7 +55,7 @@ If serviceAccount.enable is false and serviceAccount.name is set, use that name.
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "metal-operator.serviceAccountName" -}}
-{{- if and (not (.Values.serviceAccount.enable | default true)) .Values.serviceAccount.name }}
+{{- if and (hasKey .Values.serviceAccount "enable") (not .Values.serviceAccount.enable) .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
 {{- else }}
 {{- include "metal-operator.resourceName" (dict "suffix" "controller-manager" "context" .) }}


### PR DESCRIPTION
# Proposed Changes

- Fix metal-operator.serviceAccountName helper in _helpers.tpl replace the buggy .Values.serviceAccount.enable | default true with a hasKey-guarded check, so serviceAccount.enable: false with a custom serviceAccount.name is now respected instead of always falling back to the default computed name

Fixes #1077