### PR TITLE
Remove deprecated `power` field from `Server` spec

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/serverspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/serverspec.go
@@ -19,18 +19,6 @@ type ServerSpecApplyConfiguration struct {
 	SystemUUID *string `json:"systemUUID,omitempty"`
 	// SystemURI is the unique URI for the server resource in REDFISH API.
 	SystemURI *string `json:"systemURI,omitempty"`
-	// Power specifies the desired power state of the server.
-	//
-	// Deprecated: This field is an internal actuator variable exposed as
-	// user-facing API. It is written almost exclusively by controllers
-	// (the ServerReconciler while traversing the state machine, and the
-	// ServerClaim reconciler as surrogate input), and
-	// every write patches the Server object, racing with its actual owner.
-	// The desired power state is expressed more precisely through
-	// ServerClaim and the server state machine itself;
-	// the genuinely observed value is status.powerState. Do not set this
-	// field on new Server resources; it will be removed in a future release.
-	Power *apiv1alpha1.Power `json:"power,omitempty"`
 	// IndicatorLED specifies the desired state of the server's indicator LED.
 	IndicatorLED *apiv1alpha1.IndicatorLED `json:"indicatorLED,omitempty"`
 	// ReclaimPolicy specifies how the server is reclaimed after use.
@@ -76,14 +64,6 @@ func (b *ServerSpecApplyConfiguration) WithSystemUUID(value string) *ServerSpecA
 // If called multiple times, the SystemURI field is set to the value of the last call.
 func (b *ServerSpecApplyConfiguration) WithSystemURI(value string) *ServerSpecApplyConfiguration {
 	b.SystemURI = &value
-	return b
-}
-
-// WithPower sets the Power field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Power field is set to the value of the last call.
-func (b *ServerSpecApplyConfiguration) WithPower(value apiv1alpha1.Power) *ServerSpecApplyConfiguration {
-	b.Power = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -538,9 +538,6 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: indicatorLED
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.IndicatorLED
-    - name: power
-      type:
-        namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.Power
     - name: reclaimPolicy
       type:
         namedType: com.github.ironcore-dev.metal-operator.api.v1alpha1.ServerReclaimPolicy

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -98,20 +98,6 @@ type ServerSpec struct {
 	// SystemURI is the unique URI for the server resource in REDFISH API.
 	SystemURI string `json:"systemURI,omitempty"`
 
-	// Power specifies the desired power state of the server.
-	//
-	// Deprecated: This field is an internal actuator variable exposed as
-	// user-facing API. It is written almost exclusively by controllers
-	// (the ServerReconciler while traversing the state machine, and the
-	// ServerClaim reconciler as surrogate input), and
-	// every write patches the Server object, racing with its actual owner.
-	// The desired power state is expressed more precisely through
-	// ServerClaim and the server state machine itself;
-	// the genuinely observed value is status.powerState. Do not set this
-	// field on new Server resources; it will be removed in a future release.
-	// +optional
-	Power Power `json:"power,omitempty"`
-
 	// IndicatorLED specifies the desired state of the server's indicator LED.
 	// +optional
 	IndicatorLED IndicatorLED `json:"indicatorLED,omitempty"`

--- a/config/crd/bases/metal.ironcore.dev_servers.yaml
+++ b/config/crd/bases/metal.ironcore.dev_servers.yaml
@@ -178,20 +178,6 @@ spec:
                 description: IndicatorLED specifies the desired state of the server's
                   indicator LED.
                 type: string
-              power:
-                description: |-
-                  Power specifies the desired power state of the server.
-
-                  Deprecated: This field is an internal actuator variable exposed as
-                  user-facing API. It is written almost exclusively by controllers
-                  (the ServerReconciler while traversing the state machine, and the
-                  ServerClaim reconciler as surrogate input), and
-                  every write patches the Server object, racing with its actual owner.
-                  The desired power state is expressed more precisely through
-                  ServerClaim and the server state machine itself;
-                  the genuinely observed value is status.powerState. Do not set this
-                  field on new Server resources; it will be removed in a future release.
-                type: string
               reclaimPolicy:
                 default: Recycle
                 description: |-

--- a/dist/chart/templates/crd/servers.metal.ironcore.dev.yaml
+++ b/dist/chart/templates/crd/servers.metal.ironcore.dev.yaml
@@ -182,20 +182,6 @@ spec:
                 description: IndicatorLED specifies the desired state of the server's
                   indicator LED.
                 type: string
-              power:
-                description: |-
-                  Power specifies the desired power state of the server.
-
-                  Deprecated: This field is an internal actuator variable exposed as
-                  user-facing API. It is written almost exclusively by controllers
-                  (the ServerReconciler while traversing the state machine, and the
-                  ServerClaim reconciler as surrogate input), and
-                  every write patches the Server object, racing with its actual owner.
-                  The desired power state is expressed more precisely through
-                  ServerClaim and the server state machine itself;
-                  the genuinely observed value is status.powerState. Do not set this
-                  field on new Server resources; it will be removed in a future release.
-                type: string
               reclaimPolicy:
                 default: Recycle
                 description: |-

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1303,20 +1303,6 @@ spec:
                 description: IndicatorLED specifies the desired state of the server's
                   indicator LED.
                 type: string
-              power:
-                description: |-
-                  Power specifies the desired power state of the server.
-
-                  Deprecated: This field is an internal actuator variable exposed as
-                  user-facing API. It is written almost exclusively by controllers
-                  (the ServerReconciler while traversing the state machine, and the
-                  ServerClaim reconciler as surrogate input), and
-                  every write patches the Server object, racing with its actual owner.
-                  The desired power state is expressed more precisely through
-                  ServerClaim and the server state machine itself;
-                  the genuinely observed value is status.powerState. Do not set this
-                  field on new Server resources; it will be removed in a future release.
-                type: string
               reclaimPolicy:
                 default: Recycle
                 description: |-

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -468,7 +468,6 @@ Power defines the possible power states for a device.
 
 _Appears in:_
 - [ServerClaimSpec](#serverclaimspec)
-- [ServerSpec](#serverspec)
 
 | Field | Description |
 | --- | --- |
@@ -810,7 +809,6 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `systemUUID` _string_ | SystemUUID is the unique identifier for the server. |  |  |
 | `systemURI` _string_ | SystemURI is the unique URI for the server resource in REDFISH API. |  |  |
-| `power` _[Power](#power)_ | Power specifies the desired power state of the server.<br />Deprecated: This field is an internal actuator variable exposed as<br />user-facing API. It is written almost exclusively by controllers<br />(the ServerReconciler while traversing the state machine, and the<br />ServerClaim reconciler as surrogate input), and<br />every write patches the Server object, racing with its actual owner.<br />The desired power state is expressed more precisely through<br />ServerClaim and the server state machine itself;<br />the genuinely observed value is status.powerState. Do not set this<br />field on new Server resources; it will be removed in a future release. |  |  |
 | `indicatorLED` _[IndicatorLED](#indicatorled)_ | IndicatorLED specifies the desired state of the server's indicator LED. |  |  |
 | `reclaimPolicy` _[ServerReclaimPolicy](#serverreclaimpolicy)_ | ReclaimPolicy specifies how the server is reclaimed after use.<br />Can be<br />- Recycle (default), immediately transitioning the server to `Available` after use.<br />- Retain, transitioning the server to `Released` after use, leaving `spec.serverClaimRef` set,<br />  transitioning to `Available` once `spec.serverClaimRef` is removed. | Recycle | Enum: [Recycle Retain] <br /> |
 | `serverClaimRef` _[ImmutableObjectReference](#immutableobjectreference)_ | ServerClaimRef is a reference to a ServerClaim object that claims this server. |  | Optional: \{\} <br /> |

--- a/docs/concepts/servers.md
+++ b/docs/concepts/servers.md
@@ -30,7 +30,8 @@ not on the `Server`.
 
 The `Server` CRD is central to managing bare metal servers. It allows for:
 
-- **Power Management**: Powering servers on and off.
+- **Power Management**: Powering servers on and off. Workload power is requested via the [`ServerClaim`](serverclaims.md),
+  while lifecycle states drive power directly — on during [Discovery](#lifecycle-and-states), off when released or [parked](#parking).
 - **BIOS Configuration**: Changing BIOS settings and performing BIOS updates.
 - **Lifecycle Management**: Handling the server's lifecycle through various states.
 - **Hardware Discovery**: Gathering hardware information via BMC and in-band agents.

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -194,17 +194,6 @@ func (r *ServerReconciler) reconcile(ctx context.Context, server *metalv1alpha1.
 		}
 	}
 
-	// Clear the deprecated spec.power field.
-	// TODO: remove this part once the spec field is gone
-	if server.Spec.Power != "" {
-		serverBase := server.DeepCopy()
-		server.Spec.Power = ""
-		if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to clear deprecated spec.power field: %w", err)
-		}
-		log.V(1).Info("Cleared deprecated spec.power field")
-	}
-
 	bmcClient, err := bmcutils.GetBMCClientForServer(ctx, r.Client, server, r.DefaultProtocol, r.SkipCertValidation, r.BMCOptions, bmcutils.WithRegistryURL(r.RegistryURL))
 	if err != nil {
 		if errors.As(err, &bmcutils.BMCUnAvailableError{}) {

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -126,61 +126,6 @@ var _ = Describe("Server Controller", func() {
 		Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
 	})
 
-	It("should clear the deprecated spec.power field without disrupting power control", func(ctx SpecContext) {
-		By("Creating a BMCSecret")
-		bmcSecret := &metalv1alpha1.BMCSecret{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-server-",
-			},
-			Data: map[string][]byte{
-				"username": []byte("foo"),
-				"password": []byte("bar"),
-			},
-		}
-		Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
-
-		By("Creating a Server with a legacy spec.power value")
-		server := &metalv1alpha1.Server{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "server-",
-			},
-			Spec: metalv1alpha1.ServerSpec{
-				SystemUUID: "38947555-7742-3448-3784-823347823834",
-				Power:      metalv1alpha1.PowerOn,
-				BMC: &metalv1alpha1.BMCAccess{
-					Protocol: metalv1alpha1.Protocol{
-						Name: metalv1alpha1.ProtocolRedfishLocal,
-						Port: MockServerPort,
-					},
-					Address: MockServerIP,
-					BMCSecretRef: v1.LocalObjectReference{
-						Name: bmcSecret.Name,
-					},
-				},
-			},
-		}
-		Expect(k8sClient.Create(ctx, server)).To(Succeed())
-
-		By("Updating the Server to available state")
-		Eventually(UpdateStatus(server, func() {
-			server.Status.State = metalv1alpha1.ServerStateAvailable
-		})).Should(Succeed())
-
-		By("Ensuring that the deprecated spec.power field is cleared")
-		Eventually(Object(server)).Should(HaveField("Spec.Power", BeEmpty()))
-		Consistently(Object(server)).Should(HaveField("Spec.Power", BeEmpty()))
-
-		By("Ensuring that the power state is still managed by the state machine")
-		Eventually(Object(server)).Should(SatisfyAll(
-			HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
-			HaveField("Spec.Power", BeEmpty()),
-		))
-
-		// cleanup
-		Expect(k8sClient.Delete(ctx, server)).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, bmcSecret)).Should(Succeed())
-	})
-
 	It("should resume a claimed server with wiped status directly in reserved state", func(ctx SpecContext) {
 		By("Creating a BMCSecret")
 		bmcSecret := &metalv1alpha1.BMCSecret{
@@ -283,7 +228,6 @@ var _ = Describe("Server Controller", func() {
 			HaveField("OwnerReferences", BeEmpty()),
 			HaveField("Spec.SystemUUID", "38947555-7742-3448-3784-823347823834"),
 			HaveField("Spec.SystemURI", "/redfish/v1/Systems/437XR1138R2"),
-			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Spec.IndicatorLED", metalv1alpha1.IndicatorLED("")),
 			HaveField("Spec.ServerClaimRef", BeNil()),
 			HaveField("Status.Manufacturer", "Contoso"),
@@ -426,7 +370,6 @@ var _ = Describe("Server Controller", func() {
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Finalizers", ContainElement(ServerFinalizer)),
 			HaveField("OwnerReferences", BeEmpty()),
-			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Spec.BootConfigurationRef", &metalv1alpha1.ObjectReference{
 				Namespace: ns.Name,
 				Name:      server.Name,
@@ -606,7 +549,6 @@ var _ = Describe("Server Controller", func() {
 			HaveField("Finalizers", ContainElement(ServerFinalizer)),
 			HaveField("Spec.SystemUUID", "38947555-7742-3448-3784-823347823834"),
 			HaveField("Spec.SystemURI", "/redfish/v1/Systems/437XR1138R2"),
-			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Spec.IndicatorLED", metalv1alpha1.IndicatorLED("")),
 			HaveField("Spec.ServerClaimRef", BeNil()),
 			HaveField("Spec.BootConfigurationRef", &metalv1alpha1.ObjectReference{
@@ -642,7 +584,6 @@ var _ = Describe("Server Controller", func() {
 		_ = zeroCapacity.String()
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Spec.BootConfigurationRef", BeNil()),
-			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 			HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
 			HaveField("Status.NetworkInterfaces", Not(BeEmpty())),

--- a/internal/controller/serverclaim_controller_test.go
+++ b/internal/controller/serverclaim_controller_test.go
@@ -144,7 +144,6 @@ var _ = Describe("ServerClaim Controller", func() {
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Spec.ServerClaimRef", BeNil()),
 			HaveField("Spec.BootConfigurationRef", BeNil()),
-			HaveField("Spec.Power", BeEmpty()),
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
 		))
 	})
@@ -211,9 +210,6 @@ var _ = Describe("ServerClaim Controller", func() {
 		By("Ensuring the server is powered off while parked")
 		Eventually(Object(server)).Should(HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState))
 
-		By("Asserting spec.power stays cleared while parked")
-		Consistently(Object(server)).Should(HaveField("Spec.Power", BeEmpty()))
-
 		By("Resuming the server via an unpark request")
 		Eventually(Update(server, func() {
 			metav1.SetMetaDataAnnotation(&server.ObjectMeta, metalv1alpha1.OperationAnnotation, metalv1alpha1.OperationAnnotationUnpark)
@@ -223,7 +219,6 @@ var _ = Describe("ServerClaim Controller", func() {
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerStateReserved),
 			HaveField("Status.PowerState", metalv1alpha1.ServerOnPowerState),
-			HaveField("Spec.Power", BeEmpty()),
 		))
 
 		By("Removing the ServerClaim")


### PR DESCRIPTION
# Proposed Changes

Remove deprecated `power` field from `Server` spec.

Fixes #1148 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the deprecated `power` field from server specifications and the corresponding CustomResourceDefinition schema.
  * Removed the associated API configuration field and chainable setter.
  * Server reconciliation no longer clears this field automatically.

* **Documentation**
  * Updated the API reference to remove `power` from `ServerSpec`.
  * Clarified that power management is handled through `ServerClaim` requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->