### PR TITLE
Remove `Server.spec.power` usage and clear the field on reconcile

### DIFF
--- a/docs/concepts/servers.md
+++ b/docs/concepts/servers.md
@@ -14,7 +14,6 @@ metadata:
   name: my-server
 spec:
   systemUUID: "123e4567-e89b-12d3-a456-426614174000"
-  power: "Off"
   reclaimPolicy: Recycle
   bmcRef:
     name: my-bmc
@@ -23,6 +22,9 @@ spec:
       priority: 1
       device: Network
 ```
+
+Desired power for a workload is configured on the `ServerClaim` via [`spec.power`](serverclaims.md),
+not on the `Server`.
 
 ## Usage
 
@@ -230,8 +232,7 @@ and the parked marker stay the same regardless of how the request arrives.
    This is a one-shot request; it does **not** itself persist the parked state.
 2. **Park.** The `Server` reconciler observes the request and, if the server is in a parkable state
    (`Available` or `Reserved`):
-   - powers the server **off** via the BMC (idempotent; only if not already off; `spec.power` is
-     left untouched),
+   - powers the server **off** via the BMC (idempotent; only if not already off),
    - records the parked state by setting the internal `metal.ironcore.dev/parked: "true"` annotation,
    - sets `status.state = Parked`,
    - **removes** the `metal.ironcore.dev/operation: park` request annotation again.
@@ -258,8 +259,8 @@ and the parked marker stay the same regardless of how the request arrives.
      during the procedure),
    - transitions back to the pre-parking state: `Reserved` if the server has a `ServerClaimRef`,
      otherwise `Available`,
-   - the `ServerClaim` reconciler takes over again and re-applies the boot configuration and power
-     state as before.
+   - the `ServerClaim` reconciler takes over again and re-applies the boot configuration, and the
+     server state machine re-applies the claim's requested power state as before.
 
    An unpark request on a server that is not parked is a no-op: the request annotation is consumed
    and nothing else happens.
@@ -293,7 +294,7 @@ When done, bring the server back with an unpark request:
 kubectl annotate server my-server metal.ironcore.dev/operation=unpark
 ```
 
-The bound `ServerClaim` resumes ownership without re-scheduling, and its reconciler reapplies the claim's requested power state, including `Off` when the claim requests it.
+The bound `ServerClaim` resumes ownership without re-scheduling, and the server state machine reapplies the claim's requested power state, including `Off` when the claim requests it.
 
 ## Interaction with BMC
 
@@ -308,7 +309,6 @@ metadata:
   name: server-with-bmc-ref
 spec:
   systemUUID: "123e4567-e89b-12d3-a456-426614174000"
-  power: "On"
   bmcRef:
     name: my-bmc
   bootOrder:
@@ -328,7 +328,6 @@ metadata:
   name: server-with-inline-bmc
 spec:
   systemUUID: "123e4567-e89b-12d3-a456-426614174000"
-  power: "On"
   bmc:
     protocol:
       name: Redfish

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -223,6 +223,17 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 		}
 	}
 
+	// Clear the deprecated spec.power field.
+	// TODO: remove this part once the spec field is gone
+	if server.Spec.Power != "" {
+		serverBase := server.DeepCopy()
+		server.Spec.Power = ""
+		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to clear deprecated spec.power field: %w", err)
+		}
+		log.V(1).Info("Cleared deprecated spec.power field")
+	}
+
 	bmcClient, err := bmcutils.GetBMCClientForServer(ctx, r.Client, server, r.DefaultProtocol, r.SkipCertValidation, r.BMCOptions, bmcutils.WithRegistryURL(r.RegistryURL))
 	if err != nil {
 		if errors.As(err, &bmcutils.BMCUnAvailableError{}) {
@@ -331,11 +342,6 @@ func (r *ServerReconciler) handleInitialState(ctx context.Context, bmcClient bmc
 	}
 	log.V(1).Info("Initial conditions for Server met")
 
-	if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
-		return false, fmt.Errorf("failed to ensure server power state: %w", err)
-	}
-	log.V(1).Info("Ensured power state for Server")
-
 	if err := r.updateServerStatusFromSystemInfo(ctx, bmcClient, server); err != nil {
 		return false, fmt.Errorf("failed to update server status system info: %w", err)
 	}
@@ -372,13 +378,7 @@ func (r *ServerReconciler) handleDiscoveryState(ctx context.Context, bmcClient b
 	log.V(1).Info("Server boot configuration is ready")
 
 	serverBase := server.DeepCopy()
-	server.Spec.Power = metalv1alpha1.PowerOn
-	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-		return false, fmt.Errorf("failed to update server power state: %w", err)
-	}
-	log.V(1).Info("Updated Server power state", "PowerState", metalv1alpha1.PowerOn)
-
-	if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
+	if err := r.ensureServerPowerState(ctx, bmcClient, server, metalv1alpha1.PowerOn); err != nil {
 		return false, fmt.Errorf("failed to ensure server power state: %w", err)
 	}
 	log.V(1).Info("Server state set to power on")
@@ -431,15 +431,8 @@ func (r *ServerReconciler) handleDiscoveryState(ctx context.Context, bmcClient b
 
 func (r *ServerReconciler) handleAvailableState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	serverBase := server.DeepCopy()
 	if server.Status.PowerState != metalv1alpha1.ServerOffPowerState {
-		server.Spec.Power = metalv1alpha1.PowerOff
-		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-			return false, fmt.Errorf("failed to update server power state: %w", err)
-		}
-		log.V(1).Info("Updated Server power state", "PowerState", metalv1alpha1.PowerOff)
-
-		if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
+		if err := r.ensureServerPowerState(ctx, bmcClient, server, metalv1alpha1.PowerOff); err != nil {
 			return false, fmt.Errorf("failed to ensure server power state: %w", err)
 		}
 		log.V(1).Info("Server state set to power off")
@@ -535,7 +528,7 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bm
 		}
 		log.V(1).Info("Server is powered off, booting Server in PXE")
 	}
-	if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
+	if err := r.ensureServerPowerState(ctx, bmcClient, server, claim.Spec.Power); err != nil {
 		return false, fmt.Errorf("failed to ensure server power state: %w", err)
 	}
 
@@ -549,16 +542,13 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, bmcClient bm
 func (r *ServerReconciler) ensureServerPoweredOff(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (off bool, err error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if server.Spec.Power != metalv1alpha1.PowerOff || server.Spec.BootConfigurationRef != nil {
+	if server.Spec.BootConfigurationRef != nil {
 		base := server.DeepCopy()
-		// TODO: drop the spec.power write — it's deprecated (#1042) and only
-		// kept here to carry the desired state until the field is removed.
-		server.Spec.Power = metalv1alpha1.PowerOff
 		server.Spec.BootConfigurationRef = nil
 		if err := r.Patch(ctx, server, client.MergeFrom(base)); err != nil {
-			return false, fmt.Errorf("failed to patch spec.power / spec.bootConfigurationRef: %w", err)
+			return false, fmt.Errorf("failed to clear spec.bootConfigurationRef: %w", err)
 		}
-		log.V(1).Info("Requested power off and cleared boot configuration")
+		log.V(1).Info("Cleared boot configuration")
 	}
 
 	if server.Status.PowerState == metalv1alpha1.ServerOffPowerState {
@@ -714,7 +704,11 @@ func (r *ServerReconciler) handleMaintenanceState(ctx context.Context, bmcClient
 		}
 		return r.patchServerState(ctx, server, metalv1alpha1.ServerStateReserved)
 	}
-	if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
+	maintenance, err := GetServerMaintenanceForObjectReference(ctx, r.Client, server.Spec.ServerMaintenanceRef)
+	if err != nil {
+		return false, fmt.Errorf("failed to get ServerMaintenance for server: %w", err)
+	}
+	if err := r.ensureServerPowerState(ctx, bmcClient, server, maintenance.Spec.ServerPower); err != nil {
 		return false, fmt.Errorf("failed to ensure server power state: %w", err)
 	}
 
@@ -1145,44 +1139,12 @@ func (r *ServerReconciler) generateDefaultIgnitionDataForServer(flags string, ss
 
 func (r *ServerReconciler) ensureInitialConditions(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	if server.Spec.Power == "" && server.Status.PowerState == metalv1alpha1.ServerOffPowerState {
-		requeue, err := r.setAndPatchServerPowerState(ctx, bmcClient, server, metalv1alpha1.PowerOff)
-		if err != nil {
-			return false, fmt.Errorf("failed to set server power state: %w", err)
-		}
-		if requeue {
-			return requeue, nil
-		}
-	}
-
 	if server.Status.State == metalv1alpha1.ServerStateInitial &&
 		server.Status.PowerState == metalv1alpha1.ServerOnPowerState &&
 		r.EnforceFirstBoot {
 		log.V(1).Info("Server in initial state is powered on, ensuring it is powered off")
-		requeue, err := r.setAndPatchServerPowerState(ctx, bmcClient, server, metalv1alpha1.PowerOff)
-		if err != nil {
-			return false, fmt.Errorf("failed to set server power state: %w", err)
-		}
-		if requeue {
-			return requeue, nil
-		}
-	}
-	return false, nil
-}
-
-func (r *ServerReconciler) setAndPatchServerPowerState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server, powerState metalv1alpha1.Power) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
-	op, err := controllerutil.CreateOrPatch(ctx, r.Client, server, func() error {
-		server.Spec.Power = powerState
-		return nil
-	})
-	if err != nil {
-		return false, fmt.Errorf("failed to patch Server: %w", err)
-	}
-	if op == controllerutil.OperationResultUpdated {
-		log.V(1).Info("Server updated to power off state")
-		if err := r.ensureServerPowerState(ctx, bmcClient, server); err != nil {
-			log.V(1).Info("Failed to ensure power state")
+		if err := r.ensureServerPowerState(ctx, bmcClient, server, metalv1alpha1.PowerOff); err != nil {
+			return false, fmt.Errorf("failed to power off server in initial state: %w", err)
 		}
 		return true, nil
 	}
@@ -1359,9 +1321,9 @@ func (r *ServerReconciler) patchServerURI(ctx context.Context, bmcClient bmc.BMC
 	return true, nil
 }
 
-func (r *ServerReconciler) ensureServerPowerState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) error {
+func (r *ServerReconciler) ensureServerPowerState(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server, power metalv1alpha1.Power) error {
 	log := ctrl.LoggerFrom(ctx)
-	if server.Spec.Power == "" {
+	if power == "" {
 		// no desired power state set
 		return nil
 	}
@@ -1369,13 +1331,13 @@ func (r *ServerReconciler) ensureServerPowerState(ctx context.Context, bmcClient
 	powerOp := powerOpNoOP
 	if server.Status.PowerState != metalv1alpha1.ServerOnPowerState &&
 		server.Status.PowerState != metalv1alpha1.ServerPoweringOnPowerState &&
-		server.Spec.Power == metalv1alpha1.PowerOn {
+		power == metalv1alpha1.PowerOn {
 		powerOp = powerOpOn
 	}
 
 	if server.Status.PowerState != metalv1alpha1.ServerOffPowerState &&
 		server.Status.PowerState != metalv1alpha1.ServerPoweringOffPowerState &&
-		server.Spec.Power == metalv1alpha1.PowerOff {
+		power == metalv1alpha1.PowerOff {
 		powerOp = powerOpOff
 	}
 
@@ -1418,7 +1380,7 @@ func (r *ServerReconciler) ensureServerPowerState(ctx context.Context, bmcClient
 			}
 		}
 	}
-	log.V(1).Info("Ensured server power state", "PowerState", server.Spec.Power)
+	log.V(1).Info("Ensured server power state", "targetPower", power)
 
 	return nil
 }
@@ -1579,6 +1541,14 @@ func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&metalv1alpha1.ServerBootConfiguration{},
 			r.enqueueServerByServerBootConfiguration(),
 		).
+		Watches(
+			&metalv1alpha1.ServerClaim{},
+			r.enqueueServerByClaim(),
+		).
+		Watches(
+			&metalv1alpha1.ServerMaintenance{},
+			r.enqueueServerByMaintenance(),
+		).
 		Complete(r)
 }
 
@@ -1602,6 +1572,34 @@ func (r *ServerReconciler) enqueueServerByServerBootConfiguration() handler.Even
 		return []ctrl.Request{
 			{
 				NamespacedName: types.NamespacedName{Name: config.Spec.ServerRef.Name},
+			},
+		}
+	})
+}
+
+func (r *ServerReconciler) enqueueServerByClaim() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+		claim := obj.(*metalv1alpha1.ServerClaim)
+		if claim.Spec.ServerRef == nil {
+			return nil
+		}
+		return []ctrl.Request{
+			{
+				NamespacedName: types.NamespacedName{Name: claim.Spec.ServerRef.Name},
+			},
+		}
+	})
+}
+
+func (r *ServerReconciler) enqueueServerByMaintenance() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+		maintenance := obj.(*metalv1alpha1.ServerMaintenance)
+		if maintenance.Spec.ServerRef == nil {
+			return nil
+		}
+		return []ctrl.Request{
+			{
+				NamespacedName: types.NamespacedName{Name: maintenance.Spec.ServerRef.Name},
 			},
 		}
 	})

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -126,6 +126,61 @@ var _ = Describe("Server Controller", func() {
 		Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
 	})
 
+	It("should clear the deprecated spec.power field without disrupting power control", func(ctx SpecContext) {
+		By("Creating a BMCSecret")
+		bmcSecret := &metalv1alpha1.BMCSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-server-",
+			},
+			Data: map[string][]byte{
+				"username": []byte("foo"),
+				"password": []byte("bar"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+		By("Creating a Server with a legacy spec.power value")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "server-",
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				SystemUUID: "38947555-7742-3448-3784-823347823834",
+				Power:      metalv1alpha1.PowerOn,
+				BMC: &metalv1alpha1.BMCAccess{
+					Protocol: metalv1alpha1.Protocol{
+						Name: metalv1alpha1.ProtocolRedfishLocal,
+						Port: MockServerPort,
+					},
+					Address: MockServerIP,
+					BMCSecretRef: v1.LocalObjectReference{
+						Name: bmcSecret.Name,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+
+		By("Updating the Server to available state")
+		Eventually(UpdateStatus(server, func() {
+			server.Status.State = metalv1alpha1.ServerStateAvailable
+		})).Should(Succeed())
+
+		By("Ensuring that the deprecated spec.power field is cleared")
+		Eventually(Object(server)).Should(HaveField("Spec.Power", BeEmpty()))
+		Consistently(Object(server)).Should(HaveField("Spec.Power", BeEmpty()))
+
+		By("Ensuring that the power state is still managed by the state machine")
+		Eventually(Object(server)).Should(SatisfyAll(
+			HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
+			HaveField("Spec.Power", BeEmpty()),
+		))
+
+		// cleanup
+		Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
+	})
+
 	It("should initialize a Server from Endpoint", func(ctx SpecContext) {
 		By("Creating an Endpoint object")
 		endpoint := &metalv1alpha1.Endpoint{
@@ -174,7 +229,7 @@ var _ = Describe("Server Controller", func() {
 			})),
 			HaveField("Spec.SystemUUID", "38947555-7742-3448-3784-823347823834"),
 			HaveField("Spec.SystemURI", "/redfish/v1/Systems/437XR1138R2"),
-			HaveField("Spec.Power", metalv1alpha1.PowerOff),
+			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Spec.IndicatorLED", metalv1alpha1.IndicatorLED("")),
 			HaveField("Spec.ServerClaimRef", BeNil()),
 			HaveField("Status.Manufacturer", "Contoso"),
@@ -324,7 +379,7 @@ var _ = Describe("Server Controller", func() {
 				Controller:         new(true),
 				BlockOwnerDeletion: new(true),
 			})),
-			HaveField("Spec.Power", metalv1alpha1.PowerOn),
+			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Spec.BootConfigurationRef", &metalv1alpha1.ObjectReference{
 				Namespace: ns.Name,
 				Name:      server.Name,
@@ -504,7 +559,7 @@ var _ = Describe("Server Controller", func() {
 			HaveField("Finalizers", ContainElement(ServerFinalizer)),
 			HaveField("Spec.SystemUUID", "38947555-7742-3448-3784-823347823834"),
 			HaveField("Spec.SystemURI", "/redfish/v1/Systems/437XR1138R2"),
-			HaveField("Spec.Power", metalv1alpha1.PowerOn),
+			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Spec.IndicatorLED", metalv1alpha1.IndicatorLED("")),
 			HaveField("Spec.ServerClaimRef", BeNil()),
 			HaveField("Spec.BootConfigurationRef", &metalv1alpha1.ObjectReference{
@@ -540,7 +595,7 @@ var _ = Describe("Server Controller", func() {
 		_ = zeroCapacity.String()
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Spec.BootConfigurationRef", BeNil()),
-			HaveField("Spec.Power", metalv1alpha1.PowerOff),
+			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 			HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
 			HaveField("Status.NetworkInterfaces", Not(BeEmpty())),

--- a/internal/controller/serverclaim_controller.go
+++ b/internal/controller/serverclaim_controller.go
@@ -181,11 +181,6 @@ func (r *ServerClaimReconciler) reconcile(ctx context.Context, claim *metalv1alp
 	}
 	log.V(1).Info("Patched ServerClaim phase", "Phase", claim.Status.Phase)
 
-	if modified, err := r.ensurePowerStateForServer(ctx, claim, server); err != nil || modified {
-		return ctrl.Result{}, err
-	}
-	log.V(1).Info("Ensured PowerState for Server", "Server", server.Name)
-
 	log.V(1).Info("Reconciled server claim")
 	return ctrl.Result{}, nil
 }
@@ -208,22 +203,6 @@ func (r *ServerClaimReconciler) ensureObjectRefForServer(ctx context.Context, cl
 	}
 	log.V(1).Info("Patched ServerClaim reference on Server", "Server", server.Name, "ServerClaimRef", claim.Name)
 	return nil
-}
-
-func (r *ServerClaimReconciler) ensurePowerStateForServer(ctx context.Context, claim *metalv1alpha1.ServerClaim, server *metalv1alpha1.Server) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
-	if server.Spec.Power == claim.Spec.Power {
-		return false, nil
-	}
-	if server.Spec.ServerClaimRef != nil {
-		serverBase := server.DeepCopy()
-		server.Spec.Power = claim.Spec.Power
-		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-			return false, fmt.Errorf("failed to patch power for server: %w", err)
-		}
-		log.V(1).Info("Patched desired Power of the claimed Server", "Server", server.Name)
-	}
-	return true, nil
 }
 
 func (r *ServerClaimReconciler) patchServerClaimPhase(ctx context.Context, claim *metalv1alpha1.ServerClaim, phase metalv1alpha1.Phase) (bool, error) {

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -161,7 +161,7 @@ var _ = Describe("ServerClaim Controller", func() {
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Spec.ServerClaimRef", BeNil()),
 			HaveField("Spec.BootConfigurationRef", BeNil()),
-			HaveField("Spec.Power", metalv1alpha1.PowerOff),
+			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 		))
 	})
@@ -200,7 +200,7 @@ var _ = Describe("ServerClaim Controller", func() {
 		By("Ensuring that the Server has the correct claim ref")
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Spec.ServerClaimRef.Name", claim.Name),
-			HaveField("Spec.Power", metalv1alpha1.PowerOff),
+			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
 		))
 
@@ -222,7 +222,7 @@ var _ = Describe("ServerClaim Controller", func() {
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Spec.ServerClaimRef", BeNil()),
 			HaveField("Spec.BootConfigurationRef", BeNil()),
-			HaveField("Spec.Power", metalv1alpha1.PowerOff),
+			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 		))
 	})
@@ -270,7 +270,7 @@ var _ = Describe("ServerClaim Controller", func() {
 				Name:      claim.Name,
 				Namespace: claim.Namespace,
 			}),
-			HaveField("Spec.Power", metalv1alpha1.PowerOff),
+			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
 			HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
 		))
@@ -285,7 +285,7 @@ var _ = Describe("ServerClaim Controller", func() {
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Spec.ServerClaimRef", BeNil()),
 			HaveField("Spec.BootConfigurationRef", BeNil()),
-			HaveField("Spec.Power", metalv1alpha1.PowerOff),
+			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 			HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
 		))
@@ -740,7 +740,7 @@ var _ = Describe("ServerClaim Controller", func() {
 			config.Status.State = metalv1alpha1.ServerBootConfigurationStateReady
 		})).Should(Succeed())
 		Eventually(Object(claim)).Should(HaveField("Status.Phase", metalv1alpha1.PhaseBound))
-		Eventually(Object(server)).Should(HaveField("Spec.Power", metalv1alpha1.PowerOn))
+		Eventually(Object(server)).Should(HaveField("Status.PowerState", metalv1alpha1.ServerOnPowerState))
 
 		By("Parking the server")
 		Eventually(Update(server, func() {
@@ -751,18 +751,19 @@ var _ = Describe("ServerClaim Controller", func() {
 		By("Ensuring the server is powered off while parked")
 		Eventually(Object(server)).Should(HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState))
 
-		By("Asserting spec.power is left untouched while parked")
-		Consistently(Object(server)).Should(HaveField("Spec.Power", metalv1alpha1.PowerOn))
+		By("Asserting spec.power stays cleared while parked")
+		Consistently(Object(server)).Should(HaveField("Spec.Power", BeEmpty()))
 
 		By("Resuming the server via an unpark request")
 		Eventually(Update(server, func() {
 			metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 		})).Should(Succeed())
 
-		By("Ensuring the server resumes to reserved and the claim reconciler re-applies power")
+		By("Ensuring the server resumes to reserved and the state machine re-applies power")
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
-			HaveField("Spec.Power", metalv1alpha1.PowerOn),
+			HaveField("Status.PowerState", metalv1alpha1.ServerOnPowerState),
+			HaveField("Spec.Power", BeEmpty()),
 		))
 
 		By("Removing the ServerClaim")

--- a/internal/controller/servermaintenance_controller.go
+++ b/internal/controller/servermaintenance_controller.go
@@ -267,7 +267,7 @@ func (r *ServerMaintenanceReconciler) handleInMaintenanceState(ctx context.Conte
 		if err := r.setAndPatchServerState(ctx, server, maintenance); err != nil {
 			return ctrl.Result{}, err
 		}
-		log.V(1).Info("Patched server power state", "Server", server.Name, "Power", maintenance.Spec.ServerPower)
+		log.V(1).Info("Patched server indicator LED", "Server", server.Name, "IndicatorLED", maintenance.Spec.LocatorLED)
 		return ctrl.Result{}, nil
 	}
 
@@ -328,11 +328,11 @@ func (r *ServerMaintenanceReconciler) applyServerBootConfiguration(ctx context.C
 }
 
 func (r *ServerMaintenanceReconciler) setAndPatchServerState(ctx context.Context, server *metalv1alpha1.Server, maintenance *metalv1alpha1.ServerMaintenance) error {
-	serverBase := server.DeepCopy()
-	server.Spec.Power = maintenance.Spec.ServerPower
-	if maintenance.Spec.LocatorLED != "" {
-		server.Spec.IndicatorLED = maintenance.Spec.LocatorLED
+	if maintenance.Spec.LocatorLED == "" || server.Spec.IndicatorLED == maintenance.Spec.LocatorLED {
+		return nil
 	}
+	serverBase := server.DeepCopy()
+	server.Spec.IndicatorLED = maintenance.Spec.LocatorLED
 	return r.Patch(ctx, server, client.MergeFrom(serverBase))
 }
 


### PR DESCRIPTION
# Proposed Changes

Remove `Server.spec.power` usage and clear the field on reconcile.

Fixes #1044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Power management no longer writes to the deprecated `spec.power` field.
  - Power state is tracked through the server’s status and state machine.
  - Legacy power values are cleared without interrupting server power control.
  - Server updates respond more reliably to claim and maintenance changes.
  - Maintenance operations update only the configured indicator LED.

- **Documentation**
  - Clarified that workload power is configured through `ServerClaim`.
  - Updated parking and unparking documentation to describe server state-machine behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->