### PR TITLE
Add support for Fujitsu systems

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -22,6 +22,7 @@ const (
 	ManufacturerLenovo     Manufacturer = "Lenovo"
 	ManufacturerHPE        Manufacturer = "HPE"
 	ManufacturerSupermicro Manufacturer = "Supermicro"
+	ManufacturerFujitsu    Manufacturer = "Fsas"
 )
 
 // ComponentType represents a firmware component type.
@@ -219,6 +220,7 @@ func DefaultVendors() map[Manufacturer]VendorFactory {
 		ManufacturerHPE:        func(b *RedfishBaseBMC) BMC { return &HPERedfishBMC{RedfishBaseBMC: b} },
 		ManufacturerLenovo:     func(b *RedfishBaseBMC) BMC { return &LenovoRedfishBMC{RedfishBaseBMC: b} },
 		ManufacturerSupermicro: func(b *RedfishBaseBMC) BMC { return &SupermicroRedfishBMC{RedfishBaseBMC: b} },
+		ManufacturerFujitsu:    func(b *RedfishBaseBMC) BMC { return &FujitsuRedfishBMC{RedfishBaseBMC: b} },
 	}
 }
 
@@ -231,6 +233,7 @@ var (
 	_ BMC = (*HPERedfishBMC)(nil)
 	_ BMC = (*LenovoRedfishBMC)(nil)
 	_ BMC = (*SupermicroRedfishBMC)(nil)
+	_ BMC = (*FujitsuRedfishBMC)(nil)
 )
 
 type Entity struct {

--- a/bmc/redfish_fujitsu.go
+++ b/bmc/redfish_fujitsu.go
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package bmc
+
+// FujitsuRedfishBMC is the Fujitsu-specific implementation of the BMC interface.
+// Fujitsu iRMC exposes a standard Redfish API, so all operations delegate
+// to RedfishBaseBMC. Vendor-specific overrides can be added here as needed.
+type FujitsuRedfishBMC struct {
+	*RedfishBaseBMC
+}


### PR DESCRIPTION
Adds ManufacturerFujitsu constant and FujitsuRedfishBMC struct which uses all operations of RedfishBaseBMC via the standard Redfish API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Fujitsu systems using Redfish-based baseboard management.
  - Fujitsu hardware is now recognized automatically and routed through the appropriate management interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->