### PR TITLE
Deprecate `BMCUser` resource

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,6 +63,12 @@ linters:
       - linters:
           - staticcheck
         text: "SA1019.*metalv1alpha1\\.(ServerMaintenance|BMCSettingsSet|BMCSettings|BMCVersionSet|BMCVersion|BIOSVersionSet|BIOSVersion|BIOSSettingsSet|BIOSSettings)\\b"
+      # The BMCUser resource is deprecated (see issue #1033). The operator still
+      # serves and reconciles existing BMCUser objects, so these legacy consumers
+      # reference the type until the resource is fully removed.
+      - linters:
+          - staticcheck
+        text: "SA1019.*metalv1alpha1\\.BMCUser\\b"
       # The Endpoint resource is deprecated (see issue #1018). The operator still
       # serves existing Endpoint objects and the endpointRef access path, so these
       # legacy consumers reference the type until the resource is fully removed.

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcuser.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/bmcuser.go
@@ -18,6 +18,8 @@ import (
 // with apply.
 //
 // BMCUser is the Schema for the bmcusers API.
+//
+// Deprecated: The BMCUser resource is deprecated.
 type BMCUserApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/api/v1alpha1/bmcuser_types.go
+++ b/api/v1alpha1/bmcuser_types.go
@@ -57,8 +57,11 @@ type BMCUserStatus struct {
 // +kubebuilder:printcolumn:name="LastRotation",type=date,JSONPath=`.status.lastRotation`
 // +kubebuilder:printcolumn:name="PasswordExpiration",type=date,JSONPath=`.status.passwordExpiration`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:deprecatedversion:warning="metal.ironcore.dev/v1alpha1 BMCUser is deprecated"
 
 // BMCUser is the Schema for the bmcusers API.
+//
+// Deprecated: The BMCUser resource is deprecated.
 type BMCUser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/metal.ironcore.dev_bmcusers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bmcusers.yaml
@@ -35,10 +35,15 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: metal.ironcore.dev/v1alpha1 BMCUser is deprecated
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BMCUser is the Schema for the bmcusers API.
+        description: |-
+          BMCUser is the Schema for the bmcusers API.
+
+          Deprecated: The BMCUser resource is deprecated.
         properties:
           apiVersion:
             description: |-

--- a/dist/chart/templates/crd/bmcusers.metal.ironcore.dev.yaml
+++ b/dist/chart/templates/crd/bmcusers.metal.ironcore.dev.yaml
@@ -39,10 +39,15 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: metal.ironcore.dev/v1alpha1 BMCUser is deprecated
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BMCUser is the Schema for the bmcusers API.
+        description: |-
+          BMCUser is the Schema for the bmcusers API.
+
+          Deprecated: The BMCUser resource is deprecated.
         properties:
           apiVersion:
             description: |-

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2146,10 +2146,15 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: metal.ironcore.dev/v1alpha1 BMCUser is deprecated
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BMCUser is the Schema for the bmcusers API.
+        description: |-
+          BMCUser is the Schema for the bmcusers API.
+
+          Deprecated: The BMCUser resource is deprecated.
         properties:
           apiVersion:
             description: |-

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -708,6 +708,8 @@ _Appears in:_
 
 BMCUser is the Schema for the bmcusers API.
 
+Deprecated: The BMCUser resource is deprecated.
+
 
 
 

--- a/docs/concepts/bmcusers.md
+++ b/docs/concepts/bmcusers.md
@@ -1,0 +1,48 @@
+# BMCUser
+
+> **Deprecation Notice:** The `BMCUser` resource is deprecated and will be removed in a future release.
+
+`BMCUser` manages a user account on the BMC of a single `BMC` resource, including credential management and password rotation.
+
+## What It Does
+
+- Targets one BMC through `spec.bmcRef`.
+- Creates or updates the BMC user account with `spec.userName` and `spec.roleID`.
+- Uses credentials from an existing `BMCSecret` (`spec.bmcSecretRef`) or generates a secure password and stores it in a new `BMCSecret`.
+- Rotates the password according to `spec.rotationPeriod` by generating a new `BMCSecret` and updating the account on the BMC. Rotation can also be forced by setting the annotation `metal.ironcore.dev/operation: rotate-credentials` or when the BMC-reported password expiration has passed.
+- Removes the account from the BMC on deletion (finalizer-based cleanup).
+
+## Spec Reference
+
+| Field | Required | Description |
+|---|---|---|
+| `spec.userName` | Yes | Username of the BMC user. |
+| `spec.roleID` | Yes | Role ID to assign to the user. |
+| `spec.description` | No | Description of the BMC user. |
+| `spec.bmcRef.name` | No | Target BMC object. If not set, the resource is not reconciled. |
+| `spec.bmcSecretRef.name` | No | `BMCSecret` containing the credentials. If not set, the operator generates a password and creates one. |
+| `spec.rotationPeriod` | No | How often the password is rotated. If not set, the password is not rotated. |
+
+## Status Fields In Detail
+
+| Field | What it means | How to use it for debugging |
+|---|---|---|
+| `status.id` | Identifier of the user account in the BMC system. | Empty means the account has not been created on the BMC yet. |
+| `status.effectiveBMCSecretRef` | The `BMCSecret` currently in use, which may differ from `spec.bmcSecretRef` if the operator generated the password. | Points at the secret holding the working credentials. |
+| `status.lastRotation` | Timestamp of the last password rotation. | Check whether rotation is running as expected. |
+| `status.passwordExpiration` | Timestamp when the current password will expire. | Next scheduled rotation point. |
+
+## Example
+
+```yaml
+apiVersion: metal.ironcore.dev/v1alpha1
+kind: BMCUser
+metadata:
+  name: bmcuser-sample
+spec:
+  userName: operator
+  roleID: "Administrator"
+  bmcRef:
+    name: bmc-sample
+  rotationPeriod: 720h
+```

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -17,4 +17,5 @@ their relationships. Each concept is linked to its respective documentation for 
 - [**BMCSettings**](/concepts/bmcsettings): Handles updating the BMC setting on the physical server's Manager.
 - [**BMCSettingsSet**](/concepts/bmcsettingsset): Handles creation of multiple `BMCSettings` by selecting BMCs through labels.
 - [**BMCVersion**](/concepts/bmcversion): Handles upgrading the BMC Version on the physical server's Manager.
-- [**BMCVersionSet**](/concepts/bmcversionset): Handles creation of multiple `BMCVersion` by selecting BMC's through labels.
+- [**BMCVersionSet**](/concepts/bmcversionset): Handles creation of multiple `BMCVersion` by selecting BMCs through labels.
+- [**BMCUser**](/concepts/bmcusers): Deprecated. Manages user accounts on a BMC, including credential management and password rotation.


### PR DESCRIPTION
# Proposed Changes

Deprecate `BMCUser` resource.

Fixes #1033 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive documentation for the `BMCUser` resource, including configuration, status, lifecycle behavior, and examples.
  - Added the resource to the concepts documentation and clearly marked it as deprecated.
  - Updated API reference documentation with the deprecation status.

- **Deprecation**
  - Marked the `BMCUser` API resource and its configuration as deprecated.
  - Added deprecation warnings to the published resource definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->