### PR TITLE
Fix stuck deletions and deflake/parallelize the controller test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,7 @@ jobs:
 
       - name: Running Tests
         run: |
-          sudo --preserve-env=GOROOT,GOPATH,PATH go mod tidy
-          sudo --preserve-env=GOROOT,GOPATH,PATH make test-only
+          sudo --preserve-env=HOME,GOROOT,GOPATH,PATH make test-only
 
   test-alerts:
     name: Test Prometheus alert rules

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,13 @@ vet: ## Run go vet against code.
 .PHONY: check-gen
 check-gen: generate manifests docs helm fmt ## Run code generation, manifests generation, documentation generation, helm plugin setup, and formatting checks.
 
+# Number of CPU cores for parallel test execution (portable across Linux/macOS).
+NPROC ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+
 .PHONY: test-only
 test-only: setup-envtest ginkgo ## Run tests without generating manifests or code.
 	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" \
-	"$(GINKGO)" --fail-fast --cover --coverprofile=cover.out --skip-package=e2e ./...
+	"$(GINKGO)" --fail-fast --cover --coverprofile=cover.out --skip-package=e2e --procs=$(NPROC) ./...
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest test-only ## Run tests.

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ NPROC ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
 .PHONY: test-only
 test-only: setup-envtest ginkgo ## Run tests without generating manifests or code.
 	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" \
-	"$(GINKGO)" --fail-fast --cover --coverprofile=cover.out --skip-package=e2e --procs=$(NPROC) ./...
+	"$(GINKGO)" --cover --coverprofile=cover.out --skip-package=e2e --procs=$(NPROC) ./...
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest test-only ## Run tests.

--- a/bmc/mock/server/server.go
+++ b/bmc/mock/server/server.go
@@ -834,7 +834,7 @@ func (s *MockServer) parseResetType(body []byte, offStates, onStates, resetState
 }
 
 func (s *MockServer) doPowerOff(systemPath string) {
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -846,7 +846,7 @@ func (s *MockServer) doPowerOff(systemPath string) {
 }
 
 func (s *MockServer) doPowerOn(systemPath, basePath string) {
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	s.mu.Lock()
 	if base, ok := s.overrides[systemPath].(map[string]any); ok {
 		base["PowerState"] = PowerOnState
@@ -861,7 +861,7 @@ func (s *MockServer) doPowerOn(systemPath, basePath string) {
 }
 
 func (s *MockServer) doPowerReset(systemPath, basePath string) {
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	s.mu.Lock()
 	if base, ok := s.overrides[systemPath].(map[string]any); ok {
 		base["PowerState"] = PowerOffState
@@ -887,7 +887,7 @@ func (s *MockServer) doPowerReset(systemPath, basePath string) {
 func (s *MockServer) doBMCReset(bmcPath string) {
 	// Simulate the BMC being offline during reset.
 	// The lock set by handleBMCReset prevents new POST operations during this window.
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 
 	s.mu.Lock()
 	if base, ok := s.overrides[bmcPath].(map[string]any); ok {

--- a/internal/controller/biossettings_controller.go
+++ b/internal/controller/biossettings_controller.go
@@ -136,6 +136,11 @@ func (r *BIOSSettingsReconciler) delete(ctx context.Context, settings *metalv1al
 	}
 	log.V(1).Info("Ensured references were removed")
 
+	if err := r.removeServerMaintenance(ctx, settings); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to remove ServerMaintenance: %w", err)
+	}
+	log.V(1).Info("Ensured ServerMaintenance is removed")
+
 	log.V(1).Info("Ensuring that the finalizer is removed")
 	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, settings, BIOSSettingsFinalizer); err != nil || modified {
 		return ctrl.Result{}, err

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -78,7 +78,7 @@ var _ = Describe("BIOSSettings Controller", func() {
 	AfterEach(func(ctx SpecContext) {
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 		mockServers[0].ResetBIOSSettings(path.Base(server.Spec.SystemURI))
 	})
 
@@ -1117,7 +1117,7 @@ var _ = Describe("BIOSSettings Controller with BMCRef BMC", func() {
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, bmcObj)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should request maintenance when changing power status of server, even if bios settings update does not need it", func(ctx SpecContext) {
@@ -1447,7 +1447,7 @@ var _ = Describe("BIOSSettings Sequence Controller", func() {
 
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should successfully apply sequence of settings", func(ctx SpecContext) {

--- a/internal/controller/biossettings_controller_test.go
+++ b/internal/controller/biossettings_controller_test.go
@@ -76,8 +76,8 @@ var _ = Describe("BIOSSettings Controller", func() {
 	})
 
 	AfterEach(func(ctx SpecContext) {
-		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		EnsureCleanState(ctx)
 		mockServers[0].ResetBIOSSettings(path.Base(server.Spec.SystemURI))
 	})
@@ -1013,6 +1013,12 @@ var _ = Describe("BIOSSettings Controller", func() {
 			}
 			return nil
 		}).Should(Succeed())
+
+		// The force-deleted BIOSSettings above may have left a pending settings
+		// task on the (shared) mock server; a fresh BIOSSettings would observe it
+		// and fail terminally with PendingSettingsFound.
+		By("Resetting pending BIOS settings on the mock server")
+		mockServers[0].ResetBIOSSettings(path.Base(server.Spec.SystemURI))
 
 		biosSettings2 := &metalv1alpha1.BIOSSettings{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/biossettingsset_controller_test.go
+++ b/internal/controller/biossettingsset_controller_test.go
@@ -124,7 +124,7 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 		Expect(k8sClient.Delete(ctx, server02)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server03)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 		for _, ms := range mockServers {
 			ms.ResetBIOSSettings("437XR1138R2")
 		}

--- a/internal/controller/biossettingsset_controller_test.go
+++ b/internal/controller/biossettingsset_controller_test.go
@@ -5,7 +5,6 @@ package controller
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -703,17 +702,24 @@ var _ = Describe("BIOSSettingsSet Controller", func() {
 			}
 		})).Should(Succeed())
 
+		// Note: the retried Pending state is transient and can be missed by the
+		// Eventually poll when the whole retry cycle completes quickly.
+		// Assert on the persistent retry condition instead.
 		By("Ensuring that the BIOSSetting02 has been retried ")
-		Eventually(Object(biosSettings02)).WithPolling(1 * time.Millisecond).Should(SatisfyAll(
-			HaveField("Status.State", Not(Equal(metalv1alpha1.BIOSSettingsStateFailed))),
-			HaveField("Status.FailedAttempts", Not(Equal(int32(failedAutoRetryCount)))),
-		))
+		Eventually(Object(biosSettings02)).Should(
+			HaveField("Status.Conditions", ContainElement(SatisfyAll(
+				HaveField("Type", ConditionRetryOfFailedResourceIssued),
+				HaveField("Status", metav1.ConditionTrue),
+			))),
+		)
 
 		By("Ensuring that the BIOSSetting03 has been retried")
-		Eventually(Object(biosSettings03)).WithPolling(10 * time.Millisecond).Should(SatisfyAll(
-			HaveField("Status.State", Not(Equal(metalv1alpha1.BIOSSettingsStateFailed))),
-			HaveField("Status.FailedAttempts", Not(Equal(int32(failedAutoRetryCount)))),
-		))
+		Eventually(Object(biosSettings03)).Should(
+			HaveField("Status.Conditions", ContainElement(SatisfyAll(
+				HaveField("Type", ConditionRetryOfFailedResourceIssued),
+				HaveField("Status", metav1.ConditionTrue),
+			))),
+		)
 
 		By("Ensuring that the BIOSSetting02 has failed again")
 		Eventually(Object(biosSettings02)).Should(SatisfyAll(

--- a/internal/controller/biosversion_controller_test.go
+++ b/internal/controller/biosversion_controller_test.go
@@ -76,7 +76,7 @@ var _ = Describe("BIOSVersion Controller", func() {
 	AfterEach(func(ctx SpecContext) {
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 		mockServers[0].ResetUpgradeTask(server.Spec.SystemURI)
 	})
 
@@ -476,7 +476,7 @@ var _ = Describe("BIOSVersion Controller with BMCRef BMC", func() {
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, bmcObj)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 		mockServers[0].ResetUpgradeTask(server.Spec.SystemURI)
 	})
 	It("should successfully Start and monitor Upgrade task to completion", func(ctx SpecContext) {

--- a/internal/controller/biosversionset_controller_test.go
+++ b/internal/controller/biosversionset_controller_test.go
@@ -485,17 +485,24 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 			}
 		})).Should(Succeed())
 
+		// Note: the retried Pending state is transient and can be missed by the
+		// Eventually poll when the whole retry cycle completes quickly.
+		// Assert on the persistent retry condition instead.
 		By("Ensuring that the BIOSVersion 02 has been retried ")
-		Eventually(Object(biosVersion02)).Should(SatisfyAll(
-			HaveField("Status.State", Not(Equal(metalv1alpha1.BIOSVersionStateFailed))),
-			HaveField("Status.FailedAttempts", Not(Equal(int32(failedAutoRetryCount)))),
-		))
+		Eventually(Object(biosVersion02)).Should(
+			HaveField("Status.Conditions", ContainElement(SatisfyAll(
+				HaveField("Type", ConditionRetryOfFailedResourceIssued),
+				HaveField("Status", metav1.ConditionTrue),
+			))),
+		)
 
 		By("Ensuring that the BIOSVersion 03 has been retried")
-		Eventually(Object(biosVersion03)).Should(SatisfyAll(
-			HaveField("Status.State", Not(Equal(metalv1alpha1.BIOSVersionStateFailed))),
-			HaveField("Status.FailedAttempts", Not(Equal(int32(failedAutoRetryCount)))),
-		))
+		Eventually(Object(biosVersion03)).Should(
+			HaveField("Status.Conditions", ContainElement(SatisfyAll(
+				HaveField("Type", ConditionRetryOfFailedResourceIssued),
+				HaveField("Status", metav1.ConditionTrue),
+			))),
+		)
 
 		By("Ensuring that the BIOSVersion 02 has failed again")
 		Eventually(Object(biosVersion02)).Should(SatisfyAll(

--- a/internal/controller/biosversionset_controller_test.go
+++ b/internal/controller/biosversionset_controller_test.go
@@ -124,7 +124,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 		Expect(k8sClient.Delete(ctx, server02)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server03)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 		for _, ms := range mockServers {
 			ms.ResetUpgradeTask()
 		}

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -21,7 +21,7 @@ var _ = Describe("BMC Controller", func() {
 	ns := SetupTest(nil)
 
 	AfterEach(func(ctx SpecContext) {
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should successfully reconcile a BMC resource", func(ctx SpecContext) {
@@ -341,7 +341,7 @@ var _ = Describe("BMC Controller", func() {
 
 var _ = Describe("BMC Validation", func() {
 	AfterEach(func(ctx SpecContext) {
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should deny if the BMC has EndpointRef and InlineEndpoint spec fields", func(ctx SpecContext) {
@@ -511,7 +511,7 @@ var _ = Describe("BMC Reset", func() {
 	_ = SetupTest(nil)
 
 	AfterEach(func(ctx SpecContext) {
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should reset the BMC", func(ctx SpecContext) {
@@ -578,7 +578,7 @@ var _ = Describe("BMC Conditions", func() {
 	_ = SetupTest(nil)
 
 	AfterEach(func(ctx SpecContext) {
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should create ready conditions when there are BMC connection errors", func(ctx SpecContext) {

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -295,7 +295,7 @@ var _ = Describe("BMC Controller", func() {
 				},
 				Protocol: metalv1alpha1.Protocol{
 					Name: metalv1alpha1.ProtocolRedfishLocal,
-					Port: 8000,
+					Port: MockServerPort,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
 					Name: bmcSecret.Name,

--- a/internal/controller/bmcsettings_controller_test.go
+++ b/internal/controller/bmcsettings_controller_test.go
@@ -90,7 +90,7 @@ var _ = Describe("BMCSettings Controller", func() {
 		})).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 		mockServers[0].ResetBMCSettings("BMC")
 	})
 

--- a/internal/controller/bmcsettingsset_controller_test.go
+++ b/internal/controller/bmcsettingsset_controller_test.go
@@ -145,7 +145,7 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, server02))).To(Succeed())
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcSecret))).To(Succeed())
 		By("Ensuring all resources are cleaned up")
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 		for _, ms := range mockServers {
 			ms.ResetBMCSettings("BMC")
 		}

--- a/internal/controller/bmcsettingsset_controller_test.go
+++ b/internal/controller/bmcsettingsset_controller_test.go
@@ -748,11 +748,16 @@ var _ = Describe("BMCSettingsSet Controller", func() {
 			}
 		})).Should(Succeed())
 
+		// Note: the retried Pending state is transient and can be missed by the
+		// Eventually poll when the whole retry cycle completes quickly.
+		// Assert on the persistent retry condition instead.
 		By("Ensuring that the BMCSetting01 has been retried ")
-		Eventually(Object(bmcSettings01)).Should(SatisfyAll(
-			HaveField("Status.State", Not(Equal(metalv1alpha1.BMCSettingsStateFailed))),
-			HaveField("Status.FailedAttempts", Equal(int32(0))),
-		))
+		Eventually(Object(bmcSettings01)).Should(
+			HaveField("Status.Conditions", ContainElement(SatisfyAll(
+				HaveField("Type", ConditionRetryOfFailedResourceIssued),
+				HaveField("Status", metav1.ConditionTrue),
+			))),
+		)
 
 		By("Ensuring that the BMCSetting01 has failed again")
 		Eventually(Object(bmcSettings01)).Should(SatisfyAll(

--- a/internal/controller/bmcuser_controller_test.go
+++ b/internal/controller/bmcuser_controller_test.go
@@ -50,7 +50,7 @@ var _ = Describe("BMCUser Controller", func() {
 				},
 				Protocol: metalv1alpha1.Protocol{
 					Name: metalv1alpha1.ProtocolRedfishLocal,
-					Port: 8000,
+					Port: MockServerPort,
 				},
 				BMCSecretRef: v1.LocalObjectReference{
 					Name: bmcSecret.Name,

--- a/internal/controller/bmcuser_controller_test.go
+++ b/internal/controller/bmcuser_controller_test.go
@@ -72,7 +72,7 @@ var _ = Describe("BMCUser Controller", func() {
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
 		Expect(k8sClient.Delete(ctx, bmc)).Should(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should create a BMC user and secret", func(ctx SpecContext) {

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -100,13 +100,24 @@ func (r *BMCVersionReconciler) delete(ctx context.Context, bmcVersion *metalv1al
 	}
 
 	if len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
-		active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to check maintenance state: %w", err)
-		}
-		if active {
-			log.V(1).Info("Skipping delete as BMCVersion is under active maintenance")
-			return r.reconcile(ctx, bmcVersion)
+		if _, err := r.getBMCFromBMCVersion(ctx, bmcVersion); apierrors.IsNotFound(err) {
+			// The BMC is gone: its state can no longer be observed and the
+			// maintenance cleanup path (which requires the BMC client) can never
+			// run. Remove our owned ServerMaintenances here, otherwise this
+			// BMCVersion would be stuck terminating forever.
+			log.V(1).Info("Referenced BMC does not exist, removing owned ServerMaintenances", "BMCRef", bmcVersion.Spec.BMCRef.Name)
+			if err := r.removeServerMaintenances(ctx, bmcVersion); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to remove ServerMaintenances of orphaned BMCVersion: %w", err)
+			}
+		} else {
+			active, merr := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
+			if merr != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to check maintenance state: %w", merr)
+			}
+			if active {
+				log.V(1).Info("Skipping delete as BMCVersion is under active maintenance")
+				return r.reconcile(ctx, bmcVersion)
+			}
 		}
 	}
 
@@ -262,8 +273,12 @@ func (r *BMCVersionReconciler) ensureBMCVersionStateTransition(ctx context.Conte
 			return ctrl.Result{}, nil
 		}
 
-		if ok, err := r.resetBMC(ctx, bmcVersion, bmcObj, ConditionResetIssued); !ok || err != nil {
+		ok, err := r.resetBMC(ctx, bmcVersion, bmcObj, ConditionResetIssued)
+		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reset bmc %s: %w", client.ObjectKeyFromObject(bmcObj), err)
+		}
+		if !ok {
+			return ctrl.Result{}, nil
 		}
 
 		return r.handleUpgradeInProgressState(ctx, bmcVersion, bmcClient, bmcObj)

--- a/internal/controller/bmcversion_controller.go
+++ b/internal/controller/bmcversion_controller.go
@@ -84,8 +84,11 @@ func (r *BMCVersionReconciler) shouldDelete(ctx context.Context, bmcVersion *met
 		if bmcVersion.Status.State != metalv1alpha1.BMCVersionStateInProgress {
 			return false, nil
 		}
-		if _, err := r.getBMCFromBMCVersion(ctx, bmcVersion); apierrors.IsNotFound(err) {
-			return false, nil
+		if _, err := r.getBMCFromBMCVersion(ctx, bmcVersion); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
 		}
 		return metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
 	}
@@ -100,7 +103,9 @@ func (r *BMCVersionReconciler) delete(ctx context.Context, bmcVersion *metalv1al
 	}
 
 	if len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
-		if _, err := r.getBMCFromBMCVersion(ctx, bmcVersion); apierrors.IsNotFound(err) {
+		_, err := r.getBMCFromBMCVersion(ctx, bmcVersion)
+		switch {
+		case apierrors.IsNotFound(err):
 			// The BMC is gone: its state can no longer be observed and the
 			// maintenance cleanup path (which requires the BMC client) can never
 			// run. Remove our owned ServerMaintenances here, otherwise this
@@ -109,7 +114,9 @@ func (r *BMCVersionReconciler) delete(ctx context.Context, bmcVersion *metalv1al
 			if err := r.removeServerMaintenances(ctx, bmcVersion); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to remove ServerMaintenances of orphaned BMCVersion: %w", err)
 			}
-		} else {
+		case err != nil:
+			return ctrl.Result{}, fmt.Errorf("failed to get BMC for BMCVersion deletion: %w", err)
+		default:
 			active, merr := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
 			if merr != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to check maintenance state: %w", merr)

--- a/internal/controller/bmcversion_controller_test.go
+++ b/internal/controller/bmcversion_controller_test.go
@@ -89,7 +89,7 @@ var _ = Describe("BMCVersion Controller", func() {
 		Expect(k8sClient.Delete(ctx, bmcObj)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 		mockServers[0].ResetUpgradeTask("/redfish/v1/Managers/BMC")
 	})
 

--- a/internal/controller/bmcversionset_controller_test.go
+++ b/internal/controller/bmcversionset_controller_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
@@ -165,21 +166,21 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		Eventually(UpdateStatus(server01, func() {
 			server01.Status.State = metalv1alpha1.ServerStateAvailable
 		})).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, bmc01)).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmc01))).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server01)).To(Succeed())
 		Eventually(Get(server01)).Should(Satisfy(apierrors.IsNotFound))
 
 		Eventually(UpdateStatus(server02, func() {
 			server02.Status.State = metalv1alpha1.ServerStateAvailable
 		})).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, bmc02)).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmc02))).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server02)).To(Succeed())
 		Eventually(Get(server02)).Should(Satisfy(apierrors.IsNotFound))
 
 		Eventually(UpdateStatus(server03, func() {
 			server03.Status.State = metalv1alpha1.ServerStateAvailable
 		})).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, bmc03)).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmc03))).To(Succeed())
 		Expect(k8sClient.Delete(ctx, server03)).To(Succeed())
 		Eventually(Get(server03)).Should(Satisfy(apierrors.IsNotFound))
 

--- a/internal/controller/bmcversionset_controller_test.go
+++ b/internal/controller/bmcversionset_controller_test.go
@@ -185,7 +185,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		Eventually(Get(server03)).Should(Satisfy(apierrors.IsNotFound))
 
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 		for _, ms := range mockServers {
 			ms.ResetUpgradeTask()
 		}

--- a/internal/controller/bmcversionset_controller_test.go
+++ b/internal/controller/bmcversionset_controller_test.go
@@ -592,16 +592,23 @@ var _ = Describe("BMCVersionSet Controller", func() {
 			}
 		})).Should(Succeed())
 
+		// Note: the retried Pending state is transient and can be missed by the
+		// Eventually poll when the whole retry cycle completes quickly.
+		// Assert on the persistent retry condition instead.
 		By("Ensuring that the BMCVersion02 has been retried ")
-		Eventually(Object(bmcVersion02)).Should(SatisfyAll(
-			HaveField("Status.State", Not(Equal(metalv1alpha1.BMCVersionStateFailed))),
-			HaveField("Status.FailedAttempts", Not(Equal(int32(failedAutoRetryCount)))),
-		))
+		Eventually(Object(bmcVersion02)).Should(
+			HaveField("Status.Conditions", ContainElement(SatisfyAll(
+				HaveField("Type", ConditionRetryOfFailedResourceIssued),
+				HaveField("Status", metav1.ConditionTrue),
+			))),
+		)
 		By("Ensuring that the BMCVersion03 has been retried")
-		Eventually(Object(bmcVersion03)).Should(SatisfyAll(
-			HaveField("Status.State", Not(Equal(metalv1alpha1.BMCVersionStateFailed))),
-			HaveField("Status.FailedAttempts", Not(Equal(int32(failedAutoRetryCount)))),
-		))
+		Eventually(Object(bmcVersion03)).Should(
+			HaveField("Status.Conditions", ContainElement(SatisfyAll(
+				HaveField("Type", ConditionRetryOfFailedResourceIssued),
+				HaveField("Status", metav1.ConditionTrue),
+			))),
+		)
 
 		By("Ensuring that the BMCVersion02 has failed again")
 		Eventually(Object(bmcVersion02)).Should(SatisfyAll(

--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Endpoints Controller", func() {
 	_ = SetupTest(nil)
 
 	AfterEach(func(ctx SpecContext) {
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should successfully create a BMC secret and BMC object from endpoint", func(ctx SpecContext) {

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -681,7 +681,7 @@ func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient
 			log.V(1).Info("ServerMaintenanceRef points to a deleted ServerMaintenance, clearing ref", "Server", server.Name, "ServerMaintenance", ref.Name)
 			serverBase := server.DeepCopy()
 			server.Spec.ServerMaintenanceRef = nil
-			if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+			if err := r.Patch(ctx, server, client.MergeFromWithOptions(serverBase, client.MergeFromWithOptimisticLock{})); err != nil {
 				return false, fmt.Errorf("failed to clear dangling ServerMaintenance ref: %w", err)
 			}
 		}

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -670,6 +670,22 @@ func (r *ServerReconciler) hasPendingMaintenances(ctx context.Context, server *m
 
 func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
+	if ref := server.Spec.ServerMaintenanceRef; ref != nil {
+		// A maintenance holding the ref may have been deleted out of band
+		// (e.g. finalizer removed). Clear the dangling ref so the server can
+		// leave Maintenance state; pending maintenances take over afterwards.
+		if _, err := GetServerMaintenanceForObjectReference(ctx, r.Client, ref); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return false, fmt.Errorf("failed to get ServerMaintenance referenced by Server: %w", err)
+			}
+			log.V(1).Info("ServerMaintenanceRef points to a deleted ServerMaintenance, clearing ref", "Server", server.Name, "ServerMaintenance", ref.Name)
+			serverBase := server.DeepCopy()
+			server.Spec.ServerMaintenanceRef = nil
+			if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+				return false, fmt.Errorf("failed to clear dangling ServerMaintenance ref: %w", err)
+			}
+		}
+	}
 	if server.Spec.ServerMaintenanceRef == nil {
 		hasPending, err := r.hasPendingMaintenances(ctx, server)
 		if err != nil {

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -161,6 +161,15 @@ func (r *ServerReconciler) shouldDelete(ctx context.Context, server *metalv1alph
 				}
 			}
 		}
+		if server.Spec.BMC != nil {
+			// Without credentials the maintenance can never be finished or unwound;
+			// do not block deletion forever on a missing BMCSecret.
+			secretName := server.Spec.BMC.BMCSecretRef.Name
+			if err := r.Get(ctx, client.ObjectKey{Name: secretName}, &metalv1alpha1.BMCSecret{}); apierrors.IsNotFound(err) {
+				log.V(1).Info("BMCSecret not found, proceeding with deletion", "BMCSecret", secretName, "Server", server.Name)
+				return true
+			}
+		}
 		log.V(1).Info("Postponing delete as server is in Maintenance state")
 		return false
 	}

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -1155,7 +1155,7 @@ func (r *ServerReconciler) patchServerState(ctx context.Context, server *metalv1
 	}
 	serverBase := server.DeepCopy()
 	server.Status.State = state
-	if err := r.Status().Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+	if err := r.Status().Patch(ctx, server, client.MergeFromWithOptions(serverBase, client.MergeFromWithOptimisticLock{})); err != nil {
 		return false, fmt.Errorf("failed to patch server state: %w", err)
 	}
 	return true, nil

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Server Controller", func() {
 	ns := SetupTest(nil)
 
 	AfterEach(func(ctx SpecContext) {
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should transition a server to released state and back to available", func(ctx SpecContext) {

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -288,7 +288,7 @@ var _ = Describe("Server Controller", func() {
 			filepath.Join("..", "..", "config", "manager", "ignition-template.yaml"),
 			ignition.Config{
 				Image:        "foo:latest",
-				Flags:        "--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				Flags:        fmt.Sprintf("--registry-url=%s --server-uuid=38947555-7742-3448-3784-823347823834", registryURL),
 				SSHPublicKey: string(sshSecret.Data[SSHKeyPairSecretPublicKeyName]),
 				PasswordHash: passwordHash,
 			},
@@ -483,7 +483,7 @@ var _ = Describe("Server Controller", func() {
 			filepath.Join("..", "..", "config", "manager", "ignition-template.yaml"),
 			ignition.Config{
 				Image:        "foo:latest",
-				Flags:        "--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				Flags:        fmt.Sprintf("--registry-url=%s --server-uuid=38947555-7742-3448-3784-823347823834", registryURL),
 				SSHPublicKey: string(sshSecret.Data[SSHKeyPairSecretPublicKeyName]),
 				PasswordHash: passwordHash,
 			},
@@ -1106,7 +1106,7 @@ passwd:
 
 			By("Generating ignition data with custom file")
 			ignitionData, err := reconciler.generateDefaultIgnitionDataForServer(
-				"--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				fmt.Sprintf("--registry-url=%s --server-uuid=38947555-7742-3448-3784-823347823834", registryURL),
 				[]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC test@example.com"),
 				[]byte("testpassword"),
 			)
@@ -1134,7 +1134,7 @@ passwd:
 
 			By("Generating ignition data (should fail)")
 			_, err := reconciler.generateDefaultIgnitionDataForServer(
-				"--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				fmt.Sprintf("--registry-url=%s --server-uuid=38947555-7742-3448-3784-823347823834", registryURL),
 				[]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC test@example.com"),
 				[]byte("testpassword"),
 			)
@@ -1170,7 +1170,7 @@ systemd:
 
 			By("Generating ignition data (should fail)")
 			_, err = reconciler.generateDefaultIgnitionDataForServer(
-				"--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				fmt.Sprintf("--registry-url=%s --server-uuid=38947555-7742-3448-3784-823347823834", registryURL),
 				[]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC test@example.com"),
 				[]byte("testpassword"),
 			)
@@ -1219,7 +1219,7 @@ passwd:
 
 			By("Generating ignition data (should use default template)")
 			ignitionData, err := reconciler.generateDefaultIgnitionDataForServer(
-				"--registry-url=http://localhost:30000 --server-uuid=38947555-7742-3448-3784-823347823834",
+				fmt.Sprintf("--registry-url=%s --server-uuid=38947555-7742-3448-3784-823347823834", registryURL),
 				[]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC test@example.com"),
 				[]byte("testpassword"),
 			)
@@ -1277,7 +1277,7 @@ passwd:
 
 			By("Generating ignition data with custom template")
 			ignitionData, err := customReconciler.generateDefaultIgnitionDataForServer(
-				"--registry-url=http://localhost:30000 --server-uuid=e2e-test-12345",
+				fmt.Sprintf("--registry-url=%s --server-uuid=e2e-test-12345", registryURL),
 				[]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC test@example.com"),
 				[]byte("testpassword"),
 			)

--- a/internal/controller/serverbootconfiguration_controller_test.go
+++ b/internal/controller/serverbootconfiguration_controller_test.go
@@ -35,7 +35,7 @@ var _ = Describe("ServerBootConfiguration Controller", func() {
 
 	AfterEach(func(ctx SpecContext) {
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should successfully add the boot configuration ref to server", func(ctx SpecContext) {

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -655,11 +655,14 @@ var _ = Describe("ServerClaim Controller", func() {
 			HaveField("Spec.ServerClaimRef", BeNil()),
 		)
 
-		By("Ensuring the claim stays unbound")
-		Consistently(Object(claim)).Should(SatisfyAll(
+		By("Ensuring the claim is registered and stays unbound")
+		Eventually(Object(claim)).Should(SatisfyAll(
 			HaveField("Finalizers", ContainElement(serverClaimFinalizer)),
 			HaveField("Status.Phase", Equal(metalv1alpha1.PhaseUnbound)),
 		))
+		Consistently(Object(claim)).Should(
+			HaveField("Status.Phase", Equal(metalv1alpha1.PhaseUnbound)),
+		)
 
 		By("Removing the ServerClaim")
 		Expect(k8sClient.Delete(ctx, claim)).To(Succeed())

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -602,11 +602,14 @@ var _ = Describe("ServerClaim Controller", func() {
 			HaveField("Spec.ServerClaimRef", BeNil()),
 		)
 
-		By("Ensuring the claim stays unbound")
-		Consistently(Object(claim)).Should(SatisfyAll(
+		By("Ensuring the claim is registered and stays unbound")
+		Eventually(Object(claim)).Should(SatisfyAll(
 			HaveField("Finalizers", ContainElement(serverClaimFinalizer)),
 			HaveField("Status.Phase", Equal(metalv1alpha1.PhaseUnbound)),
 		))
+		Consistently(Object(claim)).Should(
+			HaveField("Status.Phase", Equal(metalv1alpha1.PhaseUnbound)),
+		)
 
 		By("Uncordoning the server")
 		Eventually(Update(server, func() {

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -68,7 +68,7 @@ var _ = Describe("ServerClaim Controller", func() {
 	AfterEach(func(ctx SpecContext) {
 		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should successfully claim a server in available state", func(ctx SpecContext) {
@@ -755,7 +755,7 @@ var _ = Describe("ServerClaim Validation", func() {
 	AfterEach(func(ctx SpecContext) {
 		Expect(k8sClient.Delete(ctx, claim)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, claimWithSelector)).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should deny if the ServerRef changes", func() {
@@ -893,7 +893,7 @@ var _ = Describe("Server Claiming", MustPassRepeatedly(5), func() {
 		for _, server := range serverList.Items {
 			Expect(k8sClient.Delete(ctx, &server)).To(Succeed())
 		}
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should bind four out of ten servers for four best effort claims", func(ctx SpecContext) {

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -853,7 +853,7 @@ var _ = Describe("Server Claiming", MustPassRepeatedly(5), func() {
 	countUniqueBoundServers := func(ctx context.Context, serverCount int) func(Gomega) int {
 		return func(g Gomega) int {
 			var serverList metalv1alpha1.ServerList
-			g.Expect(k8sClient.List(ctx, &serverList)).To(Succeed())
+			g.Expect(k8sClient.List(ctx, &serverList, client.MatchingLabels{"foo": "bar"})).To(Succeed())
 			g.Expect(serverList.Items).To(HaveLen(serverCount))
 			claimNames := make(map[string]struct{})
 			for _, server := range serverList.Items {
@@ -868,7 +868,7 @@ var _ = Describe("Server Claiming", MustPassRepeatedly(5), func() {
 	countUniqueBoundClaims := func(ctx context.Context) func(Gomega) int {
 		return func(g Gomega) int {
 			var claimList metalv1alpha1.ServerClaimList
-			g.Expect(k8sClient.List(ctx, &claimList)).To(Succeed())
+			g.Expect(k8sClient.List(ctx, &claimList, client.InNamespace(ns.Name))).To(Succeed())
 			serverNames := make(map[string]struct{})
 			for _, claim := range claimList.Items {
 				if claim.Spec.ServerRef != nil {

--- a/internal/controller/servermaintenance_controller_test.go
+++ b/internal/controller/servermaintenance_controller_test.go
@@ -61,7 +61,7 @@ var _ = Describe("ServerMaintenance Controller", func() {
 	AfterEach(func(ctx SpecContext) {
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, server))).To(Succeed())
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcSecret))).To(Succeed())
-		EnsureCleanState()
+		EnsureCleanState(ctx)
 	})
 
 	It("should force a Server into maintenance from Initial State", func(ctx SpecContext) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -43,7 +43,7 @@ import (
 const (
 	pollingInterval      = 50 * time.Millisecond
 	eventuallyTimeout    = 5 * time.Second
-	consistentlyDuration = 1 * time.Second
+	consistentlyDuration = 300 * time.Millisecond
 	MockServerIP         = "127.0.0.1"
 )
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -398,15 +399,13 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 	return ns
 }
 
-// EnsureCleanState ensures that all ServerClaims and cluster scoped objects are removed from the API server.
-func EnsureCleanState() {
+// EnsureCleanState removes leftover
+func EnsureCleanState(ctx context.Context) {
 	GinkgoHelper()
 
 	objectLists := []client.ObjectList{
 		&metalv1alpha1.EndpointList{},
 		&metalv1alpha1.BMCList{},
-		&metalv1alpha1.BMCSecretList{},
-		&metalv1alpha1.ServerClaimList{},
 		&metalv1alpha1.BMCSettingsSetList{},
 		&metalv1alpha1.BMCSettingsList{},
 		&metalv1alpha1.BMCVersionSetList{},
@@ -414,11 +413,19 @@ func EnsureCleanState() {
 		&metalv1alpha1.BIOSVersionList{},
 		&metalv1alpha1.BIOSSettingsSetList{},
 		&metalv1alpha1.BIOSSettingsList{},
+		&metalv1alpha1.ServerClaimList{},
 		&metalv1alpha1.ServerMaintenanceList{},
 		&metalv1alpha1.ServerList{},
+		&metalv1alpha1.BMCSecretList{},
 	}
 
 	for _, list := range objectLists {
+		Expect(k8sClient.List(ctx, list)).To(Succeed())
+		items, err := meta.ExtractList(list)
+		Expect(err).NotTo(HaveOccurred())
+		for _, item := range items {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, item.(client.Object)))).To(Succeed())
+		}
 		Eventually(ObjectList(list)).Should(HaveField("Items", HaveLen(0)))
 	}
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -45,14 +45,17 @@ const (
 	eventuallyTimeout    = 5 * time.Second
 	consistentlyDuration = 1 * time.Second
 	MockServerIP         = "127.0.0.1"
-	MockServerPort       = 8000
 )
 
 var (
-	cfg                     *rest.Config
-	k8sClient               client.Client
-	testEnv                 *envtest.Environment
-	registryURL             = "http://localhost:30000"
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	// MockServerPort and RegistryPort are offset per parallel ginkgo
+	// process so suites running concurrently do not collide on ports.
+	MockServerPort          int32
+	RegistryPort            int
+	registryURL             string
 	mockUpServerBiosVersion = "P79 v1.45 (12/06/2017)"
 	mockUpServerBMCVersion  = "1.45.455b66-rev4"
 	mockServers             []*server.MockServer
@@ -64,6 +67,11 @@ func TestControllers(t *testing.T) {
 	SetDefaultEventuallyTimeout(eventuallyTimeout)
 	SetDefaultConsistentlyDuration(consistentlyDuration)
 	RegisterFailHandler(Fail)
+
+	// Flags are parsed at this point, so GinkgoParallelProcess is reliable.
+	RegistryPort = 30000 + GinkgoParallelProcess()
+	MockServerPort = int32(8000 + (GinkgoParallelProcess()-1)*10)
+	registryURL = fmt.Sprintf("http://localhost:%d", RegistryPort)
 
 	RunSpecs(t, "Controller Suite")
 }
@@ -346,7 +354,7 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 
 		By("Starting the registry server")
 		Expect(k8sManager.Add(manager.RunnableFunc(func(ctx context.Context) error {
-			registryServer := registry.NewServer(GinkgoLogr, ":30000", k8sManager.GetClient())
+			registryServer := registry.NewServer(GinkgoLogr, fmt.Sprintf(":%d", RegistryPort), k8sManager.GetClient())
 			if err := registryServer.Start(ctx); err != nil {
 				return fmt.Errorf("failed to start registry server: %w", err)
 			}

--- a/internal/probe/probe_suite_test.go
+++ b/internal/probe/probe_suite_test.go
@@ -5,6 +5,7 @@ package probe_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -19,13 +20,21 @@ var (
 	probeAgent     *probe.Agent
 	registryServer *registry.Server
 
-	registryAddr = ":30001"
-	registryURL  = "http://localhost:30001"
-	systemUUID   = "1234-5678"
+	systemUUID = "1234-5678"
+)
+
+var (
+	registryAddr string
+	registryURL  string
 )
 
 func TestRegistry(t *testing.T) {
 	RegisterFailHandler(Fail)
+	// Offset the port per parallel ginkgo process to avoid bind collisions.
+	// Flags are parsed at this point, so GinkgoParallelProcess is reliable.
+	port := 30001 + GinkgoParallelProcess()
+	registryAddr = fmt.Sprintf(":%d", port)
+	registryURL = fmt.Sprintf("http://localhost:%d", port)
 	RunSpecs(t, "Probe Suite")
 }
 

--- a/internal/registry/registry_suite_test.go
+++ b/internal/registry/registry_suite_test.go
@@ -5,6 +5,7 @@ package registry_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -15,12 +16,17 @@ import (
 
 var (
 	server         *registry.Server
-	testServerURL  = "http://localhost:30002"
-	testServerAddr = ":30002"
+	testServerURL  string
+	testServerAddr string
 )
 
 func TestRegistry(t *testing.T) {
 	RegisterFailHandler(Fail)
+	// Offset the port per parallel ginkgo process to avoid bind collisions.
+	// Flags are parsed at this point, so GinkgoParallelProcess is reliable.
+	port := 30002 + GinkgoParallelProcess()
+	testServerURL = fmt.Sprintf("http://localhost:%d", port)
+	testServerAddr = fmt.Sprintf(":%d", port)
 	RunSpecs(t, "Registry Suite")
 }
 


### PR DESCRIPTION
# Proposed Changes

Parallelize suite with per-process port offsets and fix flaky retry assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved maintenance handling when referenced records are deleted or unavailable.
  - Cleans up stale maintenance references and related records during BIOS settings or BMC version deletion.
  - Reports reconciliation and reset errors more accurately.
  - Improved reliability when updating server status during concurrent changes.

- **Tests**
  - Improved parallel test execution with isolated ports, CPU-aware scheduling, and stable retry checks.
  - Reduced test wait times while preserving coverage of asynchronous operations.
  - Strengthened cleanup verification and reduced test flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->