### PR TITLE
Remove OwnerReference from BMC to Server

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ironcore-dev/metal-operator/internal/api/macdb"
 	"github.com/ironcore-dev/metal-operator/internal/controller"
 	metalmetrics "github.com/ironcore-dev/metal-operator/internal/metrics"
+	"github.com/ironcore-dev/metal-operator/internal/migration"
 	"github.com/ironcore-dev/metal-operator/internal/registry"
 	// +kubebuilder:scaffold:imports
 )
@@ -102,6 +103,7 @@ func main() { // nolint: gocyclo
 		serverClaimMaxConcurrentReconciles int
 		dnsRecordTemplatePath              string
 		defaultFailedAutoRetryCount        int
+		skipMigrations                     bool
 	)
 
 	flag.IntVar(&serverMaxConcurrentReconciles, "server-max-concurrent-reconciles", 5,
@@ -172,6 +174,7 @@ func main() { // nolint: gocyclo
 		"Path to the DNS record template file used for creating DNS records for Servers.")
 	flag.IntVar(&defaultFailedAutoRetryCount, "default-failed-auto-retry-count", 0,
 		"The default number of auto retries for a CRD when it fails. 0 for no retries.")
+	flag.BoolVar(&skipMigrations, "skip-migrations", false, "Whether to skip any migration before start or not.")
 
 	opts := zap.Options{
 		Development: true,
@@ -387,6 +390,19 @@ func main() { // nolint: gocyclo
 	serverCollector := metalmetrics.NewServerStateCollector(mgr.GetClient())
 	ctrlmetrics.Registry.MustRegister(serverCollector)
 	setupLog.Info("Registered custom server metrics collector")
+
+	if !skipMigrations {
+		migrator := migration.NewMigrator()
+		if err := migrator.Add(&migration.ServerBMCOwnerReferenceMigration{Client: mgr.GetClient()}); err != nil {
+			setupLog.Error(err, "Failed to add Server BMC owner reference migration")
+			os.Exit(1)
+		}
+		if err := mgr.Add(migrator); err != nil {
+			setupLog.Error(err, "Failed to add migrator to manager")
+			os.Exit(1)
+		}
+		mgr = migration.WrapManager(migrator, mgr)
+	}
 
 	if err = (&controller.EndpointReconciler{
 		Client:             mgr.GetClient(),

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"text/template"
 	"time"
@@ -19,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
-	"github.com/ironcore-dev/controller-utils/clientutils"
 	"github.com/ironcore-dev/controller-utils/conditionutils"
 	"github.com/ironcore-dev/controller-utils/metautils"
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
@@ -36,8 +34,6 @@ import (
 )
 
 const (
-	BMCFinalizer = "metal.ironcore.dev/bmc"
-
 	bmcUserResetMessage = "BMC reset initiated by user. Waiting for it to come back online."
 	bmcAutoResetMessage = "BMC reset initiated automatically after repeated connection failures. Waiting for it to come back online."
 )
@@ -87,23 +83,8 @@ func (r *BMCReconciler) reconcileExists(ctx context.Context, bmcObj *metalv1alph
 	return r.reconcile(ctx, bmcObj)
 }
 
-func (r *BMCReconciler) delete(ctx context.Context, bmcObj *metalv1alpha1.BMC) (ctrl.Result, error) {
+func (r *BMCReconciler) delete(ctx context.Context, _ *metalv1alpha1.BMC) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.V(1).Info("Deleting BMC")
-	bmcClient, err := bmcutils.GetBMCClientFromBMC(ctx, r.Client, bmcObj, r.DefaultProtocol, r.SkipCertValidation, r.BMCOptions)
-	if err == nil {
-		defer bmcClient.Logout()
-	}
-
-	// TODO: remove this part in a future version, as we will no longer set owner references on servers
-	if modified, err := r.removeOwnerReferencesFromServers(ctx, bmcObj); err != nil || modified {
-		return ctrl.Result{}, err
-	}
-
-	if _, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, bmcObj, BMCFinalizer); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	log.V(1).Info("Deleted BMC")
 	return ctrl.Result{}, nil
 }
@@ -111,9 +92,6 @@ func (r *BMCReconciler) delete(ctx context.Context, bmcObj *metalv1alpha1.BMC) (
 func (r *BMCReconciler) reconcile(ctx context.Context, bmcObj *metalv1alpha1.BMC) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Reconciling BMC")
-	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, bmcObj, BMCFinalizer); err != nil || modified {
-		return ctrl.Result{}, err
-	}
 	if shouldIgnoreReconciliation(bmcObj) {
 		log.V(1).Info("Skipped BMC reconciliation")
 		return ctrl.Result{}, nil
@@ -209,31 +187,6 @@ func (r *BMCReconciler) reconcile(ctx context.Context, bmcObj *metalv1alpha1.BMC
 	return ctrl.Result{}, nil
 }
 
-func (r *BMCReconciler) removeOwnerReferencesFromServers(ctx context.Context, obj *metalv1alpha1.BMC) (bool, error) {
-	serverList := &metalv1alpha1.ServerList{}
-	if err := r.List(ctx, serverList, client.MatchingFields{bmcRefField: obj.Name}); err != nil {
-		return false, fmt.Errorf("failed to list servers for BMC %s: %w", obj.Name, err)
-	}
-
-	modified := false
-	for i := range serverList.Items {
-		server := &serverList.Items[i]
-		base := server.DeepCopy()
-		server.OwnerReferences = slices.DeleteFunc(server.OwnerReferences, func(ref metav1.OwnerReference) bool {
-			return ref.APIVersion == metalv1alpha1.GroupVersion.String() && ref.Kind == "BMC"
-		})
-		if len(server.OwnerReferences) == len(base.OwnerReferences) {
-			continue
-		}
-		if err := r.Patch(ctx, server, client.MergeFrom(base)); err != nil {
-			return false, fmt.Errorf("failed to remove owner reference from server %s: %w", server.Name, err)
-		}
-		modified = true
-	}
-
-	return modified, nil
-}
-
 func (r *BMCReconciler) updateBMCStatusDetails(ctx context.Context, bmcClient bmc.BMC, bmcObj *metalv1alpha1.BMC) error {
 	log := ctrl.LoggerFrom(ctx)
 	var (
@@ -314,10 +267,6 @@ func (r *BMCReconciler) discoverServers(ctx context.Context, bmcClient bmc.BMC, 
 			server.Spec.SystemUUID = strings.ToLower(s.UUID)
 			server.Spec.SystemURI = s.URI
 			server.Spec.BMCRef = &corev1.LocalObjectReference{Name: bmcObj.Name}
-			// TODO: remove in a future version
-			server.OwnerReferences = slices.DeleteFunc(server.OwnerReferences, func(ref metav1.OwnerReference) bool {
-				return ref.APIVersion == metalv1alpha1.GroupVersion.String() && ref.Kind == "BMC"
-			})
 			return nil
 		})
 		if err != nil {

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"text/template"
 	"time"
@@ -280,7 +281,11 @@ func (r *BMCReconciler) discoverServers(ctx context.Context, bmcClient bmc.BMC, 
 			server.Spec.SystemUUID = strings.ToLower(s.UUID)
 			server.Spec.SystemURI = s.URI
 			server.Spec.BMCRef = &corev1.LocalObjectReference{Name: bmcObj.Name}
-			return controllerutil.SetControllerReference(bmcObj, server, r.Scheme)
+			// TODO: remove in a future version
+			server.OwnerReferences = slices.DeleteFunc(server.OwnerReferences, func(ref metav1.OwnerReference) bool {
+				return ref.APIVersion == metalv1alpha1.GroupVersion.String() && ref.Kind == "BMC"
+			})
+			return nil
 		})
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create or patch server %s: %w", server.Name, err))
@@ -664,11 +669,19 @@ func (r *BMCReconciler) enqueueBMCByBMCSecret(ctx context.Context, obj client.Ob
 	return reqs
 }
 
+func (r *BMCReconciler) enqueueBMCByServer(_ context.Context, obj client.Object) []ctrl.Request {
+	server := obj.(*metalv1alpha1.Server)
+	if server.Spec.BMCRef == nil {
+		return nil
+	}
+	return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: server.Spec.BMCRef.Name}}}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *BMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&metalv1alpha1.BMC{}).
-		Owns(&metalv1alpha1.Server{}).
+		Watches(&metalv1alpha1.Server{}, handler.EnqueueRequestsFromMapFunc(r.enqueueBMCByServer)).
 		Watches(&metalv1alpha1.Endpoint{}, handler.EnqueueRequestsFromMapFunc(r.enqueueBMCByEndpoint)).
 		Watches(&metalv1alpha1.BMCSecret{}, handler.EnqueueRequestsFromMapFunc(r.enqueueBMCByBMCSecret)).
 		Complete(r)

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -95,6 +95,11 @@ func (r *BMCReconciler) delete(ctx context.Context, bmcObj *metalv1alpha1.BMC) (
 		defer bmcClient.Logout()
 	}
 
+	// TODO: remove this part in a future version, as we will no longer set owner references on servers
+	if modified, err := r.removeOwnerReferencesFromServers(ctx, bmcObj); err != nil || modified {
+		return ctrl.Result{}, err
+	}
+
 	if _, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, bmcObj, BMCFinalizer); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -106,6 +111,9 @@ func (r *BMCReconciler) delete(ctx context.Context, bmcObj *metalv1alpha1.BMC) (
 func (r *BMCReconciler) reconcile(ctx context.Context, bmcObj *metalv1alpha1.BMC) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(1).Info("Reconciling BMC")
+	if modified, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, bmcObj, BMCFinalizer); err != nil || modified {
+		return ctrl.Result{}, err
+	}
 	if shouldIgnoreReconciliation(bmcObj) {
 		log.V(1).Info("Skipped BMC reconciliation")
 		return ctrl.Result{}, nil
@@ -199,6 +207,31 @@ func (r *BMCReconciler) reconcile(ctx context.Context, bmcObj *metalv1alpha1.BMC
 
 	log.V(1).Info("Reconciled BMC")
 	return ctrl.Result{}, nil
+}
+
+func (r *BMCReconciler) removeOwnerReferencesFromServers(ctx context.Context, obj *metalv1alpha1.BMC) (bool, error) {
+	serverList := &metalv1alpha1.ServerList{}
+	if err := r.List(ctx, serverList, client.MatchingFields{bmcRefField: obj.Name}); err != nil {
+		return false, fmt.Errorf("failed to list servers for BMC %s: %w", obj.Name, err)
+	}
+
+	modified := false
+	for i := range serverList.Items {
+		server := &serverList.Items[i]
+		base := server.DeepCopy()
+		server.OwnerReferences = slices.DeleteFunc(server.OwnerReferences, func(ref metav1.OwnerReference) bool {
+			return ref.APIVersion == metalv1alpha1.GroupVersion.String() && ref.Kind == "BMC"
+		})
+		if len(server.OwnerReferences) == len(base.OwnerReferences) {
+			continue
+		}
+		if err := r.Patch(ctx, server, client.MergeFrom(base)); err != nil {
+			return false, fmt.Errorf("failed to remove owner reference from server %s: %w", server.Name, err)
+		}
+		modified = true
+	}
+
+	return modified, nil
 }
 
 func (r *BMCReconciler) updateBMCStatusDetails(ctx context.Context, bmcClient bmc.BMC, bmcObj *metalv1alpha1.BMC) error {

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -84,50 +84,6 @@ var _ = Describe("BMC Controller", func() {
 		Eventually(Get(server)).Should(Satisfy(apierrors.IsNotFound))
 	})
 
-	It("should not garbage-collect Servers of an unreachable BMC carrying legacy owner references", func(ctx SpecContext) {
-		By("Creating a BMC whose endpoint does not exist (discovery fails)")
-		bmcObj := &metalv1alpha1.BMC{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-unreachable-bmc-",
-			},
-			Spec: metalv1alpha1.BMCSpec{
-				EndpointRef: &v1.LocalObjectReference{Name: "does-not-exist"},
-			},
-		}
-		Expect(k8sClient.Create(ctx, bmcObj)).To(Succeed())
-		Eventually(Object(bmcObj)).Should(HaveField("Finalizers", ContainElement(BMCFinalizer)))
-
-		By("Creating a Server with a legacy BMC owner reference")
-		server := &metalv1alpha1.Server{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-legacy-server-",
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         metalv1alpha1.GroupVersion.String(),
-					Kind:               "BMC",
-					Name:               bmcObj.Name,
-					UID:                bmcObj.UID,
-					Controller:         new(true),
-					BlockOwnerDeletion: new(true),
-				}},
-			},
-			Spec: metalv1alpha1.ServerSpec{
-				BMCRef: &v1.LocalObjectReference{Name: bmcObj.Name},
-			},
-		}
-		Expect(k8sClient.Create(ctx, server)).To(Succeed())
-
-		By("Deleting the unreachable BMC")
-		Expect(k8sClient.Delete(ctx, bmcObj)).To(Succeed())
-		Eventually(Get(bmcObj)).Should(Satisfy(apierrors.IsNotFound))
-
-		By("Ensuring the Server survived without the legacy owner reference")
-		Eventually(Object(server)).Should(HaveField("OwnerReferences", BeEmpty()))
-		Consistently(Get(server)).Should(Succeed())
-
-		By("Cleaning up the Server")
-		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
-	})
-
 	It("should successfully reconcile a BMC resource with inline access information", func(ctx SpecContext) {
 		By("Creating a BMCSecret")
 		bmcSecret := &metalv1alpha1.BMCSecret{

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -64,14 +64,7 @@ var _ = Describe("BMC Controller", func() {
 			},
 		}
 		Eventually(Object(server)).Should(SatisfyAll(
-			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-				APIVersion:         "metal.ironcore.dev/v1alpha1",
-				Kind:               "BMC",
-				Name:               bmc.Name,
-				UID:                bmc.UID,
-				Controller:         new(true),
-				BlockOwnerDeletion: new(true),
-			})),
+			HaveField("OwnerReferences", BeEmpty()),
 			HaveField("Spec.SystemUUID", "38947555-7742-3448-3784-823347823834"),
 			HaveField("Spec.SystemURI", "/redfish/v1/Systems/437XR1138R2"),
 			HaveField("Spec.BMCRef.Name", endpoint.Name),
@@ -146,14 +139,7 @@ var _ = Describe("BMC Controller", func() {
 			},
 		}
 		Eventually(Object(server)).Should(SatisfyAll(
-			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-				APIVersion:         "metal.ironcore.dev/v1alpha1",
-				Kind:               "BMC",
-				Name:               bmc.Name,
-				UID:                bmc.UID,
-				Controller:         new(true),
-				BlockOwnerDeletion: new(true),
-			})),
+			HaveField("OwnerReferences", BeEmpty()),
 			HaveField("ObjectMeta.Labels", bmcLabels),
 			HaveField("Spec.SystemUUID", "38947555-7742-3448-3784-823347823834"),
 			HaveField("Spec.SystemURI", "/redfish/v1/Systems/437XR1138R2"),
@@ -223,14 +209,7 @@ var _ = Describe("BMC Controller", func() {
 			},
 		}
 		Eventually(Object(server)).Should(SatisfyAll(
-			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-				APIVersion:         "metal.ironcore.dev/v1alpha1",
-				Kind:               "BMC",
-				Name:               bmc.Name,
-				UID:                bmc.UID,
-				Controller:         new(true),
-				BlockOwnerDeletion: new(true),
-			})),
+			HaveField("OwnerReferences", BeEmpty()),
 			HaveField("ObjectMeta.Labels", bmcLabels),
 			HaveField("Spec.SystemUUID", "38947555-7742-3448-3784-823347823834"),
 			HaveField("Spec.SystemURI", "/redfish/v1/Systems/437XR1138R2"),

--- a/internal/controller/bmc_controller_test.go
+++ b/internal/controller/bmc_controller_test.go
@@ -84,6 +84,50 @@ var _ = Describe("BMC Controller", func() {
 		Eventually(Get(server)).Should(Satisfy(apierrors.IsNotFound))
 	})
 
+	It("should not garbage-collect Servers of an unreachable BMC carrying legacy owner references", func(ctx SpecContext) {
+		By("Creating a BMC whose endpoint does not exist (discovery fails)")
+		bmcObj := &metalv1alpha1.BMC{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-unreachable-bmc-",
+			},
+			Spec: metalv1alpha1.BMCSpec{
+				EndpointRef: &v1.LocalObjectReference{Name: "does-not-exist"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bmcObj)).To(Succeed())
+		Eventually(Object(bmcObj)).Should(HaveField("Finalizers", ContainElement(BMCFinalizer)))
+
+		By("Creating a Server with a legacy BMC owner reference")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-legacy-server-",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         metalv1alpha1.GroupVersion.String(),
+					Kind:               "BMC",
+					Name:               bmcObj.Name,
+					UID:                bmcObj.UID,
+					Controller:         new(true),
+					BlockOwnerDeletion: new(true),
+				}},
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				BMCRef: &v1.LocalObjectReference{Name: bmcObj.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+
+		By("Deleting the unreachable BMC")
+		Expect(k8sClient.Delete(ctx, bmcObj)).To(Succeed())
+		Eventually(Get(bmcObj)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("Ensuring the Server survived without the legacy owner reference")
+		Eventually(Object(server)).Should(HaveField("OwnerReferences", BeEmpty()))
+		Consistently(Get(server)).Should(Succeed())
+
+		By("Cleaning up the Server")
+		Expect(k8sClient.Delete(ctx, server)).To(Succeed())
+	})
+
 	It("should successfully reconcile a BMC resource with inline access information", func(ctx SpecContext) {
 		By("Creating a BMCSecret")
 		bmcSecret := &metalv1alpha1.BMCSecret{

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -280,14 +280,7 @@ var _ = Describe("Server Controller", func() {
 		}
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Finalizers", ContainElement(ServerFinalizer)),
-			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-				APIVersion:         "metal.ironcore.dev/v1alpha1",
-				Kind:               "BMC",
-				Name:               bmc.Name,
-				UID:                bmc.UID,
-				Controller:         new(true),
-				BlockOwnerDeletion: new(true),
-			})),
+			HaveField("OwnerReferences", BeEmpty()),
 			HaveField("Spec.SystemUUID", "38947555-7742-3448-3784-823347823834"),
 			HaveField("Spec.SystemURI", "/redfish/v1/Systems/437XR1138R2"),
 			HaveField("Spec.Power", BeEmpty()),
@@ -432,14 +425,7 @@ var _ = Describe("Server Controller", func() {
 		By("Ensuring that the Server is set to discovery and powered on")
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Finalizers", ContainElement(ServerFinalizer)),
-			HaveField("OwnerReferences", ContainElement(metav1.OwnerReference{
-				APIVersion:         "metal.ironcore.dev/v1alpha1",
-				Kind:               "BMC",
-				Name:               bmc.Name,
-				UID:                bmc.UID,
-				Controller:         new(true),
-				BlockOwnerDeletion: new(true),
-			})),
+			HaveField("OwnerReferences", BeEmpty()),
 			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Spec.BootConfigurationRef", &metalv1alpha1.ObjectReference{
 				Namespace: ns.Name,

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package migration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// Migration is a single migration that can be run before controllers start.
+type Migration interface {
+	Migrate(ctx context.Context) error
+}
+
+// Migrator manages a set of migrations and runs them concurrently when Start is called.
+// The Done channel is closed after all migrations complete (whether or not they succeed).
+type Migrator struct {
+	mu      sync.Mutex
+	started bool
+
+	done       chan struct{}
+	migrateErr error
+
+	migrations []Migration
+}
+
+// NewMigrator creates a new Migrator with no registered migrations.
+func NewMigrator() *Migrator {
+	return &Migrator{
+		done: make(chan struct{}),
+	}
+}
+
+// Add registers a migration. It returns an error if the Migrator has already been started.
+func (m *Migrator) Add(migration Migration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.started {
+		return fmt.Errorf("cannot add migrations once started")
+	}
+	m.migrations = append(m.migrations, migration)
+	return nil
+}
+
+// Start runs all registered migrations concurrently. It blocks until every migration
+// has completed and returns a joined error if any migration failed. Start may only be
+// called once; subsequent calls return an error immediately.
+func (m *Migrator) Start(ctx context.Context) error {
+	m.mu.Lock()
+
+	if m.started {
+		m.mu.Unlock()
+		return fmt.Errorf("migrator already started")
+	}
+
+	m.started = true
+	m.mu.Unlock()
+
+	defer close(m.done)
+
+	var (
+		wg      sync.WaitGroup
+		errChan = make(chan error)
+	)
+	for _, migration := range m.migrations {
+		wg.Go(func() {
+			if err := migration.Migrate(ctx); err != nil {
+				errChan <- err
+			}
+		})
+	}
+	go func() {
+		defer close(errChan)
+		wg.Wait()
+	}()
+
+	var errs []error
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+
+	m.migrateErr = errors.Join(errs...)
+	return m.migrateErr
+}
+
+// Done returns a channel that is closed once Start has finished running all migrations.
+func (m *Migrator) Done() <-chan struct{} {
+	return m.done
+}
+
+// Err returns the error produced by Start or nil if Done is not yet closed.
+func (m *Migrator) Err() error {
+	select {
+	case <-m.Done():
+		return m.migrateErr
+	default:
+		return nil
+	}
+}
+
+type migrationAwareManager struct {
+	migrator *Migrator
+	manager.Manager
+}
+
+// WrapManager returns a manager.Manager that gates all runnables added via Add behind
+// the given Migrator's completion. If the migration succeeds, the runnables start normally.
+// If the migration fails, each runnable returns the migration error without starting.
+// If the context is canceled before migration completes, each runnable exits with nil.
+func WrapManager(migrator *Migrator, mgr manager.Manager) manager.Manager {
+	return &migrationAwareManager{
+		migrator: migrator,
+		Manager:  mgr,
+	}
+}
+
+func (m *migrationAwareManager) Add(fn manager.Runnable) error {
+	return m.Manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-m.migrator.Done():
+			if err := m.migrator.Err(); err != nil {
+				return fmt.Errorf("migration error, won't start (%w)", err)
+			}
+			return fn.Start(ctx)
+		}
+	}))
+}

--- a/internal/migration/server_bmc_ownerref.go
+++ b/internal/migration/server_bmc_ownerref.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package migration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+)
+
+// ServerBMCOwnerReferenceMigration removes legacy BMC owner references from all Servers.
+type ServerBMCOwnerReferenceMigration struct {
+	client.Client
+}
+
+func (m *ServerBMCOwnerReferenceMigration) Migrate(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	serverList := &metalv1alpha1.ServerList{}
+	if err := m.List(ctx, serverList); err != nil {
+		return fmt.Errorf("failed to list servers: %w", err)
+	}
+
+	var errs []error
+	migrated := 0
+	for i := range serverList.Items {
+		server := &serverList.Items[i]
+		base := server.DeepCopy()
+		server.OwnerReferences = slices.DeleteFunc(server.OwnerReferences, func(ref metav1.OwnerReference) bool {
+			return ref.APIVersion == metalv1alpha1.GroupVersion.String() && ref.Kind == "BMC"
+		})
+		if len(server.OwnerReferences) == len(base.OwnerReferences) {
+			continue
+		}
+		if err := m.Patch(ctx, server, client.MergeFrom(base)); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove BMC owner reference from server %s: %w", server.Name, err))
+			continue
+		}
+		migrated++
+	}
+
+	log.Info("Removed legacy BMC owner references from Servers", "Migrated", migrated, "Total", len(serverList.Items))
+	return errors.Join(errs...)
+}

--- a/internal/migration/server_bmc_ownerref_test.go
+++ b/internal/migration/server_bmc_ownerref_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package migration
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+)
+
+func TestServerBMCOwnerReferenceMigration(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := metalv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	legacy := &metalv1alpha1.Server{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         metalv1alpha1.GroupVersion.String(),
+				Kind:               "BMC",
+				Name:               "some-bmc",
+				Controller:         new(true),
+				BlockOwnerDeletion: new(true),
+			}},
+		},
+		Spec: metalv1alpha1.ServerSpec{
+			BMCRef: &corev1.LocalObjectReference{Name: "some-bmc"},
+		},
+	}
+	clean := &metalv1alpha1.Server{
+		ObjectMeta: metav1.ObjectMeta{Name: "clean", Namespace: "default"},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(legacy, clean).Build()
+	m := &ServerBMCOwnerReferenceMigration{Client: c}
+
+	if err := m.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	got := &metalv1alpha1.Server{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(legacy), got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.OwnerReferences) != 0 {
+		t.Errorf("legacy Server still has owner references: %v", got.OwnerReferences)
+	}
+	if got.Spec.BMCRef == nil || got.Spec.BMCRef.Name != "some-bmc" {
+		t.Errorf("legacy Server BMCRef was modified: %v", got.Spec.BMCRef)
+	}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(clean), got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.OwnerReferences) != 0 {
+		t.Errorf("clean Server gained owner references: %v", got.OwnerReferences)
+	}
+}


### PR DESCRIPTION
# Proposed Changes

Remove OwnerReference from BMC to Server.

Fixes #1137 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added startup migrations to safely update existing server resources.
  * Added an option to skip migrations during startup.

* **Changes**
  * Server resources are no longer automatically owned by BMC resources.
  * BMC reconciliation no longer manages event subscriptions or deletion finalizers.
  * BMC updates now continue to be triggered when referenced servers change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->