### PR TITLE
Fix BMC*/BIOS* watch mappings: ref-based enqueues, nil-BMCRef guards, dead branch removal

### DIFF
--- a/internal/controller/biossettingsset_controller.go
+++ b/internal/controller/biossettingsset_controller.go
@@ -394,7 +394,9 @@ func (r *BIOSSettingsSetReconciler) enqueueByServer(ctx context.Context, obj cli
 
 	// Get all BIOSSettingsSets and check if the Server matches their selectors
 	setList := &metalv1alpha1.BIOSSettingsSetList{}
-	if err := r.List(ctx, setList); err == nil {
+	if err := r.List(ctx, setList); err != nil {
+		log.Error(err, "Failed to list BIOSSettingsSets", "server", server.GetName())
+	} else {
 		for _, set := range setList.Items {
 			sel, _ := metav1.LabelSelectorAsSelector(&set.Spec.ServerSelector)
 			if sel.Matches(labels.Set(server.GetLabels())) {
@@ -407,11 +409,9 @@ func (r *BIOSSettingsSetReconciler) enqueueByServer(ctx context.Context, obj cli
 	if server.Spec.BIOSSettingsRef != nil {
 		settings := &metalv1alpha1.BIOSSettings{}
 		if err := r.Get(ctx, client.ObjectKey{Name: server.Spec.BIOSSettingsRef.Name}, settings); err != nil {
-			log.Error(err, "Failed to get BIOSSettings referenced by Server", "Server", server.Name, "BIOSSettings", server.Spec.BIOSSettingsRef.Name)
-			return nil
-		}
-		owner := metav1.GetControllerOf(settings)
-		if owner != nil && owner.Kind == "BIOSSettingsSet" {
+			// Fall through: keep the selector-based requests already collected
+			log.Error(err, "Failed to get BIOSSettings referenced by Server", "server", server.Name, "biosSettings", server.Spec.BIOSSettingsRef.Name)
+		} else if owner := metav1.GetControllerOf(settings); owner != nil && owner.Kind == "BIOSSettingsSet" {
 			reqs[client.ObjectKey{Namespace: settings.Namespace, Name: owner.Name}] = true
 		}
 	}

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -598,19 +598,35 @@ func (r *BMCReconciler) deleteEventSubscription(ctx context.Context, bmcClient b
 }
 
 func (r *BMCReconciler) enqueueBMCByEndpoint(ctx context.Context, obj client.Object) []ctrl.Request {
-	return []ctrl.Request{
-		{
-			NamespacedName: types.NamespacedName{Name: obj.(*metalv1alpha1.Endpoint).Name},
-		},
+	log := ctrl.LoggerFrom(ctx)
+	bmcList := &metalv1alpha1.BMCList{}
+	if err := r.List(ctx, bmcList); err != nil {
+		log.Error(err, "Failed to list BMCs for Endpoint watch", "endpoint", obj.GetName())
+		return nil
 	}
+	var reqs []ctrl.Request
+	for _, bmcObj := range bmcList.Items {
+		if bmcObj.Spec.EndpointRef != nil && bmcObj.Spec.EndpointRef.Name == obj.GetName() {
+			reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: bmcObj.Name}})
+		}
+	}
+	return reqs
 }
 
 func (r *BMCReconciler) enqueueBMCByBMCSecret(ctx context.Context, obj client.Object) []ctrl.Request {
-	return []ctrl.Request{
-		{
-			NamespacedName: types.NamespacedName{Name: obj.(*metalv1alpha1.BMCSecret).Name},
-		},
+	log := ctrl.LoggerFrom(ctx)
+	bmcList := &metalv1alpha1.BMCList{}
+	if err := r.List(ctx, bmcList); err != nil {
+		log.Error(err, "Failed to list BMCs for BMCSecret watch", "bmcSecret", obj.GetName())
+		return nil
 	}
+	var reqs []ctrl.Request
+	for _, bmcObj := range bmcList.Items {
+		if bmcObj.Spec.BMCSecretRef.Name == obj.GetName() {
+			reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: bmcObj.Name}})
+		}
+	}
+	return reqs
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/bmcsettings_controller.go
+++ b/internal/controller/bmcsettings_controller.go
@@ -1292,6 +1292,9 @@ func (r *BMCSettingsReconciler) enqueueBMCSettingsByBMCVersion(ctx context.Conte
 		return nil
 	}
 
+	if BMCVersion.Spec.BMCRef == nil {
+		return nil
+	}
 	var requests []ctrl.Request
 	for _, settings := range BMCSettingsList.Items {
 		if settings.Spec.BMCRef != nil && settings.Spec.BMCRef.Name == BMCVersion.Spec.BMCRef.Name {

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -1222,20 +1222,13 @@ func (r *BMCVersionReconciler) enqueueBMCVersionByBMCRefs(ctx context.Context, o
 	}
 
 	for _, bmcVersion := range bmcVersionList.Items {
-		if bmcVersion.Spec.BMCRef != nil && bmcVersion.Spec.BMCRef.Name == bmcObj.Name {
-			if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateCompleted || bmcVersion.Status.State == metalv1alpha1.BMCVersionStateFailed {
-				return nil
-			}
-			return []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: bmcVersion.Namespace, Name: bmcVersion.Name}}}
+		if bmcVersion.Spec.BMCRef == nil || bmcVersion.Spec.BMCRef.Name != bmcObj.Name {
+			continue
 		}
 		if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateCompleted || bmcVersion.Status.State == metalv1alpha1.BMCVersionStateFailed {
 			continue
 		}
-		if bmcVersion.Spec.BMCRef == nil {
-			if referredBMC, err := r.getBMCFromBMCVersion(ctx, &bmcVersion); err != nil && referredBMC != nil && referredBMC.Name == bmcObj.Name {
-				return []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: bmcVersion.Namespace, Name: bmcVersion.Name}}}
-			}
-		}
+		return []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: bmcVersion.Namespace, Name: bmcVersion.Name}}}
 	}
 	return nil
 }

--- a/internal/webhook/v1alpha1/bmcversion_webhook.go
+++ b/internal/webhook/v1alpha1/bmcversion_webhook.go
@@ -101,8 +101,11 @@ func (v *BMCVersionCustomValidator) ValidateDelete(ctx context.Context, obj *met
 }
 
 func checkForDuplicateBMCVersionsRefToBMC(versionList *metalv1alpha1.BMCVersionList, version *metalv1alpha1.BMCVersion) error {
+	if version.Spec.BMCRef == nil {
+		return nil
+	}
 	for _, v := range versionList.Items {
-		if version.Name == v.Name {
+		if version.Name == v.Name || v.Spec.BMCRef == nil {
 			continue
 		}
 		if v.Spec.BMCRef.Name == version.Spec.BMCRef.Name {


### PR DESCRIPTION
# Proposed Changes

Fixed watch bugs in the BMC and BIOS controllers causing missed reconciles and crashes:                                                                                                                                                
                                                                                                                                                                                                                                        
- The `BMC` controller matched `Endpoint`/`BMCSecret` events by name instead of by `spec.endpointRef` / `spec.bmcSecretRef`, so updates with differing names never reached the owning `BMC`. Now resolved via refs.                                
- Removed dead code in the `BMCVersion` watch mapper: a branch that could never run (helper errors on nil BMCRef, plus an inverted error check).                                                                                         
- Fixed two nil-pointer panics on the optional `BMCRef` field, one in the `BMCSettings` watch mapper (panics there crash the manager), one in the `BMCVersion` validating webhook.                                                           
- The `BIOSSettingsSet` mapper dropped already-collected requests when a referenced `BIOSSettings` fetch failed, racing with cache visibility. It now keeps them and logs the error.      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation when BIOS, BMC, and related resource lookups encounter errors.
  * Ensured all relevant BMC resources are processed when referenced objects change.
  * Prevented failures when BMC references are missing.
  * Avoided unnecessary processing for completed or failed BMC version updates.
  * Improved duplicate-reference validation for resources without BMC references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->