### PR TITLE
allow parked state from discovery

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -64,6 +64,10 @@ const (
 	// ParkedAnnotation is the durable, controller-set marker recording that a Server is parked.
 	ParkedAnnotation = "metal.ironcore.dev/parked"
 
+	// PreParkStateAnnotation is set by the controller at park time to record the state the Server
+	// was in before parking. Used by resolvePreParkState to restore the correct state on unpark.
+	PreParkStateAnnotation = "metal.ironcore.dev/pre-park-state"
+
 	// MetadataKeyPrefix is the shared prefix for labels and annotations on a Server
 	// whose suffix is exposed via the metaldata service to the booted server.
 	MetadataKeyPrefix = "metadata.metal.ironcore.dev/"

--- a/api/v1alpha1/serverreadinessrule_types.go
+++ b/api/v1alpha1/serverreadinessrule_types.go
@@ -37,7 +37,6 @@ type ServerReadinessRuleSpec struct {
 	// Conditions contains a list of the Server conditions that defines the specific
 	// criteria that must be met for taints to be managed on the target Server.
 	// The presence or status of these conditions directly triggers the application or removal of Server taints.
-	//
 	// +required
 	// +listType=map
 	// +listMapKey=type
@@ -50,14 +49,12 @@ type ServerReadinessRuleSpec struct {
 	// enforcementMode is one of BootstrapOnly, Continuous.
 	// "BootstrapOnly" applies the configuration once during initial setup.
 	// "Continuous" ensures the state is monitored and corrected throughout the resource lifecycle.
-	//
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="enforcementMode is immutable"
 	EnforcementMode EnforcementMode `json:"enforcementMode,omitempty"`
 
 	// Taint defines the specific Taint (Key, Value, and Effect) to be managed
 	// on Servers that meet the defined condition criteria.
-	//
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self.key.size() <= 253",message="taint key length must be at most 253 characters"
 	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.key) || self.key == oldSelf.key",message="taint key is immutable"
@@ -66,7 +63,6 @@ type ServerReadinessRuleSpec struct {
 	Taint Taint `json:"taint,omitempty,omitzero"`
 
 	// ServerSelector limits the scope of this rule to a specific subset of Servers.
-	//
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="serverSelector is immutable"
 	ServerSelector metav1.LabelSelector `json:"serverSelector,omitempty,omitzero"`
@@ -78,14 +74,12 @@ type ConditionRequirement struct {
 	// Type of server condition
 	//
 	// Following kubebuilder validation is referred from https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition
-	//
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=316
 	Type string `json:"type,omitempty"`
 
 	// RequiredStatus is status of the condition, one of True, False, Unknown.
-	//
 	// +required
 	// +kubebuilder:validation:Enum=True;False;Unknown
 	RequiredStatus metav1.ConditionStatus `json:"requiredStatus,omitempty"`

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -89,7 +89,7 @@ func isResetAnnotation(operation string) bool {
 
 func isParkableState(state metalv1alpha1.ServerState) bool {
 	switch state {
-	case metalv1alpha1.ServerStateAvailable, metalv1alpha1.ServerStateReserved:
+	case metalv1alpha1.ServerStateAvailable, metalv1alpha1.ServerStateReserved, metalv1alpha1.ServerStateDiscovery:
 		return true
 	}
 	return false

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -813,10 +813,20 @@ func (r *ServerReconciler) resumeParkedServer(ctx context.Context, bmcClient bmc
 	}
 
 	modified, err := r.patchServerState(ctx, server, prePark)
-	if err == nil && modified {
+	if err != nil {
+		return false, err
+	}
+	if modified {
 		r.Recorder.Eventf(server, nil, v1.EventTypeNormal, "Resumed", "Resume", "Resumed Server from Parked state to %s", prePark)
 	}
-	return modified, err
+
+	serverBase := server.DeepCopy()
+	metautils.DeleteAnnotation(server, metalv1alpha1.PreParkStateAnnotation)
+	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to remove pre-park state annotation: %w", err)
+	}
+
+	return modified, nil
 }
 
 func (r *ServerReconciler) stayParked(ctx context.Context, server *metalv1alpha1.Server) error {
@@ -867,6 +877,7 @@ func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, se
 	}
 
 	serverBase := server.DeepCopy()
+	metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.PreParkStateAnnotation, string(server.Status.State))
 	metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.ParkedAnnotation, "true")
 	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
 		return ctrl.Result{}, false, fmt.Errorf("failed to patch parked annotations: %w", err)
@@ -878,6 +889,15 @@ func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, se
 }
 
 func (r *ServerReconciler) resolvePreParkState(server *metalv1alpha1.Server) metalv1alpha1.ServerState {
+	if state, ok := server.GetAnnotations()[metalv1alpha1.PreParkStateAnnotation]; ok {
+		s := metalv1alpha1.ServerState(state)
+		if isParkableState(s) {
+			if s == metalv1alpha1.ServerStateReserved && server.Spec.ServerClaimRef == nil {
+				return metalv1alpha1.ServerStateAvailable
+			}
+			return s
+		}
+	}
 	if server.Spec.ServerClaimRef != nil {
 		return metalv1alpha1.ServerStateReserved
 	}

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -1642,22 +1642,24 @@ passwd:
 		It("should defer a park request on a non-parkable state and park once parkable", func(ctx SpecContext) {
 			server, bmcSecret := createServerAndSecret(ctx)
 
-			By("Ensuring the server reaches Discovery (a non-parkable state)")
-			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateDiscovery))
+			By("Driving the Server to Maintenance (a non-parkable state)")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateMaintenance
+			})).Should(Succeed())
 
-			By("Requesting the server to be parked while still in Discovery")
+			By("Requesting the server to be parked while in Maintenance")
 			Eventually(Update(server, func() {
 				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)
 			})).Should(Succeed())
 
 			By("Ensuring the server is not parked and the request is left in place")
 			Consistently(Object(server)).Should(SatisfyAll(
-				HaveField("Status.State", metalv1alpha1.ServerStateDiscovery),
+				HaveField("Status.State", metalv1alpha1.ServerStateMaintenance),
 				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)),
 				HaveField("Annotations", Not(HaveKey(metalv1alpha1.ParkedAnnotation))),
 			))
 
-			By("Driving the Server to available state (now parkable)")
+			By("Driving the Server to Available state (now parkable)")
 			Eventually(UpdateStatus(server, func() {
 				server.Status.State = metalv1alpha1.ServerStateAvailable
 			})).Should(Succeed())
@@ -1669,11 +1671,39 @@ passwd:
 				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
 			))
 
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should park a server in Discovery state and resume back to Discovery on unpark", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Ensuring the server reaches Discovery")
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateDiscovery))
+
+			By("Requesting the server to be parked while in Discovery")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)
+			})).Should(Succeed())
+
+			By("Ensuring the server is parked and PreParkStateAnnotation records Discovery")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.PreParkStateAnnotation, string(metalv1alpha1.ServerStateDiscovery))),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+			))
+
 			By("Requesting unpark to resume")
 			Eventually(Update(server, func() {
 				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
-			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+			By("Ensuring the server resumes back to Discovery and PreParkStateAnnotation is removed")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateDiscovery),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.PreParkStateAnnotation))),
+			))
 
 			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())


### PR DESCRIPTION
- add `ServerStateDiscovery` to `isParkableState`
- record pre-park state in `metal.ironcore.dev/pre-park-state` annotation at park time so `resumeParkedServer` can restore the correct state on unpark
- fix annotation cleanup order: transition state before removing annotation to avoid reverting to Available on retry after partial failure
- validate annotation value in `resolvePreParkState` before trusting it
- update test to reflect Discovery is now a parkable state

Fixes: #1119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Servers in Discovery state can now be parked directly.
  - Parked servers preserve their previous state and restore it when unparked.

- **Bug Fixes**
  - Improved resume handling to report patch failures and clean up saved state reliably.
  - Resume events are emitted only after successful state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->