### PR TITLE
Fix ServerMaintenance watch: wrong namespace and dropped enqueues

### DIFF
--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -511,13 +511,9 @@ func (r *ServerMaintenanceReconciler) enqueueMaintenanceByServerRefs() handler.E
 		}
 
 		var req []reconcile.Request
-		if server.Status.State == metalv1alpha1.ServerStateInitial {
-			return nil
-		}
-
 		if server.Spec.ServerMaintenanceRef != nil {
 			req = append(req, reconcile.Request{
-				NamespacedName: types.NamespacedName{Namespace: server.Namespace, Name: server.Spec.ServerMaintenanceRef.Name},
+				NamespacedName: types.NamespacedName{Namespace: server.Spec.ServerMaintenanceRef.Namespace, Name: server.Spec.ServerMaintenanceRef.Name},
 			})
 		}
 


### PR DESCRIPTION
# Proposed Changes

Fix ServerMaintenance watch: wrong namespace and dropped enqueues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maintenance requests are now reconciled when servers are in their initial state.
  * Maintenance requests now use the namespace specified by the maintenance reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->