### PR TITLE
BMC Update for Dell FIrmware upgrade

### DIFF
--- a/bmc/mock/server/data/Managers/BMC/Oem/Dell/Jobs/index.json
+++ b/bmc/mock/server/data/Managers/BMC/Oem/Dell/Jobs/index.json
@@ -1,0 +1,11 @@
+{
+    "@odata.type": "#DellJobCollection.DellJobCollection",
+    "Name": "Job Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/Oem/Dell/Jobs/repository"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Managers/BMC/Oem/Dell/Jobs"
+}

--- a/bmc/mock/server/data/Managers/BMC/Oem/Dell/Jobs/repository/index.json
+++ b/bmc/mock/server/data/Managers/BMC/Oem/Dell/Jobs/repository/index.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#DellJob.v1_0_0.DellJob",
+    "@odata.id": "/redfish/v1/Managers/BMC/Oem/Dell/Jobs/repository",
+    "Id": "repository",
+    "Name": "Repository-based Firmware Install",
+    "JobType": "RepositoryUpdate",
+    "JobState": "New",
+    "Message": "Task successfully scheduled.",
+    "PercentComplete": 0
+}

--- a/bmc/mock/server/data/Managers/BMC/Oem/Dell/Jobs/repository/steps-fail.json
+++ b/bmc/mock/server/data/Managers/BMC/Oem/Dell/Jobs/repository/steps-fail.json
@@ -1,0 +1,7 @@
+[
+    {"JobState": "New",       "Message": "Task successfully scheduled.", "PercentComplete": 0},
+    {"JobState": "Scheduled", "Message": "Task successfully scheduled.", "PercentComplete": 0},
+    {"JobState": "Running",   "Message": "Job execution in progress.",   "PercentComplete": 10},
+    {"JobState": "Running",   "Message": "Job execution in progress.",   "PercentComplete": 20},
+    {"JobState": "Failed",    "Message": "Unable to complete job.",      "PercentComplete": 20}
+]

--- a/bmc/mock/server/data/Managers/BMC/Oem/Dell/Jobs/repository/steps.json
+++ b/bmc/mock/server/data/Managers/BMC/Oem/Dell/Jobs/repository/steps.json
@@ -1,0 +1,8 @@
+[
+    {"JobState": "New",       "Message": "Task successfully scheduled.",           "PercentComplete": 0},
+    {"JobState": "Scheduled", "Message": "Task successfully scheduled.",           "PercentComplete": 0},
+    {"JobState": "Running",   "Message": "Job execution in progress.",             "PercentComplete": 10},
+    {"JobState": "Running",   "Message": "Job execution in progress.",             "PercentComplete": 50},
+    {"JobState": "Running",   "Message": "Job execution in progress.",             "PercentComplete": 100},
+    {"JobState": "Completed", "Message": "Job completed successfully.",            "PercentComplete": 100}
+]

--- a/bmc/mock/server/server.go
+++ b/bmc/mock/server/server.go
@@ -51,10 +51,29 @@ const (
 	upgradeStepsFailFilePath = "data/TaskService/Tasks/upgrade/steps-fail.json"
 	upgradeTaskURI           = "/redfish/v1/TaskService/Tasks/upgrade"
 
+	// Fixed file paths for Dell OEM repository-based firmware update job simulation.
+	dellJobFilePath          = "data/Managers/BMC/Oem/Dell/Jobs/repository/index.json"
+	dellJobStepsFilePath     = "data/Managers/BMC/Oem/Dell/Jobs/repository/steps.json"
+	dellJobStepsFailFilePath = "data/Managers/BMC/Oem/Dell/Jobs/repository/steps-fail.json"
+	dellJobURI               = "/redfish/v1/Managers/BMC/Oem/Dell/Jobs/repository"
+
 	// Firmware version JSON field names updated on upgrade task completion.
 	// The target resource path is resolved dynamically via FirmwareInventory RelatedItem links.
 	biosVersionField = "BiosVersion"
 	bmcVersionField  = "FirmwareVersion"
+)
+
+// dellRepoUpdateState models GetRepoBasedUpdateList's pending-package
+// simulation as a one-way progression through this server run:
+// unchecked → pending (on the first check-only InstallFromRepository call) →
+// applied (once an apply call's job completes successfully). See
+// handleDellGetRepoBasedUpdateList and handleDellInstallFromRepository.
+type dellRepoUpdateState int
+
+const (
+	dellRepoUpdateUnchecked dellRepoUpdateState = iota
+	dellRepoUpdatePending
+	dellRepoUpdateApplied
 )
 
 // noRebootSettings and noRebootBMCSettings are populated at init time by
@@ -144,6 +163,41 @@ func WithAuth() Option {
 	return func(s *MockServer) { s.authEnabled = true }
 }
 
+// WithResourceOverride merges fields into the embedded JSON resource at
+// subPath, given relative to the "data/" root (e.g.
+// "Systems/437XR1138R2/index.json" for a System, or
+// "Systems/437XR1138R2/Bios/index.json" for its Bios subresource),
+// overwriting any keys present in fields while leaving the rest of the
+// resource untouched. Nested fields (e.g. "Oem") are replaced wholesale
+// rather than deep-merged; supply the full nested value if a sub-field
+// needs changing. If subPath does not exist, this is a no-op.
+func WithResourceOverride(subPath string, fields map[string]any) Option {
+	return func(s *MockServer) {
+		filePath := path.Join("data", subPath)
+		resource, err := s.loadResource(filePath)
+		if err != nil {
+			return
+		}
+		for k, v := range fields {
+			resource[k] = v
+		}
+		s.saveResource(filePath, resource)
+	}
+}
+
+// WithSystemOverride merges fields into the System resource identified by
+// systemID (the folder name under data/Systems/, e.g. "437XR1138R2"),
+// overwriting any keys present in fields (e.g. "Manufacturer", "Model",
+// "SKU"). Use this to seed System resource state a test depends on - e.g.
+// BMC vendor detection (bmc.NewRedfishBMCClient / bmc.DefaultVendors) reads
+// Manufacturer to dispatch to a vendor-specific client, so overriding it to
+// "Dell Inc." obtains a Dell-capable BMC client. To override a subresource
+// such as Bios (data/Systems/<systemID>/Bios/index.json), use
+// WithResourceOverride directly.
+func WithSystemOverride(systemID string, fields map[string]any) Option {
+	return WithResourceOverride(fmt.Sprintf("Systems/%s/index.json", systemID), fields)
+}
+
 type MockServer struct {
 	log               logr.Logger
 	addr              string
@@ -151,6 +205,8 @@ type MockServer struct {
 	mu                sync.RWMutex
 	overrides         map[string]any
 	upgradeGen        int64                 // incremented on each SimpleUpdate to cancel stale goroutines
+	dellJobGen        int64                 // incremented on each Dell repository install to cancel stale goroutines
+	dellRepoState     dellRepoUpdateState   // GetRepoBasedUpdateList pending-package simulation state (see handleDellGetRepoBasedUpdateList)
 	upgradedResources map[string]string     // odata.id URI → file path for resources updated by the last upgrade
 	accounts          map[string]string     // username → password (authentication store)
 	authEnabled       bool                  // when true, all non-service-root requests require Basic Auth
@@ -266,6 +322,14 @@ func NewMockServer(log logr.Logger, addr string, opts ...Option) *MockServer {
 					strings.Contains(path, "UpdateService/Actions/UpdateService.SimpleUpdate")
 			},
 			handle: s.handleSimpleUpdate,
+		},
+		{
+			matches: hasSuffix("/DellSoftwareInstallationService.InstallFromRepository"),
+			handle:  s.handleDellInstallFromRepository,
+		},
+		{
+			matches: hasSuffix("/DellSoftwareInstallationService.GetRepoBasedUpdateList"),
+			handle:  s.handleDellGetRepoBasedUpdateList,
 		},
 		{
 			matches: hasSuffix("/Actions/ManagerAccount.ChangePassword"),
@@ -637,40 +701,161 @@ func (s *MockServer) handleSimpleUpdate(w http.ResponseWriter, r *http.Request, 
 // firmware version fields in the targeted resources are updated so that
 // GetBiosVersion / GetBMCVersion return the new version. Target resources are
 // resolved dynamically by following the FirmwareInventory items' RelatedItem
-// links — no system UUID is hardcoded here. A stale goroutine (superseded by a
-// newer SimpleUpdate call) exits without side-effects once it detects a
-// generation mismatch.
+// links — no system UUID is hardcoded here.
 func (s *MockServer) doUpgradeSteps(gen int64, steps []map[string]any, imageURI string, targets []string) {
+	s.advanceResourceSteps(&s.upgradeGen, gen, upgradeTaskFilePath, steps, func(finalStep map[string]any) {
+		// Only update version fields when the task reaches Completed.
+		if state, _ := finalStep["TaskState"].(string); state == "Completed" {
+			s.applyFirmwareVersionsLocked(targets, imageURI)
+		}
+	})
+}
+
+// advanceResourceSteps advances an overridden JSON resource through a sequence
+// of step patches (steps[0] is assumed already applied by the caller), one
+// patch per tick, simulating an async Redfish operation (Task, Job, etc.)
+// progressing toward a terminal state. Before each patch it checks *genPtr
+// against gen so that a stale goroutine — superseded by a newer request for
+// the same resource — exits without side-effects. If onTerminal is non-nil, it
+// is invoked (with s.mu held) with the last step's fields once all steps have
+// been applied, to let the caller react to the final state (e.g. writing
+// side-effect fields elsewhere).
+func (s *MockServer) advanceResourceSteps(genPtr *int64, gen int64, filePath string, steps []map[string]any, onTerminal func(finalStep map[string]any)) {
 	time.Sleep(20 * time.Millisecond)
 	for i := 1; i < len(steps); i++ {
 		time.Sleep(5 * time.Millisecond)
 		s.mu.Lock()
-		if s.upgradeGen != gen {
+		if *genPtr != gen {
 			s.mu.Unlock()
 			return
 		}
-		taskBase, err := s.loadResourceLocked(upgradeTaskFilePath)
+		resource, err := s.loadResourceLocked(filePath)
 		if err == nil {
-			mergeJSON(taskBase, steps[i])
-			s.overrides[upgradeTaskFilePath] = taskBase
+			mergeJSON(resource, steps[i])
+			s.overrides[filePath] = resource
 		}
 		s.mu.Unlock()
 	}
 
-	// Only update version fields when the task reaches Completed.
-	lastState, _ := steps[len(steps)-1]["TaskState"].(string)
-	if lastState != "Completed" {
+	if onTerminal == nil {
 		return
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if *genPtr != gen {
+		return
+	}
+	onTerminal(steps[len(steps)-1])
+}
 
-	if s.upgradeGen != gen {
+// handleDellInstallFromRepository simulates Dell's
+// DellSoftwareInstallationService.InstallFromRepository OEM action: it seeds
+// the mock iDRAC job resource with the first step and progresses it
+// asynchronously via doDellJobSteps, mirroring handleSimpleUpdate's approach
+// for the standard Task-based upgrade flow. A CatalogFile value containing
+// "fail" selects the failing step progression, mirroring the ImageURI
+// "fail" convention used by handleSimpleUpdate.
+//
+// ApplyUpdate drives the GetRepoBasedUpdateList pending-package simulation
+// (see handleDellGetRepoBasedUpdateList): the first check-only call
+// (ApplyUpdate "False"/absent) made during this server run marks a package as
+// pending, since on real hardware the check itself performs the catalog scan;
+// later check-only calls are no-ops so that re-checking doesn't keep
+// re-arming the pending flag. An apply call (ApplyUpdate "True") clears the
+// pending flag once its job completes successfully, since the package has now
+// actually been installed. Call ResetDellRepositoryUpdate to simulate a fresh
+// server run (e.g. a BMC restart) and allow the pending transition to fire again.
+func (s *MockServer) handleDellInstallFromRepository(w http.ResponseWriter, r *http.Request, body []byte) {
+	var req struct {
+		CatalogFile string `json:"CatalogFile"`
+		ApplyUpdate string `json:"ApplyUpdate"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "malformed InstallFromRepository JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	applyUpdate := strings.EqualFold(req.ApplyUpdate, "true")
+
+	stepsPath := dellJobStepsFilePath
+	if strings.Contains(req.CatalogFile, "fail") {
+		stepsPath = dellJobStepsFailFilePath
+	}
+
+	stepsData, err := dataFS.ReadFile(stepsPath)
+	if err != nil {
+		http.Error(w, "steps not found", http.StatusInternalServerError)
+		return
+	}
+	var steps []map[string]any
+	if err := json.Unmarshal(stepsData, &steps); err != nil || len(steps) == 0 {
+		http.Error(w, "corrupt steps JSON", http.StatusInternalServerError)
 		return
 	}
 
-	s.applyFirmwareVersionsLocked(targets, imageURI)
+	// Load the job template and seed it with the first step.
+	jobBase, err := s.loadResource(dellJobFilePath)
+	if err != nil {
+		http.Error(w, "job not found", http.StatusInternalServerError)
+		return
+	}
+	mergeJSON(jobBase, steps[0])
+
+	s.mu.Lock()
+	s.dellJobGen++
+	gen := s.dellJobGen
+	s.overrides[dellJobFilePath] = jobBase
+	if !applyUpdate && s.dellRepoState == dellRepoUpdateUnchecked {
+		s.dellRepoState = dellRepoUpdatePending
+	}
+	s.mu.Unlock()
+
+	go s.doDellJobSteps(gen, steps, applyUpdate)
+
+	w.Header().Set("Location", dellJobURI)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_, _ = w.Write([]byte(`{"status":"Accepted"}`))
+}
+
+// doDellJobSteps advances the mock iDRAC job through its steps. If applyUpdate
+// is true and the job reaches JobState "Completed", the simulated pending
+// package is cleared (state moves to applied) so that GetRepoBasedUpdateList
+// reports no more pending packages, mirroring the package having actually
+// been installed.
+func (s *MockServer) doDellJobSteps(gen int64, steps []map[string]any, applyUpdate bool) {
+	var onTerminal func(finalStep map[string]any)
+	if applyUpdate {
+		onTerminal = func(finalStep map[string]any) {
+			if state, _ := finalStep["JobState"].(string); state == "Completed" {
+				s.dellRepoState = dellRepoUpdateApplied
+			}
+		}
+	}
+	s.advanceResourceSteps(&s.dellJobGen, gen, dellJobFilePath, steps, onTerminal)
+}
+
+// handleDellGetRepoBasedUpdateList simulates Dell's
+// DellSoftwareInstallationService.GetRepoBasedUpdateList OEM action. The real
+// action takes no meaningful request body (callers POST an empty JSON
+// object). It reports no pending packages until the first check-only
+// InstallFromRepository call of this server run, then one pending package
+// until an apply call's job completes successfully (see
+// handleDellInstallFromRepository), after which it reports no pending
+// packages again — until the mock server state is reset via
+// ResetDellRepositoryUpdate (simulating a restart).
+func (s *MockServer) handleDellGetRepoBasedUpdateList(w http.ResponseWriter, r *http.Request, body []byte) {
+	s.mu.RLock()
+	pending := s.dellRepoState == dellRepoUpdatePending
+	s.mu.RUnlock()
+
+	packageList := ""
+	if pending {
+		packageList = "<PACKAGELIST><PACKAGE NAME=\"BIOS_FIRMWARE\" VERSION=\"2.1.0\"/></PACKAGELIST>"
+	}
+	s.writeJSON(w, http.StatusOK, map[string]any{
+		"PackageList": packageList,
+	})
 }
 
 // applyFirmwareVersionsLocked follows each FirmwareInventory target's
@@ -1056,6 +1241,22 @@ func (s *MockServer) ResetUpgradeTask(resourceURIs ...string) {
 	if len(s.upgradedResources) == 0 {
 		s.resetResourceFromEmbeddedLocked(upgradeTaskFilePath)
 	}
+}
+
+// ResetDellRepositoryUpdate resets Dell repository-update job state on the
+// mock server: the job JSON, any in-flight doDellJobSteps goroutine, and the
+// GetRepoBasedUpdateList pending-package state (back to unchecked, the
+// initial state before any InstallFromRepository call), simulating a fresh
+// server run (e.g. a BMC restart).
+//
+// Call this in AfterEach to ensure a clean slate between Dell
+// repository-update-related tests.
+func (s *MockServer) ResetDellRepositoryUpdate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dellJobGen++ // invalidate any running doDellJobSteps goroutine
+	s.dellRepoState = dellRepoUpdateUnchecked
+	s.resetResourceFromEmbeddedLocked(dellJobFilePath)
 }
 
 // resetResourceFromEmbeddedLocked replaces the override for filePath with the

--- a/bmc/redfish_dell.go
+++ b/bmc/redfish_dell.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"path"
 	"strings"
 
 	"github.com/stmcginnis/gofish/schemas"
@@ -446,8 +447,6 @@ func (r *DellRedfishBMC) CheckBMCAttributes(ctx context.Context, bmcUUID string,
 	return checkAttributes(attrs, filteredAttr)
 }
 
-// --- Firmware upgrade overrides ---
-
 func (r *DellRedfishBMC) dellBuildRequestBody(parameters *schemas.UpdateServiceSimpleUpdateParameters) *SimpleUpdateRequestBody {
 	body := &SimpleUpdateRequestBody{}
 	body.RedfishOperationApplyTime = schemas.ImmediateOperationApplyTime
@@ -551,4 +550,384 @@ func (r *DellRedfishBMC) dellMatchesComponentFilter(fw *schemas.SoftwareInventor
 
 func (r *DellRedfishBMC) dellCheckPending(fw *schemas.SoftwareInventory) bool {
 	return fw.Staged
+}
+
+// --- Repository-based firmware update (FirmwareUpdaterDell) ---
+//
+// The interface, parameter/result types, implementation, and compile-time
+// assertion for this feature are intentionally kept together in this single
+// section (rather than splitting the interface to the top of the file), since
+// FirmwareUpdaterDell is Dell-only and self-contained.
+
+// FirmwareUpdaterDell drives Dell's OEM repository-based firmware update
+// action (DellSoftwareInstallationService.InstallFromRepository), tracking
+// Dell's proprietary iDRAC job resources (not standard Redfish Tasks) to
+// completion.
+//
+// This capability is intentionally NOT part of the BMC union interface: no
+// other vendor exposes an equivalent OEM action today, and requiring every
+// other vendor's RedfishBaseBMC to carry "not supported" stubs would go
+// against this package's "accept interfaces, return structs" idiom. Consumers
+// that need this capability should use a type assertion against the concrete
+// BMC client to discover support at runtime, e.g.:
+//
+//	updater, ok := bmcClient.(bmc.FirmwareUpdaterDell)
+//	if !ok {
+//	    return fmt.Errorf("repository-based firmware update not supported by this vendor: %w", bmc.ErrNotSupported)
+//	}
+type FirmwareUpdaterDell interface {
+	// InstallFirmwareFromRepository triggers a repository-based firmware
+	// installation for the given system, and returns the ID of the job tracking
+	// the operation. Any error returned once the request has been issued is
+	// fatal, since a new request cannot safely be issued while one may already
+	// be in flight.
+	InstallFirmwareFromRepository(ctx context.Context, systemURI string, parameters *RepositoryUpdateParameters) (jobID string, isFatal bool, err error)
+
+	// GetRepositoryUpdateList performs a dry-run check against the configured
+	// repository/catalog and reports whether any packages are pending installation.
+	GetRepositoryUpdateList(ctx context.Context, systemURI string) (hasPendingPackages bool, packageListXML string, err error)
+
+	// ListJobs lists the IDs of the iDRAC jobs currently known to the BMC
+	// identified by UUID.
+	ListJobs(ctx context.Context, UUID string) ([]string, error)
+
+	// GetJob retrieves the current state of a single iDRAC job by ID.
+	GetJob(ctx context.Context, UUID string, jobID string) (*DellJob, error)
+}
+
+// RepositoryUpdateParameters are the parameters for Dell's InstallFromRepository OEM action.
+type RepositoryUpdateParameters struct {
+	// ShareType is the type of network share hosting the repository (e.g. NFS, CIFS, HTTP, HTTPS).
+	ShareType string
+	// IPAddress is the share's IP address or hostname.
+	IPAddress string
+	// ShareName is the network share name. Not required for HTTP/HTTPS catalogs.
+	ShareName string
+	// CatalogFile is the catalog file name within the share (e.g. "Catalog.xml").
+	CatalogFile string
+	// UserName is the username used to authenticate against the share, if required.
+	UserName string
+	// Password is the password used to authenticate against the share, if required.
+	Password string
+	// Workgroup is the CIFS workgroup, if applicable.
+	Workgroup string
+	// IgnoreCertWarning, if true, ignores certificate warnings for HTTPS shares.
+	IgnoreCertWarning bool
+	// ApplyUpdate, if true, applies the update; if false, performs a dry-run check only.
+	ApplyUpdate bool
+	// RebootNeeded, if true, allows the BMC to reboot the system to apply updates that require it.
+	RebootNeeded bool
+	// ApplySameVersions, if true, re-applies packages already at the same version.
+	ApplySameVersions bool
+	// ApplyDowngradeVersions, if true, allows applying packages older than the currently installed version.
+	ApplyDowngradeVersions bool
+}
+
+// DellJob represents a Dell iDRAC job resource tracking a repository-based
+// firmware operation.
+type DellJob struct {
+	// ID is the job identifier (e.g. "JID_...").
+	ID string
+	// Name is the job's display name.
+	Name string
+	// JobType is the Dell-reported job type (e.g. "RepositoryUpdate", "FirmwareUpdate").
+	JobType string
+	// State is the Dell-reported raw "JobState" string. It is intentionally a
+	// plain string, not a gofish schemas.TaskState or schemas.JobState:
+	// Dell's OEM iDRAC Job resource predates (and does not conform to) both the
+	// standard Task resource and the newer DMTF Job.v1_3_0 schema gofish also
+	// models. Dell reports failure states like "Failed", "CompletedWithErrors",
+	// and "RebootFailed" that have no equivalent in schemas.JobState (which
+	// uses "Exception"/"Cancelled" instead), and "Scheduled" rather than
+	// schemas.JobState's "Pending". Reusing either typed enum would imply a
+	// conformance Dell doesn't have, without buying real type safety since
+	// Dell-only values would need their own constants anyway.
+	State string
+	// Message is the Dell-reported status message.
+	Message string
+	// PercentComplete is the Dell-reported completion percentage.
+	PercentComplete int32
+}
+
+// Known Dell iDRAC JobState values. Dell does not publish a formal enum for
+// this field; these are the values commonly observed on iDRAC OEM Jobs and
+// used by Dell's reference scripting examples. Verify against real hardware
+// before relying on this exhaustively.
+const (
+	dellJobStateCompleted           = "Completed"
+	dellJobStateCompletedWithErrors = "CompletedWithErrors"
+	dellJobStateFailed              = "Failed"
+	dellJobStateRebootFailed        = "RebootFailed"
+)
+
+// IsCompleted reports whether the job has reached a successful terminal state.
+func (j *DellJob) IsCompleted() bool {
+	return j.State == dellJobStateCompleted
+}
+
+// IsFailed reports whether the job has reached a failed terminal state, either
+// via a known failure JobState or via failure-indicating text in Message
+// (mirroring Dell's reference scripting examples, which classify jobs by
+// substring-matching Message rather than JobState alone).
+func (j *DellJob) IsFailed() bool {
+	switch j.State {
+	case dellJobStateFailed, dellJobStateCompletedWithErrors, dellJobStateRebootFailed:
+		return true
+	}
+	msg := strings.ToLower(j.Message)
+	return strings.Contains(msg, "fail") || strings.Contains(msg, "invalid") || strings.Contains(msg, "unable")
+}
+
+// IsTerminal reports whether the job has reached any terminal state, success
+// or failure.
+func (j *DellJob) IsTerminal() bool {
+	return j.IsCompleted() || j.IsFailed()
+}
+
+// Compile-time guarantee that DellRedfishBMC additionally satisfies
+// FirmwareUpdaterDell. This capability is intentionally not part of the BMC
+// union (see the FirmwareUpdaterDell doc comment above), so it is asserted
+// here instead of alongside the BMC guarantees in bmc.go.
+var _ FirmwareUpdaterDell = (*DellRedfishBMC)(nil)
+
+// dellSoftwareInstallationServicePath is the OEM path segment appended to a
+// system's URI to reach Dell's software installation service actions.
+const dellSoftwareInstallationServicePath = "/Oem/Dell/DellSoftwareInstallationService"
+
+// dellRepositoryUpdateRequestBody is the JSON body for Dell's
+// DellSoftwareInstallationService.InstallFromRepository action.
+//
+// NOTE: field names and value encodings are based on Dell's publicly
+// documented iDRAC Redfish scripting examples and have not been verified
+// against a real iDRAC or a captured OpenAPI schema (Dell does not publish
+// one for this OEM action). Verify against real hardware/mock data before
+// relying on this in production.
+type dellRepositoryUpdateRequestBody struct {
+	ShareType         string `json:"ShareType"`
+	IPAddress         string `json:"IPAddress,omitempty"`
+	ShareName         string `json:"ShareName,omitempty"`
+	CatalogFile       string `json:"CatalogFile,omitempty"`
+	UserName          string `json:"UserName,omitempty"`
+	Password          string `json:"Password,omitempty"`
+	Workgroup         string `json:"Workgroup,omitempty"`
+	IgnoreCertWarning string `json:"IgnoreCertWarning,omitempty"`
+	ApplyUpdate       string `json:"ApplyUpdate"`
+	RebootNeeded      bool   `json:"RebootNeeded"`
+}
+
+// dellBoolString renders a bool the way Dell's OEM actions expect certain
+// fields to be encoded (capitalized string, not a JSON boolean).
+func dellBoolString(b bool) string {
+	if b {
+		return "True"
+	}
+	return "False"
+}
+
+func dellBuildRepositoryUpdateRequestBody(parameters *RepositoryUpdateParameters) *dellRepositoryUpdateRequestBody {
+	return &dellRepositoryUpdateRequestBody{
+		ShareType:         parameters.ShareType,
+		IPAddress:         parameters.IPAddress,
+		ShareName:         parameters.ShareName,
+		CatalogFile:       parameters.CatalogFile,
+		UserName:          parameters.UserName,
+		Password:          parameters.Password,
+		Workgroup:         parameters.Workgroup,
+		IgnoreCertWarning: dellBoolString(parameters.IgnoreCertWarning),
+		ApplyUpdate:       dellBoolString(parameters.ApplyUpdate),
+		RebootNeeded:      parameters.RebootNeeded,
+	}
+}
+
+// dellRepositoryActionTarget builds the URI for a Dell software installation
+// service action on the given system.
+func dellRepositoryActionTarget(systemURI, action string) string {
+	return path.Join(systemURI, dellSoftwareInstallationServicePath, "Actions", "DellSoftwareInstallationService."+action)
+}
+
+// dellExtractJobID extracts the iDRAC job ID from the Location header of a
+// Dell OEM action response (mirrors dellExtractTaskMonitorURI's approach for
+// the standard UpdateService.SimpleUpdate flow).
+func dellExtractJobID(response *http.Response) (string, error) {
+	if location, ok := response.Header["Location"]; ok && len(location) > 0 {
+		return path.Base(location[0]), nil
+	}
+	return "", fmt.Errorf("unable to extract job ID from Dell iDRAC response: no Location header")
+}
+
+// InstallFirmwareFromRepository triggers Dell's repository-based firmware
+// installation for the given system.
+func (r *DellRedfishBMC) InstallFirmwareFromRepository(_ context.Context, systemURI string, parameters *RepositoryUpdateParameters) (string, bool, error) {
+	client := r.client.GetService().GetClient()
+	target := dellRepositoryActionTarget(systemURI, "InstallFromRepository")
+
+	resp, err := client.Post(target, dellBuildRepositoryUpdateRequestBody(parameters))
+	if err != nil {
+		// gofish's client converts any non-2xx/204 response into a
+		// *schemas.Error (with a nil *http.Response), rather than returning a
+		// response we could inspect for its status code ourselves. A
+		// *schemas.Error means the BMC received and rejected the request, so
+		// the operation is fatal: a retry could trigger a second install while
+		// the rejected one may still be processing. Any other error (e.g. a
+		// network failure) means the request never reached the BMC and is
+		// therefore safe to retry.
+		var redfishErr *schemas.Error
+		isFatal := errors.As(err, &redfishErr)
+		return "", isFatal, fmt.Errorf("failed to issue repository firmware install: %w", err)
+	}
+	defer resp.Body.Close() // nolint: errcheck
+
+	jobID, err := dellExtractJobID(resp)
+	if err != nil {
+		return "", true, fmt.Errorf("failed to extract job ID from repository firmware install response: %w", err)
+	}
+	return jobID, false, nil
+}
+
+// dellGetRepoBasedUpdateListResponse is the JSON body returned by Dell's
+// DellSoftwareInstallationService.GetRepoBasedUpdateList action.
+type dellGetRepoBasedUpdateListResponse struct {
+	PackageList string `json:"PackageList"`
+}
+
+// GetRepositoryUpdateList performs a dry-run check against the configured
+// repository/catalog for the given system.
+func (r *DellRedfishBMC) GetRepositoryUpdateList(_ context.Context, systemURI string) (bool, string, error) {
+	client := r.client.GetService().GetClient()
+	target := dellRepositoryActionTarget(systemURI, "GetRepoBasedUpdateList")
+
+	resp, err := client.Post(target, map[string]any{})
+	if err != nil {
+		// As in InstallFirmwareFromRepository, gofish surfaces non-2xx/204
+		// responses as a *schemas.Error rather than a response we can inspect.
+		// Treat a "no catalog match"/"not found" message as "nothing pending"
+		// rather than a hard failure.
+		var redfishErr *schemas.Error
+		if errors.As(err, &redfishErr) {
+			msg := strings.ToLower(redfishErr.Message)
+			if strings.Contains(msg, "match catalog") || strings.Contains(msg, "not found") {
+				return false, "", nil
+			}
+		}
+		return false, "", fmt.Errorf("failed to get repository update list: %w", err)
+	}
+	defer resp.Body.Close() // nolint: errcheck
+
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to read GetRepoBasedUpdateList response body: %w", err)
+	}
+
+	var parsed dellGetRepoBasedUpdateListResponse
+	if err := json.Unmarshal(rawBody, &parsed); err != nil {
+		return false, "", fmt.Errorf("failed to unmarshal GetRepoBasedUpdateList response: %w", err)
+	}
+
+	return dellPackageListHasPendingPackages(parsed.PackageList), parsed.PackageList, nil
+}
+
+// dellPackageListHasPendingPackages performs a pragmatic check for whether
+// Dell's PackageList XML contains any pending device/package entries. The
+// exact PackageList XML schema is not fully documented in Dell's public
+// reference script (it only shows regex substring matching); this treats any
+// <PACKAGE ...> or <INSTANCE ...> element as evidence of a pending package.
+// Revisit once a real sample has been captured.
+func dellPackageListHasPendingPackages(packageListXML string) bool {
+	if strings.TrimSpace(packageListXML) == "" {
+		return false
+	}
+	upper := strings.ToUpper(packageListXML)
+	return strings.Contains(upper, "<PACKAGE") || strings.Contains(upper, "<INSTANCE")
+}
+
+// dellJob is the JSON body of a single Dell iDRAC job resource.
+type dellJob struct {
+	ID              string `json:"Id"`
+	Name            string `json:"Name"`
+	JobType         string `json:"JobType"`
+	JobState        string `json:"JobState"`
+	Message         string `json:"Message"`
+	PercentComplete int32  `json:"PercentComplete"`
+}
+
+// dellJobsCollection is the JSON body of the iDRAC Jobs collection.
+type dellJobsCollection struct {
+	Members []struct {
+		ODataID string `json:"@odata.id"`
+	} `json:"Members"`
+}
+
+// ListJobs lists the IDs of the iDRAC jobs currently known to the manager
+// identified by UUID (or the first manager, if UUID is empty).
+func (r *DellRedfishBMC) ListJobs(_ context.Context, UUID string) ([]string, error) {
+	manager, err := r.GetManager(UUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get manager: %w", err)
+	}
+
+	client := r.client.GetService().GetClient()
+	jobsURI := path.Join(manager.ODataID, "Oem", "Dell", "Jobs")
+	resp, err := client.Get(jobsURI)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() // nolint: errcheck
+
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read jobs collection response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list jobs %v, statusCode %v", string(rawBody), resp.StatusCode)
+	}
+
+	var collection dellJobsCollection
+	if err := json.Unmarshal(rawBody, &collection); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal jobs collection: %w", err)
+	}
+
+	jobIDs := make([]string, 0, len(collection.Members))
+	for _, m := range collection.Members {
+		jobIDs = append(jobIDs, path.Base(m.ODataID))
+	}
+	return jobIDs, nil
+}
+
+// GetJob retrieves the current state of a single iDRAC job by ID, from the
+// manager identified by UUID (or the first manager, if UUID is empty).
+func (r *DellRedfishBMC) GetJob(_ context.Context, UUID string, jobID string) (*DellJob, error) {
+	manager, err := r.GetManager(UUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get manager: %w", err)
+	}
+
+	client := r.client.GetService().GetClient()
+	jobURI := path.Join(manager.ODataID, "Oem", "Dell", "Jobs", jobID)
+	resp, err := client.Get(jobURI)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() // nolint: errcheck
+
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read job response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get job %v, statusCode %v", string(rawBody), resp.StatusCode)
+	}
+
+	var dj dellJob
+	if err := json.Unmarshal(rawBody, &dj); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal job: %w", err)
+	}
+
+	return &DellJob{
+		ID:              dj.ID,
+		Name:            dj.Name,
+		JobType:         dj.JobType,
+		State:           dj.JobState,
+		Message:         dj.Message,
+		PercentComplete: dj.PercentComplete,
+	}, nil
 }

--- a/bmc/redfish_dell_test.go
+++ b/bmc/redfish_dell_test.go
@@ -4,8 +4,10 @@
 package bmc
 
 import (
+	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -74,6 +76,284 @@ var _ = Describe("Dell OEM", func() {
 			_, err := dell.dellExtractTaskMonitorURI(resp)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("unable to extract task monitor URI"))
+		})
+	})
+
+	Describe("dellBuildRepositoryUpdateRequestBody", func() {
+		It("should build the request body with correct field encodings", func() {
+			params := &RepositoryUpdateParameters{
+				ShareType:         "HTTPS",
+				IPAddress:         "example.com",
+				ShareName:         "share",
+				CatalogFile:       "Catalog.xml",
+				UserName:          "admin",
+				Password:          "secret",
+				Workgroup:         "WORKGROUP",
+				IgnoreCertWarning: true,
+				ApplyUpdate:       true,
+				RebootNeeded:      true,
+			}
+
+			body := dellBuildRepositoryUpdateRequestBody(params)
+
+			Expect(body.ShareType).To(Equal("HTTPS"))
+			Expect(body.IPAddress).To(Equal("example.com"))
+			Expect(body.ShareName).To(Equal("share"))
+			Expect(body.CatalogFile).To(Equal("Catalog.xml"))
+			Expect(body.UserName).To(Equal("admin"))
+			Expect(body.Password).To(Equal("secret"))
+			Expect(body.Workgroup).To(Equal("WORKGROUP"))
+			Expect(body.IgnoreCertWarning).To(Equal("True"))
+			Expect(body.ApplyUpdate).To(Equal("True"))
+			Expect(body.RebootNeeded).To(BeTrue())
+		})
+
+		It("should render false booleans as \"False\"", func() {
+			body := dellBuildRepositoryUpdateRequestBody(&RepositoryUpdateParameters{})
+			Expect(body.IgnoreCertWarning).To(Equal("False"))
+			Expect(body.ApplyUpdate).To(Equal("False"))
+		})
+	})
+
+	Describe("dellRepositoryActionTarget", func() {
+		It("should build the action URI under the system's OEM software installation service", func() {
+			target := dellRepositoryActionTarget("/redfish/v1/Systems/1", "InstallFromRepository")
+			Expect(target).To(Equal("/redfish/v1/Systems/1/Oem/Dell/DellSoftwareInstallationService/Actions/DellSoftwareInstallationService.InstallFromRepository"))
+		})
+
+		It("should normalize a trailing slash on the system URI", func() {
+			target := dellRepositoryActionTarget("/redfish/v1/Systems/1/", "GetRepoBasedUpdateList")
+			Expect(target).To(Equal("/redfish/v1/Systems/1/Oem/Dell/DellSoftwareInstallationService/Actions/DellSoftwareInstallationService.GetRepoBasedUpdateList"))
+		})
+	})
+
+	Describe("dellExtractJobID", func() {
+		It("should extract the job ID from the Location header", func() {
+			resp := &http.Response{
+				Header: make(http.Header),
+				Body:   io.NopCloser(strings.NewReader("")),
+			}
+			resp.Header.Set("Location", "/redfish/v1/Managers/BMC/Oem/Dell/Jobs/JID_1234")
+
+			jobID, err := dellExtractJobID(resp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(jobID).To(Equal("JID_1234"))
+		})
+
+		It("should return an error when no Location header is present", func() {
+			resp := &http.Response{
+				Header: make(http.Header),
+				Body:   io.NopCloser(strings.NewReader("")),
+			}
+
+			_, err := dellExtractJobID(resp)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no Location header"))
+		})
+	})
+
+	Describe("dellPackageListHasPendingPackages", func() {
+		It("should return false for an empty package list", func() {
+			Expect(dellPackageListHasPendingPackages("")).To(BeFalse())
+			Expect(dellPackageListHasPendingPackages("   ")).To(BeFalse())
+		})
+
+		It("should return true when a PACKAGE element is present", func() {
+			Expect(dellPackageListHasPendingPackages("<PACKAGELIST><PACKAGE NAME=\"BIOS\"/></PACKAGELIST>")).To(BeTrue())
+		})
+
+		It("should return true when an INSTANCE element is present", func() {
+			Expect(dellPackageListHasPendingPackages("<INSTANCE CLASSNAME=\"foo\"/>")).To(BeTrue())
+		})
+
+		It("should return false when no package/instance element is present", func() {
+			Expect(dellPackageListHasPendingPackages("<UpdateList></UpdateList>")).To(BeFalse())
+		})
+	})
+
+	Describe("DellJob classification", func() {
+		DescribeTable("IsCompleted",
+			func(job *DellJob, expected bool) {
+				Expect(job.IsCompleted()).To(Equal(expected))
+			},
+			Entry("Completed state", &DellJob{State: "Completed"}, true),
+			Entry("Running state", &DellJob{State: "Running"}, false),
+			Entry("CompletedWithErrors state", &DellJob{State: "CompletedWithErrors"}, false),
+		)
+
+		DescribeTable("IsFailed",
+			func(job *DellJob, expected bool) {
+				Expect(job.IsFailed()).To(Equal(expected))
+			},
+			Entry("Failed state", &DellJob{State: "Failed"}, true),
+			Entry("CompletedWithErrors state", &DellJob{State: "CompletedWithErrors"}, true),
+			Entry("RebootFailed state", &DellJob{State: "RebootFailed"}, true),
+			Entry("Running state with no failure message", &DellJob{State: "Running", Message: "Job execution in progress."}, false),
+			Entry("Running state with a failure message", &DellJob{State: "Running", Message: "Unable to apply the update."}, true),
+			Entry("Completed state", &DellJob{State: "Completed"}, false),
+		)
+
+		DescribeTable("IsTerminal",
+			func(job *DellJob, expected bool) {
+				Expect(job.IsTerminal()).To(Equal(expected))
+			},
+			Entry("Completed state", &DellJob{State: "Completed"}, true),
+			Entry("Failed state", &DellJob{State: "Failed"}, true),
+			Entry("Running state", &DellJob{State: "Running"}, false),
+			Entry("Scheduled state", &DellJob{State: "Scheduled"}, false),
+		)
+	})
+
+	Describe("InstallFirmwareFromRepository", func() {
+		It("should return the job ID on a successful 202 response", func() {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(serviceRootJSON()) //nolint:errcheck
+			})
+			mux.HandleFunc("/redfish/v1/Systems/1/Oem/Dell/DellSoftwareInstallationService/Actions/DellSoftwareInstallationService.InstallFromRepository",
+				func(w http.ResponseWriter, r *http.Request) {
+					Expect(r.Method).To(Equal(http.MethodPost))
+					w.Header().Set("Location", "/redfish/v1/Managers/BMC/Oem/Dell/Jobs/JID_5678")
+					w.WriteHeader(http.StatusAccepted)
+				})
+
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			dell.RedfishBaseBMC = newTestRedfishBMC(server)
+			jobID, isFatal, err := dell.InstallFirmwareFromRepository(context.Background(), "/redfish/v1/Systems/1", &RepositoryUpdateParameters{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isFatal).To(BeFalse())
+			Expect(jobID).To(Equal("JID_5678"))
+		})
+
+		It("should return a fatal error on a non-202 response", func() {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(serviceRootJSON()) //nolint:errcheck
+			})
+			mux.HandleFunc("/redfish/v1/Systems/1/Oem/Dell/DellSoftwareInstallationService/Actions/DellSoftwareInstallationService.InstallFromRepository",
+				func(w http.ResponseWriter, _ *http.Request) {
+					http.Error(w, "bad request", http.StatusBadRequest)
+				})
+
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			dell.RedfishBaseBMC = newTestRedfishBMC(server)
+			_, isFatal, err := dell.InstallFirmwareFromRepository(context.Background(), "/redfish/v1/Systems/1", &RepositoryUpdateParameters{})
+			Expect(err).To(HaveOccurred())
+			Expect(isFatal).To(BeTrue())
+		})
+	})
+
+	Describe("GetRepositoryUpdateList", func() {
+		It("should report pending packages from a 200 response", func() {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(serviceRootJSON()) //nolint:errcheck
+			})
+			mux.HandleFunc("/redfish/v1/Systems/1/Oem/Dell/DellSoftwareInstallationService/Actions/DellSoftwareInstallationService.GetRepoBasedUpdateList",
+				func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.Write([]byte(`{"PackageList": "<PACKAGELIST><PACKAGE NAME=\"BIOS\"/></PACKAGELIST>"}`)) //nolint:errcheck
+				})
+
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			dell.RedfishBaseBMC = newTestRedfishBMC(server)
+			hasPending, packageList, err := dell.GetRepositoryUpdateList(context.Background(), "/redfish/v1/Systems/1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasPending).To(BeTrue())
+			Expect(packageList).To(ContainSubstring("<PACKAGE"))
+		})
+
+		It("should treat a \"no match catalog\" error response as no pending packages", func() {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(serviceRootJSON()) //nolint:errcheck
+			})
+			mux.HandleFunc("/redfish/v1/Systems/1/Oem/Dell/DellSoftwareInstallationService/Actions/DellSoftwareInstallationService.GetRepoBasedUpdateList",
+				func(w http.ResponseWriter, _ *http.Request) {
+					http.Error(w, "Unable to find match catalog file.", http.StatusBadRequest)
+				})
+
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			dell.RedfishBaseBMC = newTestRedfishBMC(server)
+			hasPending, packageList, err := dell.GetRepositoryUpdateList(context.Background(), "/redfish/v1/Systems/1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasPending).To(BeFalse())
+			Expect(packageList).To(BeEmpty())
+		})
+
+		It("should return an error on an unrelated failure response", func() {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(serviceRootJSON()) //nolint:errcheck
+			})
+			mux.HandleFunc("/redfish/v1/Systems/1/Oem/Dell/DellSoftwareInstallationService/Actions/DellSoftwareInstallationService.GetRepoBasedUpdateList",
+				func(w http.ResponseWriter, _ *http.Request) {
+					http.Error(w, "internal error", http.StatusInternalServerError)
+				})
+
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			dell.RedfishBaseBMC = newTestRedfishBMC(server)
+			_, _, err := dell.GetRepositoryUpdateList(context.Background(), "/redfish/v1/Systems/1")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("ListJobs and GetJob", func() {
+		It("should list job IDs and retrieve a job's details", func() {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(serviceRootJSON()) //nolint:errcheck
+			})
+			mux.HandleFunc("/redfish/v1/Managers", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(managersCollectionJSON([]string{"/redfish/v1/Managers/BMC"})) //nolint:errcheck
+			})
+			mux.HandleFunc("/redfish/v1/Managers/BMC", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(managerJSON("BMC", 0, nil)) //nolint:errcheck
+			})
+			mux.HandleFunc("/redfish/v1/Managers/BMC/Oem/Dell/Jobs", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"Members": [{"@odata.id": "/redfish/v1/Managers/BMC/Oem/Dell/Jobs/JID_1234"}]}`)) //nolint:errcheck
+			})
+			mux.HandleFunc("/redfish/v1/Managers/BMC/Oem/Dell/Jobs/JID_1234", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"Id": "JID_1234", "Name": "Repository Update", "JobType": "RepositoryUpdate", "JobState": "Running", "Message": "Job execution in progress.", "PercentComplete": 50}`)) //nolint:errcheck
+			})
+
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			dell.RedfishBaseBMC = newTestRedfishBMC(server)
+
+			jobIDs, err := dell.ListJobs(context.Background(), "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(jobIDs).To(Equal([]string{"JID_1234"}))
+
+			job, err := dell.GetJob(context.Background(), "", "JID_1234")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(job.ID).To(Equal("JID_1234"))
+			Expect(job.Name).To(Equal("Repository Update"))
+			Expect(job.JobType).To(Equal("RepositoryUpdate"))
+			Expect(job.State).To(Equal("Running"))
+			Expect(job.Message).To(Equal("Job execution in progress."))
+			Expect(job.PercentComplete).To(Equal(int32(50)))
 		})
 	})
 


### PR DESCRIPTION
# Proposed Changes

- Add Dell-specific Redfish BMC methods: `InstallFirmwareFromRepository`, `GetRepositoryUpdateList`, `ListJobs`, `GetJob`
- Introduce `dellRepositoryUpdateRequestBody` with correct field encodings (`ApplySameVersions`/`ApplyDowngradeVersions` as `"True"`/`"False"`, `IgnoreCertWarning` as `"On"`/`"Off"`)
- Treat all `InstallFromRepository` POST errors as fatal (request may have reached BMC before connection dropped)
- Fix SSH reset fallback in `BMCReconciler`: schedule SSH on any connectivity failure, not only `*schemas.Error` 5xx (gofish returns plain-text 503 without wrapping)
- Extend mock server: Dell repository-update state machine, job step simulation, `WithResourceOverride`/`WithSystemOverride` options
- Add unit tests: field encoding, dropped-connection fatal error, mock server end-to-end flow
- Fix `errcheck` lint: assign `conn.Close()` return value in test hijacker

# Fixes

Fixes #1105