### PR TITLE
Remove OwnerReference from Endpoint to BMC and BMCSecret

### DIFF
--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -48,14 +48,7 @@ var _ = Describe("BMC Controller", func() {
 			},
 		}
 		Eventually(Object(bmc)).Should(SatisfyAll(
-			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-				APIVersion:         "metal.ironcore.dev/v1alpha1",
-				Kind:               "Endpoint",
-				Name:               endpoint.Name,
-				UID:                endpoint.UID,
-				Controller:         new(true),
-				BlockOwnerDeletion: new(true),
-			})),
+			HaveField("OwnerReferences", BeEmpty()),
 			HaveField("Status.IP", metalv1alpha1.MustParseIP(MockServerIP)),
 			HaveField("Status.MACAddress", "23:11:8A:33:CF:EA"),
 			HaveField("Status.Model", "Joo Janta 200"),

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
@@ -16,11 +17,13 @@ import (
 	"github.com/ironcore-dev/metal-operator/pkg/bmcutils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
 const (
@@ -64,7 +67,30 @@ func (r *EndpointReconciler) reconcileExists(ctx context.Context, endpoint *meta
 func (r *EndpointReconciler) delete(ctx context.Context, endpoint *metalv1alpha1.Endpoint) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Deleting Endpoint")
-	// TODO: cleanup endpoint
+
+	// Drop legacy Endpoint owner references from the BMC and BMCSecret
+	for _, obj := range []client.Object{
+		&metalv1alpha1.BMC{ObjectMeta: metav1.ObjectMeta{Name: endpoint.Name}},
+		&metalv1alpha1.BMCSecret{ObjectMeta: metav1.ObjectMeta{Name: endpoint.Name}},
+	} {
+		if err := r.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return ctrl.Result{}, fmt.Errorf("failed to get %T %s: %w", obj, obj.GetName(), err)
+		}
+		if before := len(obj.GetOwnerReferences()); before > 0 {
+			base := obj.DeepCopyObject().(client.Object)
+			removeEndpointOwnerReference(obj)
+			if len(obj.GetOwnerReferences()) != before {
+				if err := r.Patch(ctx, obj, client.MergeFrom(base)); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to remove Endpoint owner reference from %T %s: %w", obj, obj.GetName(), err)
+				}
+				log.V(1).Info("Removed Endpoint owner reference", "Name", obj.GetName())
+			}
+		}
+	}
+
 	if modified, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, endpoint, endpointFinalizer); err != nil || modified {
 		return ctrl.Result{}, err
 	}
@@ -78,6 +104,10 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, endpoint *metalv1alp
 	if shouldIgnoreReconciliation(endpoint) {
 		log.V(1).Info("Skipped Endpoint reconciliation")
 		return ctrl.Result{}, nil
+	}
+
+	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, endpoint, endpointFinalizer); err != nil || modified {
+		return ctrl.Result{}, err
 	}
 
 	sanitizedMACAddress := strings.ReplaceAll(endpoint.Spec.MACAddress, ":", "")
@@ -158,7 +188,6 @@ func (r *EndpointReconciler) reconcile(ctx context.Context, endpoint *metalv1alp
 			default:
 				return ctrl.Result{}, fmt.Errorf("unknown protocol: %s", m.Protocol)
 			}
-			// TODO: other types like Switches can be handled here later
 		}
 	}
 	log.V(1).Info("Reconciled Endpoint")
@@ -209,7 +238,8 @@ func (r *EndpointReconciler) applyBMC(ctx context.Context, bmcClient bmc.BMC, en
 		if bmcUUID != "" {
 			spec.BMCUUID = bmcUUID
 		}
-		return controllerutil.SetControllerReference(endpoint, bmcObj, r.Client.Scheme())
+		removeEndpointOwnerReference(bmcObj)
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create or patch BMC: %w", err)
@@ -228,7 +258,8 @@ func (r *EndpointReconciler) applyBMCSecret(ctx context.Context, endpoint *metal
 			metalv1alpha1.BMCSecretUsernameKeyName: []byte(m.DefaultCredentials[0].Username),
 			metalv1alpha1.BMCSecretPasswordKeyName: []byte(m.DefaultCredentials[0].Password),
 		}
-		return controllerutil.SetControllerReference(endpoint, bmcSecret, r.Client.Scheme())
+		removeEndpointOwnerReference(bmcSecret)
+		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create or patch BMCSecret: %w", err)
@@ -238,11 +269,21 @@ func (r *EndpointReconciler) applyBMCSecret(ctx context.Context, endpoint *metal
 	return bmcSecret, nil
 }
 
+func removeEndpointOwnerReference(obj metav1.Object) {
+	obj.SetOwnerReferences(slices.DeleteFunc(obj.GetOwnerReferences(), func(ref metav1.OwnerReference) bool {
+		return ref.APIVersion == metalv1alpha1.GroupVersion.String() && ref.Kind == "Endpoint"
+	}))
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *EndpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	mapToEndpoint := func(_ context.Context, obj client.Object) []ctrl.Request {
+		return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: obj.GetName()}}}
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&metalv1alpha1.Endpoint{}).
-		Owns(&metalv1alpha1.BMCSecret{}).
-		Owns(&metalv1alpha1.BMC{}).
+		Watches(&metalv1alpha1.BMC{}, handler.EnqueueRequestsFromMapFunc(mapToEndpoint)).
+		Watches(&metalv1alpha1.BMCSecret{}, handler.EnqueueRequestsFromMapFunc(mapToEndpoint)).
 		Complete(r)
 }

--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -34,6 +34,11 @@ var _ = Describe("Endpoints Controller", func() {
 		}
 		Expect(k8sClient.Create(ctx, endpoint)).To(Succeed())
 
+		By("Ensuring that the Endpoint has the finalizer set")
+		Eventually(Object(endpoint)).Should(
+			HaveField("ObjectMeta.Finalizers", ContainElement(endpointFinalizer)),
+		)
+
 		By("Ensuring that the BMC secret has been created")
 		bmcSecret := &metalv1alpha1.BMCSecret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -41,14 +46,7 @@ var _ = Describe("Endpoints Controller", func() {
 			},
 		}
 		Eventually(Object(bmcSecret)).Should(SatisfyAll(
-			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-				APIVersion:         "metal.ironcore.dev/v1alpha1",
-				Kind:               "Endpoint",
-				Name:               endpoint.Name,
-				UID:                endpoint.UID,
-				Controller:         new(true),
-				BlockOwnerDeletion: new(true),
-			})),
+			HaveField("OwnerReferences", BeEmpty()),
 			HaveField("Data", Equal(map[string][]byte{
 				metalv1alpha1.BMCSecretUsernameKeyName: []byte("foo"),
 				metalv1alpha1.BMCSecretPasswordKeyName: []byte("bar"),
@@ -61,14 +59,7 @@ var _ = Describe("Endpoints Controller", func() {
 			},
 		}
 		Eventually(Object(bmcObj)).Should(SatisfyAll(
-			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-				APIVersion:         "metal.ironcore.dev/v1alpha1",
-				Kind:               "Endpoint",
-				Name:               endpoint.Name,
-				UID:                endpoint.UID,
-				Controller:         new(true),
-				BlockOwnerDeletion: new(true),
-			})),
+			HaveField("OwnerReferences", BeEmpty()),
 			HaveField("Spec.EndpointRef.Name", Equal(endpoint.Name)),
 			HaveField("Spec.BMCSecretRef.Name", Equal(bmcObj.Name)),
 			HaveField("Spec.Protocol", metalv1alpha1.Protocol{
@@ -93,8 +84,80 @@ var _ = Describe("Endpoints Controller", func() {
 		By("Cleaning up the created Endpoint")
 		Expect(k8sClient.Delete(ctx, endpoint)).To(Succeed())
 
-		By("Ensuring that all subsequent objects have been removed")
+		By("Ensuring that the Endpoint has been removed")
 		Eventually(Get(endpoint)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("Ensuring that the BMC and BMCSecret objects are not garbage collected with the Endpoint")
+		Consistently(Get(bmcObj)).Should(Succeed())
+		Consistently(Get(bmcSecret)).Should(Succeed())
+
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcObj))).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcSecret))).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, server))).To(Succeed())
+	})
+
+	It("should remove legacy Endpoint owner references from BMC and BMCSecret on deletion", func(ctx SpecContext) {
+		By("Creating an Endpoints object")
+		endpoint := &metalv1alpha1.Endpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-endpoint-",
+			},
+			Spec: metalv1alpha1.EndpointSpec{
+				MACAddress: "23:11:8A:33:CF:EA",
+				IP:         metalv1alpha1.MustParseIP(MockServerIP),
+			},
+		}
+		Expect(k8sClient.Create(ctx, endpoint)).To(Succeed())
+
+		By("Ensuring that the BMC and BMCSecret have been created")
+		bmcObj := &metalv1alpha1.BMC{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: endpoint.Name,
+			},
+		}
+		bmcSecret := &metalv1alpha1.BMCSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: endpoint.Name,
+			},
+		}
+		Eventually(Get(bmcObj)).Should(Succeed())
+		Eventually(Get(bmcSecret)).Should(Succeed())
+
+		By("Adding legacy Endpoint owner references to BMC and BMCSecret")
+		legacyOwnerRef := metav1.OwnerReference{
+			APIVersion:         metalv1alpha1.GroupVersion.String(),
+			Kind:               "Endpoint",
+			Name:               endpoint.Name,
+			UID:                endpoint.UID,
+			Controller:         new(true),
+			BlockOwnerDeletion: new(true),
+		}
+		for _, obj := range []client.Object{bmcObj, bmcSecret} {
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+					return err
+				}
+				obj.SetOwnerReferences(append(obj.GetOwnerReferences(), legacyOwnerRef))
+				return k8sClient.Update(ctx, obj)
+			}).Should(Succeed())
+		}
+
+		By("Deleting the Endpoint")
+		Expect(k8sClient.Delete(ctx, endpoint)).To(Succeed())
+		Eventually(Get(endpoint)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("Ensuring the BMC and BMCSecret survived without Endpoint owner references")
+		Consistently(Get(bmcObj)).Should(Succeed())
+		Consistently(Get(bmcSecret)).Should(Succeed())
+		Eventually(Object(bmcObj)).Should(HaveField("OwnerReferences", BeEmpty()))
+		Eventually(Object(bmcSecret)).Should(HaveField("OwnerReferences", BeEmpty()))
+
+		By("Cleaning up the created objects")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bmcutils.GetServerNameFromBMCandIndex(0, bmcObj),
+			},
+		}
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcObj))).To(Succeed())
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, bmcSecret))).To(Succeed())
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, server))).To(Succeed())


### PR DESCRIPTION
# Proposed Changes

Remove OwnerReference from Endpoint to BMC and BMCSecret.

Fixes #1022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - BMC and BMCSecret resources are preserved when their associated Endpoint is deleted.
  - Legacy Endpoint ownership references are removed safely during cleanup.
  - Endpoint reconciliation no longer reacts to ownership changes on generated resources.
  - Endpoint finalization is now applied consistently during reconciliation, improving cleanup reliability.
  - Existing BMC and BMCSecret resources remain available independently after Endpoint removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->