### PR TITLE
Use metal-operator.* helpers in ignition ConfigMap; rename ingition to ignition

### DIFF
--- a/dist/chart/templates/configmap/ignition-template.yaml
+++ b/dist/chart/templates/configmap/ignition-template.yaml
@@ -2,10 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "chart.name" . }}-ignition-template
+  name: {{ include "metal-operator.resourceName" (dict "suffix" "ignition-template" "context" $) }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "metal-operator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   # The Ignition template has the following parameters substituted at runtime:
   # {{.Image}} - The Docker image to run for metalprobe


### PR DESCRIPTION
# Proposed Changes

- Fix the ignition ConfigMap template (dist/chart/templates/configmap/) to use the current metal-operator.* helm helpers instead of the removed chart.name/chart.labels, which broke `helm template`/`helm install` whenever ignition.override=true (no template "chart.name" associated with template "gotpl").
- Set the ConfigMap name via include "metal-operator.resourceName" (dict "suffix" "ignition-template" "context" $), preserving the existing metal-operator-ignition-template name so consumers referencing it are unaffected.
- Emit standard app.kubernetes.io/{name,instance,managed-by} labels inline, matching the convention used by the rest of the chart (the v2-alpha plugin defines no chart.labels helper).
- Rename the misspelled template file ingition-template.yaml -> ignition-template.yaml (via git mv, preserving history).

Fixes #1086
