### PR TITLE
Refactor BMCVersionSet/BIOSVersionSet: dedupe-safe child creation and leaner deletion paths

### DIFF
--- a/internal/controller/biosversionset_controller.go
+++ b/internal/controller/biosversionset_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 const (
@@ -41,6 +42,7 @@ type BIOSVersionSetReconciler struct {
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversionsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servermaintenances,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -208,10 +210,19 @@ func (r *BIOSVersionSetReconciler) patchBIOSVersionFromTemplate(ctx context.Cont
 	var pendingPatchingVersion bool
 	var errs []error
 	for _, version := range versions.Items {
-		if version.Status.State == metalv1alpha1.BIOSVersionStateInProgress && version.Status.UpgradeTask != nil {
-			log.V(1).Info("Skipping BIOSVersion spec patching as it is InProgress with an active UpgradeTask", "BIOSVersion", version.Name)
-			pendingPatchingVersion = true
-			continue
+		// stop patching once maintenance is approved: the BIOSVersion controller
+		// performs active operations (e.g. BMC reset) before the upgrade task exists
+		if version.Status.State == metalv1alpha1.BIOSVersionStateInProgress && version.Spec.ServerMaintenanceRef != nil {
+			active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*version.Spec.ServerMaintenanceRef})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to check maintenance state for BIOSVersion %s: %w", version.Name, err))
+				continue
+			}
+			if active {
+				log.V(1).Info("Skipping BIOSVersion spec patching as its maintenance is approved", "BIOSVersion", version.Name)
+				pendingPatchingVersion = true
+				continue
+			}
 		}
 		opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, &version, func() error {
 			version.Spec.BIOSVersionTemplate = *template.DeepCopy()

--- a/internal/controller/biosversionset_controller.go
+++ b/internal/controller/biosversionset_controller.go
@@ -7,23 +7,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
-	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 const (
@@ -42,7 +41,6 @@ type BIOSVersionSetReconciler struct {
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversionsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=biosversions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servers,verbs=get;list;watch
-// +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servermaintenances,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -63,35 +61,20 @@ func (r *BIOSVersionSetReconciler) reconcileExists(ctx context.Context, versionS
 
 func (r *BIOSVersionSetReconciler) delete(ctx context.Context, versionSet *metalv1alpha1.BIOSVersionSet) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.V(1).Info("Deleting BIOSVersionSet")
 	if !controllerutil.ContainsFinalizer(versionSet, BIOSVersionSetFinalizer) {
 		return ctrl.Result{}, nil
-	}
-
-	if err := r.handleIgnoreAnnotationPropagation(ctx, versionSet); err != nil {
-		return ctrl.Result{}, err
 	}
 
 	versions, err := r.getOwnedBIOSVersions(ctx, versionSet)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get owned BIOSVersions: %w", err)
 	}
-
-	status := r.getOwnedBIOSVersionSetStatus(versions)
-	if status.AvailableBIOSVersion != (status.CompletedBIOSVersion+status.FailedBIOSVersion) ||
-		versionSet.Status.AvailableBIOSVersion != status.AvailableBIOSVersion {
-		if err = r.patchStatus(ctx, status, versionSet); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to patch BIOSVersionSet status: %w", err)
-		}
-		log.V(1).Info("BIOSVersionSet status patched", "Status", status)
-
-		if err := r.handleRetryAnnotationPropagation(ctx, versionSet); err != nil {
-			return ctrl.Result{}, err
-		}
-		log.Info("Waiting on the created BIOSVersion to reach terminal status")
-		return ctrl.Result{}, nil
+	if err := handleIgnoreAnnotationPropagation(ctx, r.Client, versionSet, versions); err != nil {
+		return ctrl.Result{}, err
 	}
 
+	// children are garbage collected through the owner reference; their own
+	// finalizers postpone deletion while an upgrade maintenance is active
 	log.V(1).Info("Ensuring that the finalizer is removed")
 	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, versionSet, BIOSVersionSetFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
@@ -101,38 +84,16 @@ func (r *BIOSVersionSetReconciler) delete(ctx context.Context, versionSet *metal
 	return ctrl.Result{}, nil
 }
 
-func (r *BIOSVersionSetReconciler) handleIgnoreAnnotationPropagation(ctx context.Context, versionSet *metalv1alpha1.BIOSVersionSet) error {
-	log := ctrl.LoggerFrom(ctx)
-	versions, err := r.getOwnedBIOSVersions(ctx, versionSet)
-	if err != nil {
-		return err
-	}
-
-	if len(versions.Items) == 0 {
-		log.V(1).Info("No BIOSVersions found, skipping ignore annotation propagation")
-		return nil
-	}
-	return handleIgnoreAnnotationPropagation(ctx, r.Client, versionSet, versions)
-}
-
-func (r *BIOSVersionSetReconciler) handleRetryAnnotationPropagation(ctx context.Context, versionSet *metalv1alpha1.BIOSVersionSet) error {
-	log := ctrl.LoggerFrom(ctx)
-	versions, err := r.getOwnedBIOSVersions(ctx, versionSet)
-	if err != nil {
-		return err
-	}
-
-	if len(versions.Items) == 0 {
-		log.V(1).Info("No BIOSVersion found, skipping retry annotation propagation")
-		return nil
-	}
-	return handleRetryAnnotationPropagation(ctx, r.Client, versionSet, versions)
-}
-
 func (r *BIOSVersionSetReconciler) reconcile(ctx context.Context, versionSet *metalv1alpha1.BIOSVersionSet) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Reconciling BIOSVersionSet")
-	if err := r.handleIgnoreAnnotationPropagation(ctx, versionSet); err != nil {
+
+	versions, err := r.getOwnedBIOSVersions(ctx, versionSet)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get owned BIOSVersions: %w", err)
+	}
+
+	if err := handleIgnoreAnnotationPropagation(ctx, r.Client, versionSet, versions); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -148,11 +109,6 @@ func (r *BIOSVersionSetReconciler) reconcile(ctx context.Context, versionSet *me
 	servers, err := r.getServersBySelector(ctx, versionSet)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get servers by selector: %w", err)
-	}
-
-	versions, err := r.getOwnedBIOSVersions(ctx, versionSet)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get owned BIOSVersions: %w", err)
 	}
 
 	log.V(1).Info("Summary of Servers and BIOSVersions", "ServerCount", len(servers.Items), "BIOSVersionCount", len(versions.Items))
@@ -181,7 +137,7 @@ func (r *BIOSVersionSetReconciler) reconcile(ctx context.Context, versionSet *me
 	}
 	log.V(1).Info("Patched BIOSVersionSet status", "Status", status)
 
-	if err := r.handleRetryAnnotationPropagation(ctx, versionSet); err != nil {
+	if err := handleRetryAnnotationPropagation(ctx, r.Client, versionSet, versions); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -204,20 +160,12 @@ func (r *BIOSVersionSetReconciler) ensureBIOSVersionsForServers(ctx context.Cont
 	var errs []error
 	for _, server := range servers.Items {
 		if !withBiosVersion[server.Name] {
-			var newBiosVersion *metalv1alpha1.BIOSVersion
-			newBiosVersionName := fmt.Sprintf("%s-%s", versionSet.Name, server.Name)
-			if len(newBiosVersionName) > utilvalidation.DNS1123SubdomainMaxLength {
-				log.V(1).Info("BIOSVersion name is too long, it will be shortened using random string", "BIOSVersionName", newBiosVersionName)
-				newBiosVersion = &metalv1alpha1.BIOSVersion{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: newBiosVersionName[:utilvalidation.DNS1123SubdomainMaxLength-10] + "-",
-					}}
-			} else {
-				newBiosVersion = &metalv1alpha1.BIOSVersion{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: newBiosVersionName,
-					}}
-			}
+			name, generateName := versionSetChildName(versionSet.Name, server.Name)
+			newBiosVersion := &metalv1alpha1.BIOSVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         name,
+					GenerateName: generateName,
+				}}
 
 			opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, newBiosVersion, func() error {
 				newBiosVersion.Spec.BIOSVersionTemplate = *versionSet.Spec.BIOSVersionTemplate.DeepCopy()
@@ -234,7 +182,6 @@ func (r *BIOSVersionSetReconciler) ensureBIOSVersionsForServers(ctx context.Cont
 }
 
 func (r *BIOSVersionSetReconciler) deleteOrphanBIOSVersions(ctx context.Context, servers *metalv1alpha1.ServerList, versions *metalv1alpha1.BIOSVersionList) error {
-	log := ctrl.LoggerFrom(ctx)
 	serverMap := make(map[string]bool)
 	for _, server := range servers.Items {
 		serverMap[server.Name] = true
@@ -242,18 +189,9 @@ func (r *BIOSVersionSetReconciler) deleteOrphanBIOSVersions(ctx context.Context,
 
 	var errs []error
 	for _, biosVersion := range versions.Items {
+		// the BIOSVersion finalizer postpones deletion while a maintenance is
+		// active, so orphans can be deleted unconditionally
 		if !serverMap[biosVersion.Spec.ServerRef.Name] {
-			if biosVersion.Status.State == metalv1alpha1.BIOSVersionStateInProgress && biosVersion.Spec.ServerMaintenanceRef != nil {
-				active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, []metalv1alpha1.ObjectReference{*biosVersion.Spec.ServerMaintenanceRef})
-				if err != nil {
-					errs = append(errs, fmt.Errorf("failed to check maintenance state for BIOSVersion %s: %w", biosVersion.Name, err))
-					continue
-				}
-				if active {
-					log.V(1).Info("Waiting for BIOSVersion maintenance to complete before deletion", "BIOSVersion", biosVersion.Name, "Status", biosVersion.Status)
-					continue
-				}
-			}
 			if err := r.Delete(ctx, &biosVersion); err != nil {
 				errs = append(errs, err)
 			}
@@ -272,7 +210,8 @@ func (r *BIOSVersionSetReconciler) patchBIOSVersionFromTemplate(ctx context.Cont
 	var pendingPatchingVersion bool
 	var errs []error
 	for _, version := range versions.Items {
-		if version.Status.State == metalv1alpha1.BIOSVersionStateInProgress {
+		if version.Status.State == metalv1alpha1.BIOSVersionStateInProgress && version.Status.UpgradeTask != nil {
+			log.V(1).Info("Skipping BIOSVersion spec patching as it is InProgress with an active UpgradeTask", "BIOSVersion", version.Name)
 			pendingPatchingVersion = true
 			continue
 		}
@@ -325,6 +264,9 @@ func (r *BIOSVersionSetReconciler) getServersBySelector(ctx context.Context, set
 	if err := r.List(ctx, servers, client.MatchingLabelsSelector{Selector: selector}); err != nil {
 		return nil, err
 	}
+	servers.Items = slices.DeleteFunc(servers.Items, func(s metalv1alpha1.Server) bool {
+		return !s.DeletionTimestamp.IsZero()
+	})
 	return servers, nil
 }
 
@@ -340,35 +282,17 @@ func (r *BIOSVersionSetReconciler) patchStatus(ctx context.Context, status *meta
 
 func (r *BIOSVersionSetReconciler) enqueueByServer(ctx context.Context, obj client.Object) []ctrl.Request {
 	log := ctrl.LoggerFrom(ctx)
-	server := obj.(*metalv1alpha1.Server)
 
 	setList := &metalv1alpha1.BIOSVersionSetList{}
 	if err := r.List(ctx, setList); err != nil {
 		log.Error(err, "Failed to list BIOSVersionSet")
 		return nil
 	}
-	reqs := make([]ctrl.Request, 0)
+	// on label changes enqueue all sets; each reconcile decides whether the
+	// server is in scope or its child became an orphan
+	reqs := make([]ctrl.Request, 0, len(setList.Items))
 	for _, set := range setList.Items {
-		selector, err := metav1.LabelSelectorAsSelector(&set.Spec.ServerSelector)
-		if err != nil {
-			log.Error(err, "Failed to convert label selector")
-			return nil
-		}
-		// If the Server label matches the selector, enqueue the request
-		if selector.Matches(labels.Set(server.GetLabels())) {
-			reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKey{Name: set.Name}})
-		} else { // if the label has been removed
-			versions, err := r.getOwnedBIOSVersions(ctx, &set)
-			if err != nil {
-				log.Error(err, "Failed to get owned BIOSVersions")
-				return nil
-			}
-			for _, version := range versions.Items {
-				if version.Spec.ServerRef.Name == server.Name {
-					reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKey{Name: set.Name}})
-				}
-			}
-		}
+		reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKey{Name: set.Name}})
 	}
 	return reqs
 }
@@ -377,7 +301,25 @@ func (r *BIOSVersionSetReconciler) enqueueByServer(ctx context.Context, obj clie
 func (r *BIOSVersionSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&metalv1alpha1.BIOSVersionSet{}).
-		Owns(&metalv1alpha1.BIOSVersion{}).
+		Watches(
+			&metalv1alpha1.BIOSVersion{},
+			handler.EnqueueRequestForOwner(r.Scheme, r.RESTMapper(), &metalv1alpha1.BIOSVersionSet{}),
+			builder.WithPredicates(
+				predicate.Funcs{
+					CreateFunc: func(e event.CreateEvent) bool {
+						return true
+					},
+					UpdateFunc: func(e event.UpdateEvent) bool {
+						return enqueueFromChildObjUpdatesExceptAnnotation(e)
+					},
+					DeleteFunc: func(e event.DeleteEvent) bool {
+						return true
+					}, GenericFunc: func(e event.GenericEvent) bool {
+						return false
+					},
+				},
+			),
+		).
 		Watches(&metalv1alpha1.Server{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueByServer),
 			builder.WithPredicates(predicate.LabelChangedPredicate{})).

--- a/internal/controller/biosversionset_controller.go
+++ b/internal/controller/biosversionset_controller.go
@@ -160,11 +160,9 @@ func (r *BIOSVersionSetReconciler) ensureBIOSVersionsForServers(ctx context.Cont
 	var errs []error
 	for _, server := range servers.Items {
 		if !withBiosVersion[server.Name] {
-			name, generateName := versionSetChildName(versionSet.Name, server.Name)
 			newBiosVersion := &metalv1alpha1.BIOSVersion{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:         name,
-					GenerateName: generateName,
+					Name: versionSetChildName(versionSet.Name, server.Name),
 				}}
 
 			opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, newBiosVersion, func() error {

--- a/internal/controller/biosversionset_controller_test.go
+++ b/internal/controller/biosversionset_controller_test.go
@@ -79,7 +79,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 				},
 			},
 			Spec: metalv1alpha1.ServerSpec{
-				SystemUUID: "48947555-7742-3448-3784-823347823835",
+				SystemUUID: "38947555-7742-3448-3784-823347823834",
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
@@ -103,7 +103,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 				},
 			},
 			Spec: metalv1alpha1.ServerSpec{
-				SystemUUID: "58947555-7742-3448-3784-823347823836",
+				SystemUUID: "38947555-7742-3448-3784-823347823834",
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,

--- a/internal/controller/biosversionset_controller_test.go
+++ b/internal/controller/biosversionset_controller_test.go
@@ -79,7 +79,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 				},
 			},
 			Spec: metalv1alpha1.ServerSpec{
-				SystemUUID: "38947555-7742-3448-3784-823347823834",
+				SystemUUID: "48947555-7742-3448-3784-823347823835",
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
@@ -103,7 +103,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 				},
 			},
 			Spec: metalv1alpha1.ServerSpec{
-				SystemUUID: "38947555-7742-3448-3784-823347823834",
+				SystemUUID: "58947555-7742-3448-3784-823347823836",
 				BMC: &metalv1alpha1.BMCAccess{
 					Protocol: metalv1alpha1.Protocol{
 						Name: metalv1alpha1.ProtocolRedfishLocal,
@@ -230,7 +230,7 @@ var _ = Describe("BIOSVersionSet Controller", func() {
 		)
 	})
 
-	It("should successfully reconcile the resource when BMC are deleted/created", func(ctx SpecContext) {
+	It("should successfully reconcile the resource when Servers are deleted/created", func(ctx SpecContext) {
 		By("Create resource")
 		biosVersionSet := &metalv1alpha1.BIOSVersionSet{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/bmcversionset_controller.go
+++ b/internal/controller/bmcversionset_controller.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
-	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 const (
@@ -42,7 +41,6 @@ type BMCVersionSetReconciler struct {
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcversionsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcs,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcversions,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servermaintenances,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -80,30 +78,16 @@ func (r *BMCVersionSetReconciler) delete(
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.handleIgnoreAnnotationPropagation(ctx, bmcVersionSet); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	ownedBMCVersions, err := r.getOwnedBMCVersions(ctx, bmcVersionSet)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get owned BMCVersion resources %w", err)
 	}
-
-	currentStatus := r.getOwnedBMCVersionSetStatus(ownedBMCVersions)
-
-	if currentStatus.AvailableBMCVersion != (currentStatus.CompletedBMCVersion+currentStatus.FailedBMCVersion) ||
-		bmcVersionSet.Status.AvailableBMCVersion != currentStatus.AvailableBMCVersion {
-		err = r.updateStatus(ctx, currentStatus, bmcVersionSet)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update current BMCVersionSet Status %w", err)
-		}
-		if err := r.handleRetryAnnotationPropagation(ctx, bmcVersionSet); err != nil {
-			return ctrl.Result{}, err
-		}
-		log.Info("Waiting on the created BMCVersion to reach terminal status")
-		return ctrl.Result{}, nil
+	if err := handleIgnoreAnnotationPropagation(ctx, r.Client, bmcVersionSet, ownedBMCVersions); err != nil {
+		return ctrl.Result{}, err
 	}
 
+	// children are garbage collected through the owner reference; their own
+	// finalizers postpone deletion while an upgrade maintenance is active
 	log.V(1).Info("Ensuring that the finalizer is removed")
 	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, bmcVersionSet, BMCVersionSetFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
@@ -113,44 +97,17 @@ func (r *BMCVersionSetReconciler) delete(
 	return ctrl.Result{}, nil
 }
 
-func (r *BMCVersionSetReconciler) handleIgnoreAnnotationPropagation(
-	ctx context.Context,
-	bmcVersionSet *metalv1alpha1.BMCVersionSet,
-) error {
-	log := ctrl.LoggerFrom(ctx)
-	ownedBMCVersions, err := r.getOwnedBMCVersions(ctx, bmcVersionSet)
-	if err != nil {
-		return err
-	}
-	if len(ownedBMCVersions.Items) == 0 {
-		log.V(1).Info("No BMCVersion found, skipping ignore annotation propagation")
-		return nil
-	}
-	return handleIgnoreAnnotationPropagation(ctx, r.Client, bmcVersionSet, ownedBMCVersions)
-}
-
-func (r *BMCVersionSetReconciler) handleRetryAnnotationPropagation(
-	ctx context.Context,
-	bmcVersionSet *metalv1alpha1.BMCVersionSet,
-) error {
-	log := ctrl.LoggerFrom(ctx)
-	ownedBMCVersion, err := r.getOwnedBMCVersions(ctx, bmcVersionSet)
-	if err != nil {
-		return err
-	}
-	if len(ownedBMCVersion.Items) == 0 {
-		log.V(1).Info("No BMCVersion found, skipping retry annotation propagation")
-		return nil
-	}
-	return handleRetryAnnotationPropagation(ctx, r.Client, bmcVersionSet, ownedBMCVersion)
-}
-
 func (r *BMCVersionSetReconciler) reconcile(
 	ctx context.Context,
 	bmcVersionSet *metalv1alpha1.BMCVersionSet,
 ) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	if err := r.handleIgnoreAnnotationPropagation(ctx, bmcVersionSet); err != nil {
+	ownedBMCVersions, err := r.getOwnedBMCVersions(ctx, bmcVersionSet)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get owned BMCVersion resources %w", err)
+	}
+
+	if err := handleIgnoreAnnotationPropagation(ctx, r.Client, bmcVersionSet, ownedBMCVersions); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -168,11 +125,6 @@ func (r *BMCVersionSetReconciler) reconcile(
 		return ctrl.Result{}, fmt.Errorf("failed to get BMC resource through label selector %w", err)
 	}
 
-	ownedBMCVersions, err := r.getOwnedBMCVersions(ctx, bmcVersionSet)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get owned BMCVersion resources %w", err)
-	}
-
 	log.V(1).Info("Summary of BMC and BMCVersions", "BMCs count", len(bmcList.Items),
 		"BMCVersion count", len(ownedBMCVersions.Items))
 
@@ -182,7 +134,7 @@ func (r *BMCVersionSetReconciler) reconcile(
 	}
 
 	// delete BMCVersion for BMCs which do not exist anymore
-	if _, err := r.deleteOrphanBMCVersions(ctx, bmcList, ownedBMCVersions); err != nil {
+	if err := r.deleteOrphanBMCVersions(ctx, bmcList, ownedBMCVersions); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to delete orphaned BMCVersion resources %w", err)
 	}
 
@@ -199,7 +151,7 @@ func (r *BMCVersionSetReconciler) reconcile(
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update current BMCVersionSet Status %w", err)
 	}
-	if err := r.handleRetryAnnotationPropagation(ctx, bmcVersionSet); err != nil {
+	if err := handleRetryAnnotationPropagation(ctx, r.Client, bmcVersionSet, ownedBMCVersions); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -227,9 +179,11 @@ func (r *BMCVersionSetReconciler) createMissingBMCVersions(
 	var errs []error
 	for _, bmc := range bmcList.Items {
 		if _, ok := BMCWithBMCVersion[bmc.Name]; !ok {
+			name, generateName := versionSetChildName(bmcVersionSet.Name, bmc.Name)
 			newBMCVersion := &metalv1alpha1.BMCVersion{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "bmc-version-set-",
+					Name:         name,
+					GenerateName: generateName,
 				}}
 			opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, newBMCVersion, func() error {
 				newBMCVersion.Spec.BMCVersionTemplate = *bmcVersionSet.Spec.BMCVersionTemplate.DeepCopy()
@@ -249,37 +203,24 @@ func (r *BMCVersionSetReconciler) deleteOrphanBMCVersions(
 	ctx context.Context,
 	bmcList *metalv1alpha1.BMCList,
 	bmcVersionList *metalv1alpha1.BMCVersionList,
-) ([]string, error) {
-	log := ctrl.LoggerFrom(ctx)
-
+) error {
 	bmcMap := make(map[string]struct{})
 	for _, bmc := range bmcList.Items {
 		bmcMap[bmc.Name] = struct{}{}
 	}
 
 	var errs []error
-	var warnings []string
 	for _, bmcVersion := range bmcVersionList.Items {
+		// the BMCVersion finalizer postpones deletion while a maintenance is
+		// active, so orphans can be deleted unconditionally
 		if _, ok := bmcMap[bmcVersion.Spec.BMCRef.Name]; !ok {
-			if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateInProgress && len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
-				active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
-				if err != nil {
-					errs = append(errs, fmt.Errorf("failed to check maintenance state for BMCVersion %s: %w", bmcVersion.Name, err))
-					continue
-				}
-				if active {
-					log.V(1).Info("Waiting for BMCVersion maintenance to complete before deletion", "BMCVersion", bmcVersion.Name, "status", bmcVersion.Status)
-					warnings = append(warnings, fmt.Sprintf("BMCVersion %s is under active maintenance, skipping deletion", bmcVersion.Name))
-					continue
-				}
-			}
 			if err := r.Delete(ctx, &bmcVersion); err != nil {
 				errs = append(errs, err)
 			}
 		}
 	}
 
-	return warnings, errors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 func (r *BMCVersionSetReconciler) patchBMCVersionfromTemplate(
@@ -358,6 +299,9 @@ func (r *BMCVersionSetReconciler) getBMCBySelector(
 	if err := r.List(ctx, bmcList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
 		return nil, err
 	}
+	bmcList.Items = slices.DeleteFunc(bmcList.Items, func(b metalv1alpha1.BMC) bool {
+		return !b.DeletionTimestamp.IsZero()
+	})
 
 	return bmcList, nil
 }
@@ -385,45 +329,21 @@ func (r *BMCVersionSetReconciler) updateStatus(
 func (r *BMCVersionSetReconciler) enqueueByBMC(ctx context.Context, obj client.Object) []ctrl.Request {
 	log := ctrl.LoggerFrom(ctx)
 
-	host := obj.(*metalv1alpha1.BMC)
-
 	bmcVersionSetList := &metalv1alpha1.BMCVersionSetList{}
 	if err := r.List(ctx, bmcVersionSetList); err != nil {
 		log.Error(err, "Failed to list BMCVersionSet")
 		return nil
 	}
-	reqs := make([]ctrl.Request, 0)
+	// on label changes enqueue all sets; each reconcile decides whether the
+	// BMC is in scope or its child became an orphan
+	reqs := make([]ctrl.Request, 0, len(bmcVersionSetList.Items))
 	for _, bmcVersionSet := range bmcVersionSetList.Items {
-		selector, err := metav1.LabelSelectorAsSelector(&bmcVersionSet.Spec.BMCSelector)
-		if err != nil {
-			log.Error(err, "Failed to convert label selector")
-			return nil
-		}
-		// if the host label matches the selector, enqueue the request
-		if selector.Matches(labels.Set(host.GetLabels())) {
-			reqs = append(reqs, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      bmcVersionSet.Name,
-					Namespace: bmcVersionSet.Namespace,
-				},
-			})
-		} else { // if the label has been removed
-			ownedBMCVersions, err := r.getOwnedBMCVersions(ctx, &bmcVersionSet)
-			if err != nil {
-				log.Error(err, "Failed to get owned BMCVersion resources")
-				return nil
-			}
-			for _, bmcVersion := range ownedBMCVersions.Items {
-				if bmcVersion.Spec.BMCRef.Name == host.Name {
-					reqs = append(reqs, ctrl.Request{
-						NamespacedName: client.ObjectKey{
-							Name:      bmcVersionSet.Name,
-							Namespace: bmcVersionSet.Namespace,
-						},
-					})
-				}
-			}
-		}
+		reqs = append(reqs, ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      bmcVersionSet.Name,
+				Namespace: bmcVersionSet.Namespace,
+			},
+		})
 	}
 	return reqs
 }

--- a/internal/controller/bmcversionset_controller.go
+++ b/internal/controller/bmcversionset_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	metalutil "github.com/ironcore-dev/metal-operator/internal/util"
 )
 
 const (
@@ -41,6 +42,7 @@ type BMCVersionSetReconciler struct {
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcversionsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcs,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcversions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=metal.ironcore.dev,resources=servermaintenances,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -235,10 +237,19 @@ func (r *BMCVersionSetReconciler) patchBMCVersionfromTemplate(
 	var pendingPatchingVersion bool
 	var errs []error
 	for _, bmcVersion := range bmcVersionList.Items {
-		if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateInProgress && bmcVersion.Status.UpgradeTask != nil {
-			log.V(1).Info("Skipping BMCVersion spec patching as it is in InProgress state with an active UpgradeTask")
-			pendingPatchingVersion = true
-			continue
+		// stop patching once maintenance is approved: the BMCVersion controller
+		// performs active operations before the upgrade task exists
+		if bmcVersion.Status.State == metalv1alpha1.BMCVersionStateInProgress && len(bmcVersion.Spec.ServerMaintenanceRefs) > 0 {
+			active, err := metalutil.IsAnyServerMaintenanceActive(ctx, r.Client, bmcVersion.Spec.ServerMaintenanceRefs)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to check maintenance state for BMCVersion %s: %w", bmcVersion.Name, err))
+				continue
+			}
+			if active {
+				log.V(1).Info("Skipping BMCVersion spec patching as its maintenance is approved", "BMCVersion", bmcVersion.Name)
+				pendingPatchingVersion = true
+				continue
+			}
 		}
 		opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, &bmcVersion, func() error {
 			bmcVersion.Spec.BMCVersionTemplate = *bmcVersionSet.Spec.BMCVersionTemplate.DeepCopy()

--- a/internal/controller/bmcversionset_controller.go
+++ b/internal/controller/bmcversionset_controller.go
@@ -179,11 +179,9 @@ func (r *BMCVersionSetReconciler) createMissingBMCVersions(
 	var errs []error
 	for _, bmc := range bmcList.Items {
 		if _, ok := BMCWithBMCVersion[bmc.Name]; !ok {
-			name, generateName := versionSetChildName(bmcVersionSet.Name, bmc.Name)
 			newBMCVersion := &metalv1alpha1.BMCVersion{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:         name,
-					GenerateName: generateName,
+					Name: versionSetChildName(bmcVersionSet.Name, bmc.Name),
 				}}
 			opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, newBMCVersion, func() error {
 				newBMCVersion.Spec.BMCVersionTemplate = *bmcVersionSet.Spec.BMCVersionTemplate.DeepCopy()

--- a/internal/controller/bmcversionset_controller_test.go
+++ b/internal/controller/bmcversionset_controller_test.go
@@ -219,7 +219,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		By("Ensuring that the BMCVersion has been created")
 		bmcVersion01 := &metalv1alpha1.BMCVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: bmcVersionList.Items[0].Name,
+				Name: versionSetChildName(bmcVersionSet.Name, bmc02.Name),
 			},
 		}
 		Eventually(Get(bmcVersion01)).Should(Succeed())
@@ -227,7 +227,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		By("Ensuring that the BMCVersion has been created")
 		bmcVersion02 := &metalv1alpha1.BMCVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: bmcVersionList.Items[1].Name,
+				Name: versionSetChildName(bmcVersionSet.Name, bmc03.Name),
 			},
 		}
 		Eventually(Get(bmcVersion02)).Should(Succeed())
@@ -323,7 +323,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		By("Checking if the BMCVersion has been created")
 		bmcVersion02 := &metalv1alpha1.BMCVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: bmcVersionList.Items[0].Name,
+				Name: versionSetChildName(bmcVersionSet.Name, bmc02.Name),
 			},
 		}
 		Eventually(Get(bmcVersion02)).Should(Succeed())
@@ -331,7 +331,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		By("Checking if the 2nd BMCVersion has been created")
 		bmcVersion03 := &metalv1alpha1.BMCVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: bmcVersionList.Items[1].Name,
+				Name: versionSetChildName(bmcVersionSet.Name, bmc03.Name),
 			},
 		}
 		Eventually(Get(bmcVersion03)).Should(Succeed())
@@ -413,7 +413,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		By("Checking if the BMCVersion has been created")
 		bmcVersion02 = &metalv1alpha1.BMCVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: bmcVersionList.Items[0].Name,
+				Name: versionSetChildName(bmcVersionSet.Name, bmc02.Name),
 			},
 		}
 		Eventually(Get(bmcVersion02)).Should(Succeed())
@@ -421,7 +421,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		By("Checking if the 2nd BMCVersion has been created")
 		bmcVersion03 = &metalv1alpha1.BMCVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: bmcVersionList.Items[1].Name,
+				Name: versionSetChildName(bmcVersionSet.Name, bmc03.Name),
 			},
 		}
 		Eventually(Get(bmcVersion03)).Should(Succeed())
@@ -453,7 +453,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		By("Checking if the 3rd BMCVersion has been created")
 		bmcVersion01 := &metalv1alpha1.BMCVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: bmcVersionList.Items[2].Name,
+				Name: versionSetChildName(bmcVersionSet.Name, bmc01.Name),
 			},
 		}
 		Eventually(Get(bmcVersion01)).Should(Succeed())
@@ -535,7 +535,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		By("Checking if the BMCVersion has been created")
 		bmcVersion02 := &metalv1alpha1.BMCVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: bmcVersionList.Items[0].Name,
+				Name: versionSetChildName(bmcVersionSet.Name, bmc02.Name),
 			},
 		}
 		Eventually(Get(bmcVersion02)).Should(Succeed())
@@ -543,7 +543,7 @@ var _ = Describe("BMCVersionSet Controller", func() {
 		By("Checking if the 2nd BMCVersion has been created")
 		bmcVersion03 := &metalv1alpha1.BMCVersion{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: bmcVersionList.Items[1].Name,
+				Name: versionSetChildName(bmcVersionSet.Name, bmc03.Name),
 			},
 		}
 		Eventually(Get(bmcVersion03)).Should(Succeed())

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"maps"
 	"math/big"
 	"reflect"
@@ -24,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	randutil "k8s.io/apimachinery/pkg/util/rand"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,15 +71,19 @@ func GetServerMaintenanceForObjectReference(ctx context.Context, c client.Client
 
 // versionSetChildName returns a deterministic child resource name for the
 // combination of set and target (Server/BMC), so that a re-reconcile on a
-// stale cache cannot create duplicate children. Falls back to a GenerateName
-// prefix when the deterministic name would exceed the DNS1123 limit.
-// Exactly one of the two return values is set.
-func versionSetChildName(setName, targetName string) (name, generateName string) {
-	name = fmt.Sprintf("%s-%s", setName, targetName)
-	if len(name) > utilvalidation.DNS1123SubdomainMaxLength {
-		return "", name[:utilvalidation.DNS1123SubdomainMaxLength-10] + "-"
+// stale cache cannot create duplicate children. Combinations exceeding the
+// DNS1123 limit are truncated and suffixed with a stable hash to stay valid.
+func versionSetChildName(setName, targetName string) string {
+	name := fmt.Sprintf("%s-%s", setName, targetName)
+	if len(name) <= utilvalidation.DNS1123SubdomainMaxLength {
+		return name
 	}
-	return name, ""
+	// Same scheme as Deployment -> ReplicaSet pod-template-hash:
+	// FNV-32a hash, SafeEncodeString keeps it DNS1123-safe.
+	hash := fnv.New32a()
+	hash.Write([]byte(name)) // hash.Hash never errors on Write
+	suffix := "-" + randutil.SafeEncodeString(fmt.Sprint(hash.Sum32()))
+	return name[:utilvalidation.DNS1123SubdomainMaxLength-len(suffix)] + suffix
 }
 
 // shouldProceedWithDeletion returns true when obj should proceed with deletion.

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ironcore-dev/metal-operator/third_party/expansion"
 	"github.com/stmcginnis/gofish/schemas"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -361,7 +362,11 @@ func handleRetryAnnotationPropagation(ctx context.Context, c client.Client, pare
 		childObj := cObj.DeepCopyObject().(client.Object)
 		err := c.Get(ctx, client.ObjectKeyFromObject(cObj), childObj)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to fetch latest child %s: %w", cObj.GetName(), err))
+			// child may have been deleted after listing (e.g. orphan cleanup);
+			// nothing to propagate to it
+			if !apierrors.IsNotFound(err) {
+				errs = append(errs, fmt.Errorf("failed to fetch latest child %s: %w", cObj.GetName(), err))
+			}
 			return nil
 		}
 		// if the child is being deleted, we don't need to propagate

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -64,6 +65,19 @@ func GetServerMaintenanceForObjectReference(ctx context.Context, c client.Client
 	}
 
 	return maintenance, nil
+}
+
+// versionSetChildName returns a deterministic child resource name for the
+// combination of set and target (Server/BMC), so that a re-reconcile on a
+// stale cache cannot create duplicate children. Falls back to a GenerateName
+// prefix when the deterministic name would exceed the DNS1123 limit.
+// Exactly one of the two return values is set.
+func versionSetChildName(setName, targetName string) (name, generateName string) {
+	name = fmt.Sprintf("%s-%s", setName, targetName)
+	if len(name) > utilvalidation.DNS1123SubdomainMaxLength {
+		return "", name[:utilvalidation.DNS1123SubdomainMaxLength-10] + "-"
+	}
+	return name, ""
 }
 
 // shouldProceedWithDeletion returns true when obj should proceed with deletion.

--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -4,15 +4,38 @@
 package controller
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 )
 
 var _ = Describe("Variable templating", func() {
+
+	Describe("versionSetChildName", func() {
+		It("returns the plain combined name when it fits", func() {
+			Expect(versionSetChildName("set", "target")).To(Equal("set-target"))
+		})
+
+		It("returns the same valid bounded name for repeated overlength calls", func() {
+			set := strings.Repeat("a", 200) + "-set"
+			target := strings.Repeat("b", 200) + "-target"
+			name1 := versionSetChildName(set, target)
+			Expect(name1).To(Equal(versionSetChildName(set, target)))
+			Expect(name1).To(HaveLen(utilvalidation.DNS1123SubdomainMaxLength))
+			Expect(utilvalidation.IsDNS1123Subdomain(name1)).To(BeEmpty())
+		})
+
+		It("produces distinct names for distinct overlength inputs", func() {
+			prefix := strings.Repeat("a", 250)
+			Expect(versionSetChildName(prefix+"-one", "x")).NotTo(Equal(versionSetChildName(prefix+"-two", "y")))
+		})
+	})
 
 	Describe("substituteVars", func() {
 		It("replaces a single placeholder", func() {


### PR DESCRIPTION
# Proposed Changes

Refactor BMCVersionSet/BIOSVersionSet: dedupe-safe child creation and leaner deletion paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of BIOS and BMC version resources during deletion.
  * Excluded servers and BMCs marked for deletion from selection results.
  * Improved reconciliation when server or BMC labels change.
  * Prevented unnecessary template updates for versions with active upgrades.
  * Improved handling of orphaned version resources and ownership changes.

* **Improvements**
  * Child resource names are generated consistently and remain valid within Kubernetes naming limits.
  * Improved retry handling when resources are removed during reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->