### PR TITLE
Fix BMC test cleanup

### DIFF
--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -735,17 +735,7 @@ var _ = Describe("BMC SSH Reset", func() {
 	AfterEach(func(ctx SpecContext) {
 		bmcutils.SSHResetBMCFunc = bmcutils.SSHResetBMC
 		mockServers[0].SetUnavailable(false)
-		// Use a longer timeout since BMC may be in a reset-wait state that delays cleanup.
-		Eventually(func(g Gomega) {
-			list := &metalv1alpha1.BMCList{}
-			g.Expect(k8sClient.List(ctx, list)).To(Succeed())
-			g.Expect(list.Items).To(BeEmpty())
-		}).WithTimeout(30 * time.Second).Should(Succeed())
-		Eventually(func(g Gomega) {
-			list := &metalv1alpha1.ServerList{}
-			g.Expect(k8sClient.List(ctx, list)).To(Succeed())
-			g.Expect(list.Items).To(BeEmpty())
-		}).WithTimeout(30 * time.Second).Should(Succeed())
+		EnsureCleanState(ctx)
 	})
 
 	It("Should successfully perform SSH reset after Redfish 5xx error", func(ctx SpecContext) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -199,9 +199,11 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			DNSRecordTemplate:      dnsTemplate,
 			Conditions:             accessor,
 			BMCOptions: bmc.Options{
-				PowerPollingInterval: 50 * time.Millisecond,
-				PowerPollingTimeout:  200 * time.Millisecond,
-				BasicAuth:            true,
+				ResourcePollingInterval: 50 * time.Millisecond,
+				ResourcePollingTimeout:  200 * time.Millisecond,
+				PowerPollingInterval:    50 * time.Millisecond,
+				PowerPollingTimeout:     200 * time.Millisecond,
+				BasicAuth:               true,
 			},
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
@@ -223,9 +225,11 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			MaxConcurrentReconciles: 5,
 			Conditions:              accessor,
 			BMCOptions: bmc.Options{
-				PowerPollingInterval: 50 * time.Millisecond,
-				PowerPollingTimeout:  200 * time.Millisecond,
-				BasicAuth:            true,
+				ResourcePollingInterval: 50 * time.Millisecond,
+				ResourcePollingTimeout:  200 * time.Millisecond,
+				PowerPollingInterval:    50 * time.Millisecond,
+				PowerPollingTimeout:     200 * time.Millisecond,
+				BasicAuth:               true,
 			},
 			DiscoveryTimeout:      30 * time.Second, // Set a short discovery timeout for testing
 			DiscoveryIgnitionPath: filepath.Join("..", "..", "config", "manager", "ignition-template.yaml"),
@@ -258,9 +262,11 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			ResyncInterval:     10 * time.Millisecond,
 			Conditions:         accessor,
 			BMCOptions: bmc.Options{
-				PowerPollingInterval: 50 * time.Millisecond,
-				PowerPollingTimeout:  200 * time.Millisecond,
-				BasicAuth:            true,
+				ResourcePollingInterval: 50 * time.Millisecond,
+				ResourcePollingTimeout:  200 * time.Millisecond,
+				PowerPollingInterval:    50 * time.Millisecond,
+				PowerPollingTimeout:     200 * time.Millisecond,
+				BasicAuth:               true,
 			},
 			TimeoutExpiry: 6 * time.Second,
 		}).SetupWithManager(k8sManager)).To(Succeed())
@@ -274,9 +280,11 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			ResyncInterval:     10 * time.Millisecond,
 			Conditions:         accessor,
 			BMCOptions: bmc.Options{
-				PowerPollingInterval: 50 * time.Millisecond,
-				PowerPollingTimeout:  200 * time.Millisecond,
-				BasicAuth:            true,
+				ResourcePollingInterval: 50 * time.Millisecond,
+				ResourcePollingTimeout:  200 * time.Millisecond,
+				PowerPollingInterval:    50 * time.Millisecond,
+				PowerPollingTimeout:     200 * time.Millisecond,
+				BasicAuth:               true,
 			},
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
@@ -295,9 +303,11 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			ResyncInterval:     10 * time.Millisecond,
 			Conditions:         accessor,
 			BMCOptions: bmc.Options{
-				PowerPollingInterval: 50 * time.Millisecond,
-				PowerPollingTimeout:  200 * time.Millisecond,
-				BasicAuth:            true,
+				ResourcePollingInterval: 50 * time.Millisecond,
+				ResourcePollingTimeout:  200 * time.Millisecond,
+				PowerPollingInterval:    50 * time.Millisecond,
+				PowerPollingTimeout:     200 * time.Millisecond,
+				BasicAuth:               true,
 			},
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
@@ -310,9 +320,11 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			ResyncInterval:     10 * time.Millisecond,
 			Conditions:         accessor,
 			BMCOptions: bmc.Options{
-				PowerPollingInterval: 50 * time.Millisecond,
-				PowerPollingTimeout:  200 * time.Millisecond,
-				BasicAuth:            true,
+				ResourcePollingInterval: 50 * time.Millisecond,
+				ResourcePollingTimeout:  200 * time.Millisecond,
+				PowerPollingInterval:    50 * time.Millisecond,
+				PowerPollingTimeout:     200 * time.Millisecond,
+				BasicAuth:               true,
 			},
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
@@ -340,9 +352,11 @@ func SetupTest(redfishMockServers []netip.AddrPort) *corev1.Namespace {
 			DefaultProtocol:    metalv1alpha1.HTTPProtocolScheme,
 			SkipCertValidation: true,
 			BMCOptions: bmc.Options{
-				PowerPollingInterval: 50 * time.Millisecond,
-				PowerPollingTimeout:  200 * time.Millisecond,
-				BasicAuth:            true,
+				ResourcePollingInterval: 50 * time.Millisecond,
+				ResourcePollingTimeout:  200 * time.Millisecond,
+				PowerPollingInterval:    50 * time.Millisecond,
+				PowerPollingTimeout:     200 * time.Millisecond,
+				BasicAuth:               true,
 			},
 		}).SetupWithManager(k8sManager)).To(Succeed())
 


### PR DESCRIPTION
# Proposed Changes

Fix BMC test cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved BMC SSH reset test cleanup by using a shared clean-state check.
  * Removed redundant polling and extended cleanup waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->