### PR TITLE
Record pre-park state in annotation and allow parking servers in discovery state

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -64,6 +64,10 @@ const (
 	// ParkedAnnotation is the durable, controller-set marker recording that a Server is parked.
 	ParkedAnnotation = "metal.ironcore.dev/parked"
 
+	// PreParkStateAnnotation records the Server state before it was parked, so unpark can
+	// resume the Server into its previous state.
+	PreParkStateAnnotation = "metal.ironcore.dev/pre-park-state"
+
 	// MetadataKeyPrefix is the shared prefix for labels and annotations on a Server
 	// whose suffix is exposed via the metaldata service to the booted server.
 	MetadataKeyPrefix = "metadata.metal.ironcore.dev/"

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -42,14 +42,6 @@ func isResetAnnotation(operation string) bool {
 	return ok
 }
 
-func isParkableState(state metalv1alpha1.ServerState) bool {
-	switch state {
-	case metalv1alpha1.ServerStateAvailable, metalv1alpha1.ServerStateReserved:
-		return true
-	}
-	return false
-}
-
 // GenerateRandomPassword generates a random password of the given length.
 func GenerateRandomPassword(length int) ([]byte, error) {
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -678,6 +678,13 @@ func (r *ServerReconciler) resumeParkedServer(ctx context.Context, bmcClient bmc
 
 	modified, err := r.patchServerState(ctx, server, prePark)
 	if err == nil && modified {
+		if _, ok := server.GetAnnotations()[metalv1alpha1.PreParkStateAnnotation]; ok {
+			serverBase := server.DeepCopy()
+			metautils.DeleteAnnotation(server, metalv1alpha1.PreParkStateAnnotation)
+			if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+				return true, fmt.Errorf("failed to remove pre-park state annotation: %w", err)
+			}
+		}
 		r.Recorder.Eventf(server, nil, v1.EventTypeNormal, "Resumed", "Resume", "Resumed Server from Parked state to %s", prePark)
 	}
 	return modified, err
@@ -706,12 +713,6 @@ func (r *ServerReconciler) resetServer(ctx context.Context, bmcClient bmc.BMC, s
 func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, server *metalv1alpha1.Server) (ctrl.Result, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if !isParkableState(server.Status.State) {
-		log.V(1).Info("Server is not in a parkable state, deferring park request", "currentState", server.Status.State)
-		r.Recorder.Eventf(server, nil, v1.EventTypeWarning, "ParkDeferred", "DeferPark", "Park request deferred because server is in state %q", server.Status.State)
-		return ctrl.Result{}, false, nil
-	}
-
 	if err := r.updateServerStatus(ctx, bmcClient, server); err != nil {
 		return ctrl.Result{}, false, fmt.Errorf("failed to update server status: %w", err)
 	}
@@ -732,6 +733,7 @@ func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, se
 
 	serverBase := server.DeepCopy()
 	metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.ParkedAnnotation, "true")
+	metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.PreParkStateAnnotation, string(server.Status.State))
 	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
 		return ctrl.Result{}, false, fmt.Errorf("failed to patch parked annotations: %w", err)
 	}
@@ -742,6 +744,18 @@ func (r *ServerReconciler) parkServer(ctx context.Context, bmcClient bmc.BMC, se
 }
 
 func (r *ServerReconciler) resolvePreParkState(server *metalv1alpha1.Server) metalv1alpha1.ServerState {
+	if state, ok := server.GetAnnotations()[metalv1alpha1.PreParkStateAnnotation]; ok {
+		switch s := metalv1alpha1.ServerState(state); s {
+		case metalv1alpha1.ServerStateInitial,
+			metalv1alpha1.ServerStateDiscovery,
+			metalv1alpha1.ServerStateAvailable,
+			metalv1alpha1.ServerStateReserved,
+			metalv1alpha1.ServerStateReleased,
+			metalv1alpha1.ServerStateError:
+			return s
+		}
+		r.Recorder.Eventf(server, nil, v1.EventTypeWarning, "InvalidPreParkState", "Resume", "Ignoring invalid pre-park state %q, falling back to claim ref inference", state)
+	}
 	if server.Spec.ServerClaimRef != nil {
 		return metalv1alpha1.ServerStateReserved
 	}

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -1276,6 +1276,7 @@ passwd:
 				HaveField("Status.State", metalv1alpha1.ServerStateParked),
 				HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
 				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.PreParkStateAnnotation, string(metalv1alpha1.ServerStateAvailable))),
 				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
 			))
 
@@ -1288,6 +1289,7 @@ passwd:
 			Eventually(Object(server)).Should(SatisfyAll(
 				HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.PreParkStateAnnotation))),
 			))
 
 			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
@@ -1324,6 +1326,7 @@ passwd:
 				HaveField("Status.State", metalv1alpha1.ServerStateParked),
 				HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
 				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.PreParkStateAnnotation, string(metalv1alpha1.ServerStateReserved))),
 			))
 			Eventually(Object(claim)).Should(HaveField("Status.Phase", metalv1alpha1.PhaseBound))
 
@@ -1372,7 +1375,7 @@ passwd:
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		})
 
-		It("should fall back to available on resume if the ServerClaimRef is gone while parked", func(ctx SpecContext) {
+		It("should resume via the stored pre-park state and settle available if the ServerClaimRef is gone while parked", func(ctx SpecContext) {
 			server, bmcSecret := createServerAndSecret(ctx)
 
 			By("Driving the Server to available state and claiming it")
@@ -1407,8 +1410,72 @@ passwd:
 				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
 
-			By("Ensuring the server resumes to available (not reserved) since the claim ref is gone")
-			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+			By("Ensuring the server resumes and finally settles to available since the claim ref is gone")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.PreParkStateAnnotation))),
+			))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should park a server in discovery state and resume to discovery", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to discovery state")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateDiscovery
+			})).Should(Succeed())
+
+			park(server)
+
+			By("Ensuring the server is parked and the pre-park state is recorded")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.PreParkStateAnnotation, string(metalv1alpha1.ServerStateDiscovery))),
+			))
+
+			By("Requesting unpark to resume")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
+			})).Should(Succeed())
+
+			By("Ensuring the server resumes to discovery and the pre-park annotation is removed")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateDiscovery),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.PreParkStateAnnotation))),
+			))
+
+			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
+		})
+
+		It("should fall back to the inferred state when the pre-park annotation is bogus", func(ctx SpecContext) {
+			server, bmcSecret := createServerAndSecret(ctx)
+
+			By("Driving the Server to available state and parking it")
+			Eventually(UpdateStatus(server, func() {
+				server.Status.State = metalv1alpha1.ServerStateAvailable
+			})).Should(Succeed())
+			park(server)
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateParked))
+
+			By("Setting the pre-park annotation to a bogus value")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.PreParkStateAnnotation, "NoSuchState")
+			})).Should(Succeed())
+
+			By("Requesting unpark and resuming to the inferred (available) state")
+			Eventually(Update(server, func() {
+				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
+			})).Should(Succeed())
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.PreParkStateAnnotation))),
+			))
 
 			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
@@ -1492,41 +1559,35 @@ passwd:
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())
 		})
 
-		It("should defer a park request on a non-parkable state and park once parkable", func(ctx SpecContext) {
+		It("should park a server in error state and resume to error", func(ctx SpecContext) {
 			server, bmcSecret := createServerAndSecret(ctx)
 
-			By("Ensuring the server reaches Discovery (a non-parkable state)")
-			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateDiscovery))
-
-			By("Requesting the server to be parked while still in Discovery")
-			Eventually(Update(server, func() {
-				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)
-			})).Should(Succeed())
-
-			By("Ensuring the server is not parked and the request is left in place")
-			Consistently(Object(server)).Should(SatisfyAll(
-				HaveField("Status.State", metalv1alpha1.ServerStateDiscovery),
-				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationPark)),
-				HaveField("Annotations", Not(HaveKey(metalv1alpha1.ParkedAnnotation))),
-			))
-
-			By("Driving the Server to available state (now parkable)")
+			By("Driving the Server to error state")
 			Eventually(UpdateStatus(server, func() {
-				server.Status.State = metalv1alpha1.ServerStateAvailable
+				server.Status.State = metalv1alpha1.ServerStateError
 			})).Should(Succeed())
+			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateError))
 
-			By("Ensuring the deferred request is now honored and the server is parked")
+			park(server)
+
+			By("Ensuring the server is parked and the pre-park state is recorded")
 			Eventually(Object(server)).Should(SatisfyAll(
 				HaveField("Status.State", metalv1alpha1.ServerStateParked),
+				HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
 				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.ParkedAnnotation, Not(BeEmpty()))),
-				HaveField("Annotations", Not(HaveKey(metalv1alpha1.OperationAnnotation))),
+				HaveField("Annotations", HaveKeyWithValue(metalv1alpha1.PreParkStateAnnotation, string(metalv1alpha1.ServerStateError))),
 			))
 
 			By("Requesting unpark to resume")
 			Eventually(Update(server, func() {
 				metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
 			})).Should(Succeed())
-			Eventually(Object(server)).Should(HaveField("Status.State", metalv1alpha1.ServerStateAvailable))
+
+			By("Ensuring the server resumes to error and the pre-park annotation is removed")
+			Eventually(Object(server)).Should(SatisfyAll(
+				HaveField("Status.State", metalv1alpha1.ServerStateError),
+				HaveField("Annotations", Not(HaveKey(metalv1alpha1.PreParkStateAnnotation))),
+			))
 
 			Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, bmcSecret)).To(Succeed())


### PR DESCRIPTION
# Proposed Changes

Record pre-park state in annotation and allow parking servers in discovery state.

Fixes #1119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Servers now remember their state before parking and restore it when unparked.
  * Parking and resuming supports additional server states, including Discovery and Error.
  * Invalid saved state information now falls back to the server’s inferred state.

* **Bug Fixes**
  * Improved recovery when a server’s claim is deleted while parked.
  * Saved parking state is automatically cleared after a successful resume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->